### PR TITLE
Move social info to config and add open graph tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,27 @@ permalink: pretty
 exclude: ["README.md"]
 
 aux_links:
-    "View Docs on GitHub":
-      - "https://github.com/rapidsai/docs"
+  "View Docs on GitHub":
+    - "https://github.com/rapidsai/docs"
+
+social:
+  google-groups:
+    name: Google Groups
+    url: https://groups.google.com/forum/#!forum/rapidsai
+    fa-icon-class: fas fa-users
+  twitter:
+    name: Twitter
+    username: rapidsai
+    url: https://twitter.com/rapidsai
+    fa-icon-class: fab fa-twitter
+  slack:
+    name: Slack
+    url: https://join.slack.com/t/rapids-goai/shared_invite/enQtMjE0Njg5NDQ1MDQxLTViZWFiYTY5MDA4NWY3OWViODg0YWM1MGQ1NzgzNTQwOWI1YjE3NGFlOTVhYjQzYWQ4YjI4NzljYzhiOGZmMGM
+    fa-icon-class: fab fa-slack
+  stack-overflow:
+    name: Stack Overflow
+    url: https://stackoverflow.com/tags/rapids
+    fa-icon-class: fab fa-stack-overflow
 
 # Enable or disable the site search
 search_enabled: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,6 @@
   <meta property="og:description" content="{{ page.description | truncate: 200 }}">
   <meta name="twitter:description" content="{{ page.description | truncate: 200 }}" />
   {% endif %}
-  {{ page.excerpt }}
   <meta property="og:title" content="{{ page.title }} - {{ site.title }}">
   <meta property="og:image" content="https://rapids.ai/assets/images/og_image.png">
   <meta property="og:image:secure_url" content="https://rapids.ai/assets/images/og_image.png" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,28 +2,48 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   {% if page.description %}
-  <meta name="Description" content="{{ page.description }}">
+  <meta name="Description" content="{{ page.description | truncate: 200 }}">
+  <meta property="og:description" content="{{ page.description | truncate: 200 }}">
+  <meta name="twitter:description" content="{{ page.description | truncate: 200 }}" />
   {% endif %}
+  {{ page.excerpt }}
+  <meta property="og:title" content="{{ page.title }} - {{ site.title }}">
+  <meta property="og:image" content="https://rapids.ai/assets/images/og_image.png">
+  <meta property="og:image:secure_url" content="https://rapids.ai/assets/images/og_image.png" />
+  <meta property="og:image:type" content="image/jpeg" />
+  <meta property="og:image:width" content="400" />
+  <meta property="og:image:height" content="300" />
+  <meta property="og:url" content="{{ page.url }}">
+  <meta property="og:site_name" content="{{ site.title }}">
+
+  <meta name="twitter:site" content="{{ site.social.twitter.url }}" />
+  <meta name="twitter:creator" content="@{{ site.social.twitter.username }}" />
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:image" content="https://rapids.ai/assets/images/og_image.png" />
+  <meta name="twitter:image:alt" content="{{ site.title }}">
+  <meta property="fb:app_id" content="1679326302390196" />
 
   <title>{{ page.title }} - {{ site.title }}</title>
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | absolute_url }}">
   <link rel="stylesheet" href="{{ "/assets/css/custom.css" | absolute_url }}">
 
   {% if site.ga_tracking != nil %}
-    <script>
-      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-      ga('create', '{{ site.ga_tracking }}', '{{ site.url }}');
-      ga('send', 'pageview');
-    </script>
-    <script async src="https://www.google-analytics.com/analytics.js"></script>
+  <script>
+    window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
+    ga('create', '{{ site.ga_tracking }}', '{{ site.url }}');
+    ga('send', 'pageview');
+  </script>
+  <script async src="https://www.google-analytics.com/analytics.js"></script>
   {% endif %}
 
   {% if site.search_enabled != nil %}
-    <script type="text/javascript" src="{{ "/assets/js/vendor/lunr.min.js" | absolute_url }}"></script>
+  <script type="text/javascript" src="{{ "/assets/js/vendor/lunr.min.js" | absolute_url }}"></script>
   {% endif %}
   <script type="text/javascript" src="{{ "/assets/js/just-the-docs.js" | absolute_url }}"></script>
   <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-  <script defer src="https://use.fontawesome.com/releases/v5.8.0/js/all.js" integrity="sha384-ukiibbYjFS/1dhODSWD+PrZ6+CGCgf8VbyUH7bQQNUulL+2r59uGYToovytTf4Xm" crossorigin="anonymous"></script>
+  <script defer src="https://use.fontawesome.com/releases/v5.8.0/js/all.js"
+    integrity="sha384-ukiibbYjFS/1dhODSWD+PrZ6+CGCgf8VbyUH7bQQNUulL+2r59uGYToovytTf4Xm"
+    crossorigin="anonymous"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -134,12 +134,12 @@
 .footer-help-section {
   display: flex;
   justify-content: left;
-  align-items: left;
-  padding: 10px 0;
+  padding: 1rem 0;
+  flex-wrap: wrap;
 }
 
 .footer-help-box {
-  padding: 0px 30px;
+  padding: 0 1rem;
   text-align: center;
 }
 

