### PR TITLE
Update rapids-demo.md

### DIFF
--- a/demos/containers/rapids-demo.md
+++ b/demos/containers/rapids-demo.md
@@ -39,7 +39,7 @@ images in order to make it easy to add RAPIDS libraries while maintaining suppor
 
 RAPIDS images come in three types, distributed in two different repos:
 
-This repo (rapidsai), contains the following:
+The [rapidsai/rapidsai](https://hub.docker.com/r/rapidsai/rapidsai/tags) repo contains the following:
 - `base` - contains a RAPIDS environment ready for use.
   - **TIP: Use this image if you want to use RAPIDS as a part of your pipeline.**
 - `runtime` - extends the `base` image by adding a notebook server and example notebooks.
@@ -53,7 +53,7 @@ The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags)
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.9-cuda9.2-runtime-ubuntu16.04-py3.6
+0.12-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -67,12 +67,12 @@ To get the latest RAPIDS version of a specific platform combination, simply excl
 cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 
-Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda9.2-runtime-ubuntu16.04-py3.6`.
+Many users do not need a specific platform combination but would like to ensure they're getting the latest version of RAPIDS, so as an additional convenience, a tag named simply `latest` is also provided which is equivalent to `cuda10.0-runtime-ubuntu16.04-py3.6`.
 
 ## Prerequisites
 
 * NVIDIA Pascal™ GPU architecture or better
-* CUDA [9.2](https://developer.nvidia.com/cuda-92-download-archive) or [10.0](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
+* CUDA [10.0](https://developer.nvidia.com/cuda-downloads) compatible NVIDIA driver
 * Ubuntu 16.04/18.04 or CentOS 7
 * Docker CE v18+
 * [nvidia-docker](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)) v2+
@@ -83,17 +83,17 @@ Many users do not need a specific platform combination but would like to ensure 
 
 #### Preferred - Docker CE v19+ and `nvidia-container-toolkit`
 ```bash
-$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+$ docker pull rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+         rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
-$ docker pull rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+$ docker pull rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-         rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+         rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 **NOTE:** This will open a shell with [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) running in the background on port 8888 on your host machine.
 
@@ -117,14 +117,14 @@ You are free to modify the above steps. For example, you can launch an interacti
 ```bash
 $ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+                  rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 
 #### Legacy - Docker CE v18 and `nvidia-docker2`
 ```bash
 $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
          -v /path/to/host/data:/rapids/my_data \
-                  rapidsai/rapidsai:cuda9.2-runtime-ubuntu16.04-py3.6
+                  rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04-py3.6
 ```
 This will map data from your host operating system to the container OS in the `/rapids/my_data` directory. You may need to modify the provided notebooks for the new data paths.
 


### PR DESCRIPTION
This PR includes the following changes:

- Adds missing DockerHub link
- Removes mentions of `cuda9.2` since we no longer support it
- Updates some rapids/Ubuntu version mentions to stay current