### PR TITLE
Prevent Extra Whitespace in Docs

### DIFF
--- a/customization/customize_doc.py
+++ b/customization/customize_doc.py
@@ -268,7 +268,7 @@ def main():
     soup.head.append(style_tab)
 
     with open(filepath, "w") as fp:
-        fp.write(soup.prettify())
+        fp.write(str(soup))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR prevents BeautifulSoup from pretty-printing (and thus adding extra lines to) our processed documentation.

BeautifulSoup _output_ docs for reference (see the _Pretty-printing_ section and the _Non-pretty printing_ section below it): https://www.crummy.com/software/BeautifulSoup/bs4/doc/#output

Fixes: https://github.com/rapidsai/cudf/issues/5063