### PR TITLE
Adds /api files for cuspatial and cusignal

### DIFF
--- a/_data/apis.yml
+++ b/_data/apis.yml
@@ -136,7 +136,7 @@ cuxfilter:
       link: https://rapidsai.github.io/projects/cuxfilter/en/nightly/dataframe.html
 
 cuspatial:
-  name: cuspatial
+  name: cuSpatial
   path: cuspatial
   desc: 'cuSpatial is a GPU accelerated C++/Python library for  accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
   ghlink: https://github.com/rapidsai/cuspatial
@@ -146,7 +146,7 @@ cuspatial:
       link: https://rapidsai.github.io/projects/cuspatial/en/nightly/api.html
 
 cusignal:
-  name: cusignal
+  name: cuSignal
   path: cusignal
   desc: 'cuSignal leverages CuPy, Numba, and the RAPIDS ecosystem for GPU accelerated signal processing. In some cases, cuSignal is a direct port of Scipy Signal to leverage GPU compute resources via CuPy but also contains Numba CUDA kernels for additional speedups for selected functions.'
   ghlink: https://github.com/rapidsai/cusignal

--- a/api/clx/nightly.md
+++ b/api/clx/nightly.md
@@ -1,0 +1,8 @@
+---
+layout: api
+nav_exclude: true
+title: CLX - Nightly Docs
+library: clx
+---
+
+{% include api-iframe.html library=page.library name=page.name %}

--- a/api/cusignal/nightly.md
+++ b/api/cusignal/nightly.md
@@ -1,0 +1,8 @@
+---
+layout: api
+nav_exclude: true
+title: cuSignal - Nightly Docs
+library: cusignal
+---
+
+{% include api-iframe.html library=page.library name=page.name %}

--- a/api/cuspatial/nightly.md
+++ b/api/cuspatial/nightly.md
@@ -1,0 +1,8 @@
+---
+layout: api
+nav_exclude: true
+title: cuSpatial - Nightly Docs
+library: cuspatial
+---
+
+{% include api-iframe.html library=page.library name=page.name %}

--- a/api/cuxfilter/nightly.md
+++ b/api/cuxfilter/nightly.md
@@ -1,0 +1,8 @@
+---
+layout: api
+nav_exclude: true
+title: cuxfilter - Nightly Docs
+library: cuxfilter
+---
+
+{% include api-iframe.html library=page.library name=page.name %}

--- a/api/cuxfilter/stable.md
+++ b/api/cuxfilter/stable.md
@@ -1,8 +1,0 @@
----
-layout: api
-nav_exclude: true
-title: cuxfilter - Stable Docs
-library: cuxfilter
----
-
-{% include api-iframe.html library=page.library name=page.name %}


### PR DESCRIPTION
This PR adds the correct markdown files in the `/api` folder for `cuspatial`, `cusignal`, `cuxfilter`, and `clx`.

It also fixes some capitalization issues in `apis.yml`.