--- a/index.md
+++ b/index.md
@@ -4,17 +4,17 @@ title: Home
 nav_order: 1
 permalink: /
 description: |
-    This site serves as a collection of all the documentation for RAPIDS. Whether you're new to RAPIDS, looking to contribute, or are a part of the RAPIDS team, the docs here will help guide you.
+  This site serves as a collection of all the documentation for RAPIDS. Whether you're new to RAPIDS, looking to contribute, or are a part of the RAPIDS team, the docs here will help guide you.
 ---
 
-
 # RAPIDS Docs
+
 {: .fs-8 }
 
 This site serves as a collection of all the documentation for RAPIDS. Whether you're new to RAPIDS, looking to contribute, or are a part of the RAPIDS team, the docs here will help guide you. Visit [rapids.ai](http://rapids.ai) for more information on the overall project.
 {: .fs-6 .fw-300 }
 
-[<i class="far fa-file-code"></i> Documentation]({{site.url}}{{site.baseurl}}/api){: .btn .btn-primary .fs-4 .mb-4 .mb-md-0 .mr-2 }  [<i class="fas fa-bolt"></i> Get Started]({{site.url}}{{site.baseurl}}/start){: .btn .fs-4 .mb-4 .mb-md-0 .mr-2 }  [<i class="fab fa-github"></i> RAPIDS on GitHub](https://github.com/rapidsai){: .btn.fs-4 .mb-4 .mb-md-0 .mr-2 }
+[<i class="far fa-file-code"></i> Documentation]({{site.url}}{{site.baseurl}}/api){: .btn .btn-primary .fs-4 .mb-4 .mb-md-0 .mr-2 } [<i class="fas fa-bolt"></i> Get Started]({{site.url}}{{site.baseurl}}/start){: .btn .fs-4 .mb-4 .mb-md-0 .mr-2 } [<i class="fab fa-github"></i> RAPIDS on GitHub](https://github.com/rapidsai){: .btn.fs-4 .mb-4 .mb-md-0 .mr-2 }
 
 ---
 
@@ -24,7 +24,7 @@ This site serves as a collection of all the documentation for RAPIDS. Whether yo
     {% for i in site.social %}
         {% assign social = i[1] %}
         <div class="footer-help-box">
-            <div class="footer-help-box-image"><i class="{{ social.fa-icon-class }} fa-4x"></i></div>
+            <div class="footer-help-box-image"><i class="{{ social.fa-icon-class }} fa-3x"></i></div>
             <a href=" {{ social.url }}" target="_blank" class="btn">{{ social.name }}</a>
         </div>
     {% endfor %}

--- a/index.md
+++ b/index.md
@@ -3,6 +3,8 @@ layout: default
 title: Home
 nav_order: 1
 permalink: /
+description: |
+    This site serves as a collection of all the documentation for RAPIDS. Whether you're new to RAPIDS, looking to contribute, or are a part of the RAPIDS team, the docs here will help guide you.
 ---
 
 
@@ -19,22 +21,13 @@ This site serves as a collection of all the documentation for RAPIDS. Whether yo
 ## Stay Connected
 
 <div class="footer-help-section">
-    <div class="footer-help-box">
-        <div class="footer-help-box-image"><i class="fas fa-users fa-4x"></i></div>
-        <a href="https://groups.google.com/forum/#!forum/rapidsai" target="_blank" class="btn">Google Groups</a>
-    </div>
-    <div class="footer-help-box">
-        <div class="footer-help-box-image"><i class="fab fa-twitter fa-4x"></i></div>
-        <a href="https://twitter.com/rapidsai" target="_blank" class="btn">Twitter</a>
-    </div>
-    <div class="footer-help-box">
-        <div class="footer-help-box-image"><i class="fab fa-slack fa-4x"></i></div>
-        <a href="https://join.slack.com/t/rapids-goai/shared_invite/enQtMjE0Njg5NDQ1MDQxLTViZWFiYTY5MDA4NWY3OWViODg0YWM1MGQ1NzgzNTQwOWI1YjE3NGFlOTVhYjQzYWQ4YjI4NzljYzhiOGZmMGM" target="_blank" class="btn">Slack</a>
-    </div>
-    <div class="footer-help-box">
-        <div class="footer-help-box-image"><i class="fab fa-stack-overflow fa-4x"></i></div>
-        <a href="https://stackoverflow.com/tags/rapids" target="_blank" class="btn">Stack Overflow</a>
-    </div>
+    {% for i in site.social %}
+        {% assign social = i[1] %}
+        <div class="footer-help-box">
+            <div class="footer-help-box-image"><i class="{{ social.fa-icon-class }} fa-4x"></i></div>
+            <a href=" {{ social.url }}" target="_blank" class="btn">{{ social.name }}</a>
+        </div>
+    {% endfor %}
 </div>
 
 ## Issues or Feedback


### PR DESCRIPTION
_I've not contributed to the docs yet so thought I'd dip my toe in with a small PR._

I noticed that when sharing docs on social media, slack, etc there was no preview card. This PR adds the meta tags to enable this. Info and content mostly copied from the main website.

I've moved the social page info (twitter, google groups, stack overflow, slack) into the `_config.yml` so that I could access it from the meta tags and reduce duplication.

I also added a page description to the index page.