### PR TITLE
Updates for RAPIDS 0.10

### DIFF
--- a/demos/containers/rapids-demo.md
+++ b/demos/containers/rapids-demo.md
@@ -109,23 +109,29 @@ View the full [tag list](#full-tag-list) for all available images.
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [9.2](https://developer.nvidia.com/cuda-92-download-archive) or [10.0](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [9.2](https://developer.nvidia.com/cuda-92-download-archive), [10.0](https://developer.nvidia.com/cuda-10.0-download-archive) or [10.1.2](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
-* Docker CE v18+
-* [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
+* Docker and NVIDIA Docker
+  * **Preferred** - Docker CE v19.03+ and [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-docker#quickstart)
+  * **Legacy** - Docker CE v18 and [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0))
 
 ## Usage
 
 ### Start Container and Notebook Server
 
+#### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
 $ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
-$ docker run --runtime=nvidia \
---rm -it \
--p 8888:8888 \
--p 8787:8787 \
--p 8786:8786 \
-rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+$ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+```
+**NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
+
+#### Legacy - Docker CE v18 and `nvidia-docker2`
+```bash
+$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+$ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
 ```
 **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
@@ -145,14 +151,18 @@ For a full description of each notebook, see the [README](https://github.com/rap
 
 You are free to modify the above steps. For example, you can launch an interactive session with your own data:
 
+#### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-docker run --runtime=nvidia \
---rm -it \
--p 8888:8888 \
--p 8787:8787 \
--p 8786:8786 \
--v /path/to/host/data:/rapids/my_data
-rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+$ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         -v /path/to/host/data:/rapids/my_data \
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
+```
+
+#### Legacy - Docker CE v18 and `nvidia-docker2`
+```bash
+$ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
+         -v /path/to/host/data:/rapids/my_data \
+         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04
 ```
 
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.

--- a/demos/containers/rapids-demo.md
+++ b/demos/containers/rapids-demo.md
@@ -209,7 +209,7 @@ All `ubuntu16.04` images use `gcc 5.4`
 **CUDA 9.2**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda9.2-base-ubuntu16.04` | `0.10-cuda9.2-base-ubuntu16.04` | base | 3.6 |
 | `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.10-cuda9.2-runtime-ubuntu16.04` | runtime | 3.6 |
 | --- | `0.10-cuda9.2-devel-ubuntu16.04-py3.6` | devel | 3.6 |
@@ -218,7 +218,7 @@ All `ubuntu16.04` images use `gcc 5.4`
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.0-base-ubuntu16.04` | `0.10-cuda10.0-base-ubuntu16.04` | base | 3.6 |
 | `cuda10.0-runtime-ubuntu16.04` | `0.10-cuda10.0-runtime-ubuntu16.04` | runtime | 3.6 |
 | --- | `0.10-cuda10.0-devel-ubuntu16.04-py3.6` | devel | 3.6 |
@@ -227,7 +227,7 @@ All `ubuntu16.04` images use `gcc 5.4`
 **CUDA 10.1**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.1-base-ubuntu16.04` | `0.10-cuda10.1-base-ubuntu16.04` | base | 3.6 |
 | `cuda10.1-runtime-ubuntu16.04` | `0.10-cuda10.1-runtime-ubuntu16.04` | runtime | 3.6 |
 | --- | `0.10-cuda10.1-devel-ubuntu16.04-py3.6` | devel | 3.6 |
@@ -240,7 +240,7 @@ All `ubuntu18.04` images use `gcc 7.3`
 **CUDA 9.2**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda9.2-base-ubuntu18.04` | `0.10-cuda9.2-base-ubuntu18.04` | base | 3.6 |
 | `cuda9.2-runtime-ubuntu18.04` | `0.10-cuda9.2-runtime-ubuntu18.04` | runtime | 3.6 |
 | --- | `0.10-cuda9.2-devel-ubuntu18.04-py3.6` | devel | 3.6 |
@@ -249,7 +249,7 @@ All `ubuntu18.04` images use `gcc 7.3`
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.0-base-ubuntu18.04` | `0.10-cuda10.0-base-ubuntu18.04` | base | 3.6 |
 | `cuda10.0-runtime-ubuntu18.04` | `0.10-cuda10.0-runtime-ubuntu18.04` | runtime | 3.6 |
 | --- | `0.10-cuda10.0-devel-ubuntu18.04-py3.6` | devel | 3.6 |
@@ -258,7 +258,7 @@ All `ubuntu18.04` images use `gcc 7.3`
 **CUDA 10.1**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.1-base-ubuntu18.04` | `0.10-cuda10.1-base-ubuntu18.04` | base | 3.6 |
 | `cuda10.1-runtime-ubuntu18.04` | `0.10-cuda10.1-runtime-ubuntu18.04` | runtime | 3.6 |
 | --- | `0.10-cuda10.1-devel-ubuntu18.04-py3.6` | devel | 3.6 |
@@ -271,7 +271,7 @@ All `centos7` images use `gcc 7.3`
 **CUDA 9.2**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda9.2-base-centos7` | `0.10-cuda9.2-base-centos7` | base | 3.6 |
 | `cuda9.2-runtime-centos7` | `0.10-cuda9.2-runtime-centos7` | runtime | 3.6 |
 | --- | `0.10-cuda9.2-devel-centos7-py3.6` | devel | 3.6 |
@@ -280,7 +280,7 @@ All `centos7` images use `gcc 7.3`
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.0-base-centos7` | `0.10-cuda10.0-base-centos7` | base | 3.6 |
 | `cuda10.0-runtime-centos7` | `0.10-cuda10.0-runtime-centos7` | runtime | 3.6 |
 | --- | `0.10-cuda10.0-devel-centos7-py3.6` | devel | 3.6 |
@@ -289,7 +289,7 @@ All `centos7` images use `gcc 7.3`
 **CUDA 10.1**
 
 | Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `cuda10.1-base-centos7` | `0.10-cuda10.1-base-centos7` | base | 3.6 |
 | `cuda10.1-runtime-centos7` | `0.10-cuda10.1-runtime-centos7` | runtime | 3.6 |
 | --- | `0.10-cuda10.1-devel-centos7-py3.6` | devel | 3.6 |

--- a/demos/containers/rapids-demo.md
+++ b/demos/containers/rapids-demo.md
@@ -17,6 +17,19 @@ Get started with our preconfigured RAPIDS demo container, featuring several demo
 
 ### Current Version
 
+#### RAPIDS 0.10 - 17 October 2019
+
+Versions of libraries included in the `0.10` [images](#rapids-10-images):
+- `cuDF` [v0.10.0](https://github.com/rapidsai/cudf/tree/v0.10.0), `cuML` [v0.10.0](https://github.com/rapidsai/cuml/tree/v0.10.0), `cuGraph` [v0.10.0](https://github.com/rapidsai/cugraph/tree/v0.10.0), `RMM` [v0.10.0](https://github.com/rapidsai/RMM/tree/v0.10.0), `cuSpatial` [v0.10.0](https://github.com/rapidsai/cuspatial/tree/v0.10.0)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.10-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.10)
+
+Updates & changes
+- Added cuSpatial, the GPU-accelerated spatial and trajectory data management and analytics library.
+- Added support for CUDA 10.1.
+- Updated containers with `v0.10.0` release of cuDF, cuML, cuGraph, cuStrings, and RMM, as well as updated versions of xgboost, dask-xgboost, and dask-cuda.
+
+### Former Versions
+
 #### RAPIDS 0.9 - 21 August 2019
 
 Versions of libraries included in the `0.9` [images](#rapids-09-images):
@@ -25,8 +38,6 @@ Versions of libraries included in the `0.9` [images](#rapids-09-images):
 
 Updates & changes
 - Updated containers with `v0.9.0` release of cuDF, cuML, cuGraph, cuStrings, RMM, and dask-cuda.
-
-### Former Versions
 
 #### RAPIDS 0.8 - 27 June 2019
 
@@ -82,14 +93,14 @@ RAPIDS images come in three types:
 
 - `base` - contains a RAPIDS environment ready for use.<br/>Use this image if you want to use RAPIDS as a part of your pipeline.
 - `runtime` - extends the `base` image by adding a notebook server and example notebooks.<br/>Use this image if you want to explore RAPIDS through notebooks and examples.
-- `devel` - extends the `runtime` image by adding the compiler toolchain, the debugging tools, the headers and the libraries for RAPIDS development.<br/>Use this image to develop RAPIDS from source.
+- `devel` - contains the compiler toolchain, the debugging tools, the headers and the libraries for RAPIDS development, as well as the RAPIDS source code and all build artifacts in place.<br/>Use this image to develop RAPIDS from source.
 
 #### Common Tags
 
 For most users the `runtime` image will be sufficient to get started with RAPIDS,
 you can use the following tags to pull the latest stable image:
 - `latest` or `cuda9.2-runtime-ubuntu16.04` <br/>with `gcc 5.4` and `Python 3.6`
-- `cuda10.0-runtime-ubuntu16.04`<br/>with `gcc 7.3` and `Python 3.6`
+- `cuda10.0-runtime-ubuntu18.04`<br/>with `gcc 7.3` and `Python 3.6`
 
 #### Other Tags
 
@@ -178,7 +189,7 @@ Using the image types [above](#tags) `base`, `runtime`, or `devel` we use the fo
 tag naming scheme for RAPIDS images:
 
 ```
-0.9-cuda9.2-devel-ubuntu16.04-py3.6
+0.10-cuda9.2-devel-ubuntu16.04-py3.6
 ^       ^    ^        ^         ^
 |       |    type     |         python version
 |       |             |
@@ -189,7 +200,7 @@ RAPIDS version        linux version
 
 The `base` and `runtime` image types can be found in the `rapidsai/rapidsai` DockerHub repo, and the `devel` image types can be found in the `rapidsai/rapidsai-dev` DockerHub repo.
 
-### RAPIDS 0.9 Images
+### RAPIDS 0.10 Images
 
 #### Ubuntu 16.04
 
@@ -199,19 +210,28 @@ All `ubuntu16.04` images use `gcc 5.4`
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda9.2-base-ubuntu16.04` | `0.9-cuda9.2-base-ubuntu16.04` | base | 3.6 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.9-cuda9.2-runtime-ubuntu16.04` | runtime | 3.6 |
-| --- | `0.9-cuda9.2-devel-ubuntu16.04-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda9.2-devel-ubuntu16.04-py3.7` | devel | 3.7 |
+| `cuda9.2-base-ubuntu16.04` | `0.10-cuda9.2-base-ubuntu16.04` | base | 3.6 |
+| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.10-cuda9.2-runtime-ubuntu16.04` | runtime | 3.6 |
+| --- | `0.10-cuda9.2-devel-ubuntu16.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda9.2-devel-ubuntu16.04-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda10.0-base-ubuntu16.04` | `0.9-cuda10.0-base-ubuntu16.04` | base | 3.6 |
-| `latest`<br>or<br>`cuda10.0-runtime-ubuntu16.04` | `0.9-cuda10.0-runtime-ubuntu16.04` | runtime | 3.6 |
-| --- | `0.9-cuda10.0-devel-ubuntu16.04-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda10.0-devel-ubuntu16.04-py3.7` | devel | 3.7 |
+| `cuda10.0-base-ubuntu16.04` | `0.10-cuda10.0-base-ubuntu16.04` | base | 3.6 |
+| `cuda10.0-runtime-ubuntu16.04` | `0.10-cuda10.0-runtime-ubuntu16.04` | runtime | 3.6 |
+| --- | `0.10-cuda10.0-devel-ubuntu16.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.0-devel-ubuntu16.04-py3.7` | devel | 3.7 |
+
+**CUDA 10.1**
+
+| Short Tags | Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `cuda10.1-base-ubuntu16.04` | `0.10-cuda10.1-base-ubuntu16.04` | base | 3.6 |
+| `cuda10.1-runtime-ubuntu16.04` | `0.10-cuda10.1-runtime-ubuntu16.04` | runtime | 3.6 |
+| --- | `0.10-cuda10.1-devel-ubuntu16.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.1-devel-ubuntu16.04-py3.7` | devel | 3.7 |
 
 #### Ubuntu 18.04
 
@@ -221,19 +241,28 @@ All `ubuntu18.04` images use `gcc 7.3`
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda9.2-base-ubuntu18.04` | `0.9-cuda9.2-base-ubuntu18.04` | base | 3.6 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu18.04` | `0.9-cuda9.2-runtime-ubuntu18.04` | runtime | 3.6 |
-| --- | `0.9-cuda9.2-devel-ubuntu18.04-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda9.2-devel-ubuntu18.04-py3.7` | devel | 3.7 |
+| `cuda9.2-base-ubuntu18.04` | `0.10-cuda9.2-base-ubuntu18.04` | base | 3.6 |
+| `cuda9.2-runtime-ubuntu18.04` | `0.10-cuda9.2-runtime-ubuntu18.04` | runtime | 3.6 |
+| --- | `0.10-cuda9.2-devel-ubuntu18.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda9.2-devel-ubuntu18.04-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda10.0-base-ubuntu18.04` | `0.9-cuda10.0-base-ubuntu18.04` | base | 3.6 |
-| `latest`<br>or<br>`cuda10.0-runtime-ubuntu18.04` | `0.9-cuda10.0-runtime-ubuntu18.04` | runtime | 3.6 |
-| --- | `0.9-cuda10.0-devel-ubuntu18.04-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda10.0-devel-ubuntu18.04-py3.7` | devel | 3.7 |
+| `cuda10.0-base-ubuntu18.04` | `0.10-cuda10.0-base-ubuntu18.04` | base | 3.6 |
+| `cuda10.0-runtime-ubuntu18.04` | `0.10-cuda10.0-runtime-ubuntu18.04` | runtime | 3.6 |
+| --- | `0.10-cuda10.0-devel-ubuntu18.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.0-devel-ubuntu18.04-py3.7` | devel | 3.7 |
+
+**CUDA 10.1**
+
+| Short Tags | Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `cuda10.1-base-ubuntu18.04` | `0.10-cuda10.1-base-ubuntu18.04` | base | 3.6 |
+| `cuda10.1-runtime-ubuntu18.04` | `0.10-cuda10.1-runtime-ubuntu18.04` | runtime | 3.6 |
+| --- | `0.10-cuda10.1-devel-ubuntu18.04-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.1-devel-ubuntu18.04-py3.7` | devel | 3.7 |
 
 #### CentOS 7
 
@@ -243,19 +272,96 @@ All `centos7` images use `gcc 7.3`
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda9.2-base-centos7` | `0.9-cuda9.2-base-centos7` | base | 3.6 |
-| `cuda9.2-runtime-centos7` | `0.9-cuda9.2-runtime-centos7` | runtime | 3.6 |
-| --- | `0.9-cuda9.2-devel-centos7-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda9.2-devel-centos7-py3.7` | devel | 3.7 |
+| `cuda9.2-base-centos7` | `0.10-cuda9.2-base-centos7` | base | 3.6 |
+| `cuda9.2-runtime-centos7` | `0.10-cuda9.2-runtime-centos7` | runtime | 3.6 |
+| --- | `0.10-cuda9.2-devel-centos7-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda9.2-devel-centos7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
 | Short Tags | Full Tag | Image Type | Python Version |
 | --- | --- | --- |
-| `cuda10.0-base-centos7` | `0.9-cuda10.0-base-centos7` | base | 3.6 |
-| `latest`<br>or<br>`cuda10.0-runtime-centos7` | `0.9-cuda10.0-runtime-centos7` | runtime | 3.6 |
-| --- | `0.9-cuda10.0-devel-centos7-py3.6` | devel | 3.6 |
-| --- | `0.9-cuda10.0-devel-centos7-py3.7` | devel | 3.7 |
+| `cuda10.0-base-centos7` | `0.10-cuda10.0-base-centos7` | base | 3.6 |
+| `cuda10.0-runtime-centos7` | `0.10-cuda10.0-runtime-centos7` | runtime | 3.6 |
+| --- | `0.10-cuda10.0-devel-centos7-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.0-devel-centos7-py3.7` | devel | 3.7 |
+
+**CUDA 10.1**
+
+| Short Tags | Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `cuda10.1-base-centos7` | `0.10-cuda10.1-base-centos7` | base | 3.6 |
+| `cuda10.1-runtime-centos7` | `0.10-cuda10.1-runtime-centos7` | runtime | 3.6 |
+| --- | `0.10-cuda10.1-devel-centos7-py3.6` | devel | 3.6 |
+| --- | `0.10-cuda10.1-devel-centos7-py3.7` | devel | 3.7 |
+
+### RAPIDS 0.9 Images
+
+#### Ubuntu 16.04
+
+All `ubuntu16.04` images use `gcc 5.4`
+
+**CUDA 9.2**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda9.2-base-ubuntu16.04` | base | 3.6 |
+| `0.9-cuda9.2-runtime-ubuntu16.04` | runtime | 3.6 |
+| `0.9-cuda9.2-devel-ubuntu16.04-py3.6` | devel | 3.6 |
+| `0.9-cuda9.2-devel-ubuntu16.04-py3.7` | devel | 3.7 |
+
+**CUDA 10.0**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda10.0-base-ubuntu16.04` | base | 3.6 |
+| `0.9-cuda10.0-runtime-ubuntu16.04` | runtime | 3.6 |
+| `0.9-cuda10.0-devel-ubuntu16.04-py3.6` | devel | 3.6 |
+| `0.9-cuda10.0-devel-ubuntu16.04-py3.7` | devel | 3.7 |
+
+#### Ubuntu 18.04
+
+All `ubuntu18.04` images use `gcc 7.3`
+
+**CUDA 9.2**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda9.2-base-ubuntu18.04` | base | 3.6 |
+| `0.9-cuda9.2-runtime-ubuntu18.04` | runtime | 3.6 |
+| `0.9-cuda9.2-devel-ubuntu18.04-py3.6` | devel | 3.6 |
+| `0.9-cuda9.2-devel-ubuntu18.04-py3.7` | devel | 3.7 |
+
+**CUDA 10.0**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda10.0-base-ubuntu18.04` | base | 3.6 |
+| `0.9-cuda10.0-runtime-ubuntu18.04` | runtime | 3.6 |
+| `0.9-cuda10.0-devel-ubuntu18.04-py3.6` | devel | 3.6 |
+| `0.9-cuda10.0-devel-ubuntu18.04-py3.7` | devel | 3.7 |
+
+#### CentOS 7
+
+All `centos7` images use `gcc 7.3`
+
+**CUDA 9.2**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda9.2-base-centos7` | base | 3.6 |
+| `0.9-cuda9.2-runtime-centos7` | runtime | 3.6 |
+| `0.9-cuda9.2-devel-centos7-py3.6` | devel | 3.6 |
+| `0.9-cuda9.2-devel-centos7-py3.7` | devel | 3.7 |
+
+**CUDA 10.0**
+
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.9-cuda10.0-base-centos7` | base | 3.6 |
+| `0.9-cuda10.0-runtime-centos7` | runtime | 3.6 |
+| `0.9-cuda10.0-devel-centos7-py3.6` | devel | 3.6 |
+| `0.9-cuda10.0-devel-centos7-py3.7` | devel | 3.7 |
 
 ### RAPIDS 0.8 Images
 
@@ -265,25 +371,25 @@ All `ubuntu16.04` images use `gcc 5.4`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu16.04` | `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu16.04` | `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.8-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.8-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.8-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu16.04` | `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu16.04` | `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu16.04` | `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.8-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.8-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.8-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 #### Ubuntu 18.04
 
@@ -291,25 +397,25 @@ All `ubuntu18.04` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu18.04` | `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-ubuntu18.04` | `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu18.04` | `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.8-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.8-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.8-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu18.04` | `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu18.04` | `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu18.04` | `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.8-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.8-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 #### CentOS 7
 
@@ -317,25 +423,25 @@ All `centos7` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-centos7` | `0.8-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.8-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-centos7` | `0.8-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-centos7` | `0.8-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.8-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.8-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.8-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.8-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.8-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.8-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-centos7` | `0.8-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.8-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-centos7` | `0.8-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.8-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-centos7` | `0.8-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.8-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.8-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.8-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.8-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.8-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.8-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.8-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 ### RAPIDS 0.7 Images
 
@@ -345,25 +451,25 @@ All `ubuntu16.04` images use `gcc 5.4`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu16.04` | `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu16.04` | `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.7-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.7-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.7-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu16.04` | `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu16.04` | `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu16.04` | `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.7-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.7-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.7-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 #### Ubuntu 18.04
 
@@ -371,25 +477,25 @@ All `ubuntu18.04` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu18.04` | `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-ubuntu18.04` | `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu18.04` | `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.7-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.7-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.7-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu18.04` | `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu18.04` | `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu18.04` | `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.7-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.7-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.7-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 #### CentOS 7
 
@@ -397,25 +503,25 @@ All `centos7` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-centos7` | `0.7-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.7-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-centos7` | `0.7-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-centos7` | `0.7-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.7-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.7-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.7-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.7-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.7-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.7-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-centos7` | `0.7-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.7-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-centos7` | `0.7-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.7-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-centos7` | `0.7-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.7-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.7-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.7-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.7-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.7-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.7-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.7-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 ### RAPIDS 0.6 Images
 
@@ -425,25 +531,25 @@ All `ubuntu16.04` images use `gcc 5.4`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu16.04` | `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `latest`<br>or<br>`cuda9.2-runtime-ubuntu16.04` | `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu16.04` | `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.6-cuda9.2-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.6-cuda9.2-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.6-cuda9.2-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu16.04` | `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
-| - | `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu16.04` | `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu16.04` | `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
-| - | `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.6` | base | 3.6 |
+| `0.6-cuda10.0-base-ubuntu16.04-gcc5-py3.7` | base | 3.7 |
+| `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.6` | runtime | 3.6 |
+| `0.6-cuda10.0-runtime-ubuntu16.04-gcc5-py3.7` | runtime | 3.7 |
+| `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.6` | devel | 3.6 |
+| `0.6-cuda10.0-devel-ubuntu16.04-gcc5-py3.7` | devel | 3.7 |
 
 #### Ubuntu 18.04
 
@@ -451,25 +557,25 @@ All `ubuntu18.04` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-ubuntu18.04` | `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-ubuntu18.04` | `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-ubuntu18.04` | `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.6-cuda9.2-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.6-cuda9.2-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.6-cuda9.2-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-ubuntu18.04` | `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
-| - | `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-ubuntu18.04` | `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-ubuntu18.04` | `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
-| - | `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.6` | base | 3.6 |
+| `0.6-cuda10.0-base-ubuntu18.04-gcc7-py3.7` | base | 3.7 |
+| `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6` | runtime | 3.6 |
+| `0.6-cuda10.0-runtime-ubuntu18.04-gcc7-py3.7` | runtime | 3.7 |
+| `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.6` | devel | 3.6 |
+| `0.6-cuda10.0-devel-ubuntu18.04-gcc7-py3.7` | devel | 3.7 |
 
 #### CentOS 7
 
@@ -477,25 +583,25 @@ All `centos7` images use `gcc 7.3`
 
 **CUDA 9.2**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda9.2-base-centos7` | `0.6-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.6-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda9.2-runtime-centos7` | `0.6-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda9.2-devel-centos7` | `0.6-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.6-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda9.2-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.6-cuda9.2-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.6-cuda9.2-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.6-cuda9.2-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.6-cuda9.2-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.6-cuda9.2-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 **CUDA 10.0**
 
-| Short Tags | Full Tag | Image Type | Python Version |
-| --- | --- | --- | --- |
-| `cuda10.0-base-centos7` | `0.6-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
-| - | `0.6-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
-| `cuda10.0-runtime-centos7` | `0.6-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
-| - | `0.6-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
-| `cuda10.0-devel-centos7` | `0.6-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
-| - | `0.6-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
+| Full Tag | Image Type | Python Version |
+| --- | --- | --- |
+| `0.6-cuda10.0-base-centos7-gcc7-py3.6` | base | 3.6 |
+| `0.6-cuda10.0-base-centos7-gcc7-py3.7` | base | 3.7 |
+| `0.6-cuda10.0-runtime-centos7-gcc7-py3.6` | runtime | 3.6 |
+| `0.6-cuda10.0-runtime-centos7-gcc7-py3.7` | runtime | 3.7 |
+| `0.6-cuda10.0-devel-centos7-gcc7-py3.6` | devel | 3.6 |
+| `0.6-cuda10.0-devel-centos7-gcc7-py3.7` | devel | 3.7 |
 
 ### RAPIDS 0.5 Images
 


### PR DESCRIPTION
Updates for RAPIDS 0.10, also fixed prior releases to remove now-invalid tags, formatting, etc.