### PR TITLE
Fix minor typo for multi-gpu with dask-cudf

### DIFF
--- a/start/start.md
+++ b/start/start.md
@@ -38,7 +38,7 @@ Getting started guide and source code for XGBoost4J-Spark, along with notebooks 
 {: .mb-7 }
 
 ### Multi-GPU with Dask-cuDF
-#### **[Dask-XGBoost Docs](https://rapidsai.github.io/projects/cudf/en/latest/dask-cudf.htmll){: target="_blank"}**
+#### **[Dask-XGBoost Docs](https://rapidsai.github.io/projects/cudf/en/latest/dask-cudf.html){: target="_blank"}**
 Overview of using Dask for Multi-GPU cuDF solutions, on both a single machine or multiple GPUs across many machines in a cluster.
 {: .mb-7 }
 

--- a/start/start.md
+++ b/start/start.md
@@ -38,7 +38,7 @@ Getting started guide and source code for XGBoost4J-Spark, along with notebooks 
 {: .mb-7 }
 
 ### Multi-GPU with Dask-cuDF
-#### **[Dask-XGBoost Docs](https://rapidsai.github.io/projects/cudf/en/latest/dask-cudf.html){: target="_blank"}**
+#### **[Dask-cuDF Post](https://rapidsai.github.io/projects/cudf/en/latest/dask-cudf.html){: target="_blank"}**
 Overview of using Dask for Multi-GPU cuDF solutions, on both a single machine or multiple GPUs across many machines in a cluster.
 {: .mb-7 }
 


### PR DESCRIPTION
- Link had an extra 'l' that led to 404 error.
- Link text mentioned dask -XGBoost instead of dask-cuDF 