### PR TITLE
Add cuspatial & cusignal. Update CLX

### DIFF
--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -133,7 +133,7 @@ cuxfilter:
   cllink: https://github.com/rapidsai/cuxfilter/blob/master/CHANGELOG.md
   nightly:
     - ver: '0.13'
-      link: https://rapidsai.github.io/projects/cuxfilter/en/0.13.0/dataframe.html
+      link: https://rapidsai.github.io/projects/cuxfilter/en/nightly/dataframe.html
 
 cuspatial:
   name: cuspatial

--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -131,3 +131,23 @@ cuxfilter:
   stable:
     - ver: '0.12'
       link: https://rapidsai.github.io/cuxfilter/index.html
+
+cuspatial:
+  name: cuspatial
+  path: cuspatial
+  desc: 'PLACEHOLDER TEXT'
+  ghlink: https://github.com/rapidsai/cuspatial
+  cllink: https://github.com/rapidsai/cuspatial/blob/master/CHANGELOG.md
+  stable:
+    - ver: '0.12'
+      link: https://rapidsai.github.io/cuspatial/index.html
+
+cusignal:
+  name: cusignal
+  path: cusignal
+  desc: 'PLACEHOLDER TEXT'
+  ghlink: https://github.com/rapidsai/cusignal
+  cllink: https://github.com/rapidsai/cusignal/blob/master/CHANGELOG.md
+  stable:
+    - ver: '0.12'
+      link: https://rapidsai.github.io/cusignal/index.html

--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -120,7 +120,7 @@ clx:
   cllink: https://github.com/rapidsai/clx/blob/master/CHANGELOG.md
   stable:
     - ver: '0.12'
-      link: https://rapidsai.github.io/clx/index.html
+      link: https://rapidsai.github.io/clx/api.html
 
 cuxfilter:
   name: cuxfilter
@@ -130,7 +130,7 @@ cuxfilter:
   cllink: https://github.com/rapidsai/cuxfilter/blob/master/CHANGELOG.md
   stable:
     - ver: '0.12'
-      link: https://rapidsai.github.io/cuxfilter/index.html
+      link: https://rapidsai.github.io/cuxfilter/api.html
 
 cuspatial:
   name: cuspatial
@@ -140,7 +140,7 @@ cuspatial:
   cllink: https://github.com/rapidsai/cuspatial/blob/master/CHANGELOG.md
   stable:
     - ver: '0.12'
-      link: https://rapidsai.github.io/cuspatial/index.html
+      link: https://rapidsai.github.io/cuspatial/api.html
 
 cusignal:
   name: cusignal
@@ -150,4 +150,4 @@ cusignal:
   cllink: https://github.com/rapidsai/cusignal/blob/master/CHANGELOG.md
   stable:
     - ver: '0.12'
-      link: https://rapidsai.github.io/cusignal/index.html
+      link: https://rapidsai.github.io/cusignal/api.html

--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -120,7 +120,10 @@ clx:
   cllink: https://github.com/rapidsai/clx/blob/master/CHANGELOG.md
   stable:
     - ver: '0.12'
-      link: https://rapidsai.github.io/clx/api.html
+      link: https://rapidsai.github.io/projects/clx/en/stable/api.html
+  nightly:
+    - ver: '0.13'
+      link: https://rapidsai.github.io/projects/clx/en/nightly/api.html
 
 cuxfilter:
   name: cuxfilter
@@ -128,26 +131,26 @@ cuxfilter:
   desc: 'cuxfilter acts as a connector library, which provides the connections between different visualization libraries and a GPU dataframe without much hassle. This also allows the user to use charts from different libraries in a single dashboard, while also providing the interaction.'
   ghlink: https://github.com/rapidsai/cuxfilter
   cllink: https://github.com/rapidsai/cuxfilter/blob/master/CHANGELOG.md
-  stable:
-    - ver: '0.12'
-      link: https://rapidsai.github.io/cuxfilter/api.html
+  nightly:
+    - ver: '0.13'
+      link: https://rapidsai.github.io/projects/cuxfilter/en/0.13.0/dataframe.html
 
 cuspatial:
   name: cuspatial
   path: cuspatial
-  desc: 'PLACEHOLDER TEXT'
+  desc: 'cuSpatial is a GPU accelerated C++/Python library for  accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
   ghlink: https://github.com/rapidsai/cuspatial
   cllink: https://github.com/rapidsai/cuspatial/blob/master/CHANGELOG.md
-  stable:
-    - ver: '0.12'
-      link: https://rapidsai.github.io/cuspatial/api.html
+  nightly:
+    - ver: '0.13'
+      link: https://rapidsai.github.io/projects/cuspatial/en/nightly/api.html
 
 cusignal:
   name: cusignal
   path: cusignal
-  desc: 'PLACEHOLDER TEXT'
+  desc: 'cuSignal leverages CuPy, Numba, and the RAPIDS ecosystem for GPU accelerated signal processing. In some cases, cuSignal is a direct port of Scipy Signal to leverage GPU compute resources via CuPy but also contains Numba CUDA kernels for additional speedups for selected functions.'
   ghlink: https://github.com/rapidsai/cusignal
   cllink: https://github.com/rapidsai/cusignal/blob/master/CHANGELOG.md
-  stable:
-    - ver: '0.12'
-      link: https://rapidsai.github.io/cusignal/api.html
+  nightly:
+    - ver: '0.13'
+      link: https://rapidsai.github.io/projects/cusignal/en/nightly/api.html


### PR DESCRIPTION
This PR:

- Adds `cuspatial` and `cusignal` to the [api docs page](https://docs.rapids.ai/api)
- Updates `clx` doc paths

**Note:** Please navigate to all the `/projects` links in this PR to make sure they're working correctly before approving.