### PR TITLE
0.14 release updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,8 @@ baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://docs.rapids.ai"
 
 permalink: pretty
-exclude: ["README.md", "customization", "update_symlinks.sh"]
+exclude:
+  ["README.md", "release_checklist.md", "customization", "update_symlinks.sh"]
 include: ["_sources", "_static", "_images"]
 
 aux_links:

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -71,7 +71,7 @@ apis:
   cuspatial:
     name: cuspatial
     path: cuspatial
-    desc: 'cuSpatial is a GPU accelerated C++/Python library for  accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
+    desc: 'cuSpatial is a GPU accelerated C++/Python library for accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial
     cllink: https://github.com/rapidsai/cuspatial/blob/master/CHANGELOG.md
     versions:
@@ -105,6 +105,17 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
+  libcugraph:
+    name: libcugraph
+    path: libcugraph
+    desc: 'libcugraph is a C/C++ library for graph processing. The library provides a C++ API for users wanting low-level access to CUDA-based graph processes.'
+    ghlink: https://github.com/rapidsai/cugraph
+    cllink: https://github.com/rapidsai/cugraph/blob/master/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 1
+      nightly: 1
   libcuml:
     name: libcuml
     path: libcuml
@@ -114,7 +125,7 @@ libs:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
-      stable: 0
+      stable: 1
       nightly: 1
   libnvstrings:
     name: libnvstrings

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,12 +1,9 @@
 # Versions for site
 #
 # NOTE: Must use "" to prevent loosing data like 0.10 -> 0.1
-legacy-version: "0.12"
-legacy-docs: "0.12.0"
-legacy-date: "FEB 2020"
-stable-version: "0.13"
-stable-docs: "0.13.0"
-stable-date: "MAR 2020"
-nightly-version: "0.14"
-nightly-docs: "0.14.0"
-nightly-date: "JUN 2020"
+legacy-version: "0.13"
+legacy-date: "31 March 2020"
+stable-version: "0.14"
+stable-date: "3 June 2020"
+nightly-version: "0.15"
+nightly-date: "19 August 2020"

--- a/customization/README.md
+++ b/customization/README.md
@@ -17,9 +17,9 @@ The documentation below describes how the scripts work to customize the generate
 
 ### Symlinks
 
-For the doc customization to work correctly, all of the symlinks need to be up to date. The symlinks ultimately enable us to generate paths like `/cudf/en/stable/` that point to the latest RAPIDS release version folder (i.e. `/cudf/en/0.13.0/`).
+For the doc customization to work correctly, all of the symlinks need to be up to date. The symlinks ultimately enable us to generate paths like `/cudf/stable/` that point to the latest RAPIDS release version folder (i.e. `/cudf/0.13/`).
 
-[update_symlinks.sh](/update_symlinks.sh) is a shell script that accepts the current RAPIDS nightly version (i.e. `13`) as a positional parameter and updates each project's symlinks accordingly. It looks for the legacy, stable, and nightly version folders (i.e. `0.11.0`, `0.12.0`, etc.) and creates the corresponding symlinks if those folders exist.
+[update_symlinks.sh](/update_symlinks.sh) is a shell script that accepts the current RAPIDS nightly version (i.e. `13`) as a positional parameter and updates each project's symlinks accordingly. It looks for the legacy, stable, and nightly version folders (i.e. `0.11`, `0.12`, etc.) and creates the corresponding symlinks if those folders exist.
 
 **Usage:**
 

--- a/demos/containers/rapids-demo.md
+++ b/demos/containers/rapids-demo.md
@@ -17,21 +17,21 @@ Get started with our preconfigured RAPIDS demo container, featuring several demo
 
 ### Current Version
 
-#### RAPIDS 0.13 - 31 March 2020
+#### RAPIDS {{ site.data.releases.stable-version }} - {{ site.data.releases.stable-date }}
 
-Versions of libraries included in the `0.13` images:
-- `cuDF` [v0.13.0](https://github.com/rapidsai/cudf/tree/v0.13.0), `cuML` [v0.13.0](https://github.com/rapidsai/cuml/tree/v0.13.0), `cuGraph` [v0.13.0](https://github.com/rapidsai/cugraph/tree/v0.13.0), `RMM` [v0.13.0](https://github.com/rapidsai/RMM/tree/v0.13.0), `cuSpatial` [v0.13.0](https://github.com/rapidsai/cuspatial/tree/v0.13.0), `cuxfilter` [v0.13.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.13)
+Versions of libraries included in the `{{ site.data.releases.stable-version }}` images:
+- `cuDF` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cudf/tree/v{{ site.data.releases.stable-version }}.0), `cuML` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cuml/tree/v{{ site.data.releases.stable-version }}.0), `cuGraph` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cugraph/tree/v{{ site.data.releases.stable-version }}.0), `RMM` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/RMM/tree/v{{ site.data.releases.stable-version }}.0), `cuSpatial` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cuspatial/tree/v{{ site.data.releases.stable-version }}.0), `cuxfilter` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cuxfilter/tree/branch-{{ site.data.releases.stable-version }}), `cuSignal` [v{{ site.data.releases.stable-version }}](https://github.com/rapidsai/cusignal/tree/branch-{{ site.data.releases.stable-version }})
   - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.13-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.13)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-{{ site.data.releases.stable-version }}-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-{{ site.data.releases.stable-version }})
 
 ### Former Version
 
-#### RAPIDS 0.12 - 4 February 2020
+#### RAPIDS {{ site.data.releases.legacy-version }} - {{ site.data.releases.legacy-date }}
 
-Versions of libraries included in the `0.12` images:
-- `cuDF` [v0.12.0](https://github.com/rapidsai/cudf/tree/v0.12.0), `cuML` [v0.12.0](https://github.com/rapidsai/cuml/tree/v0.12.0), `cuGraph` [v0.12.0](https://github.com/rapidsai/cugraph/tree/v0.12.0), `RMM` [v0.12.0](https://github.com/rapidsai/RMM/tree/v0.12.0), `cuSpatial` [v0.12.0](https://github.com/rapidsai/cuspatial/tree/v0.12.0), `cuxfilter` [v0.12.0](https://github.com/rapidsai/cuxfilter/tree/branch-0.12)
+Versions of libraries included in the `{{ site.data.releases.legacy-version }}` images:
+- `cuDF` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cudf/tree/v{{ site.data.releases.legacy-version }}.0), `cuML` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cuml/tree/v{{ site.data.releases.legacy-version }}.0), `cuGraph` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cugraph/tree/v{{ site.data.releases.legacy-version }}.0), `RMM` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/RMM/tree/v{{ site.data.releases.legacy-version }}.0), `cuSpatial` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cuspatial/tree/v{{ site.data.releases.legacy-version }}.0), `cuxfilter` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cuxfilter/tree/branch-{{ site.data.releases.legacy-version }}), `cuSignal` [v{{ site.data.releases.legacy-version }}](https://github.com/rapidsai/cusignal/tree/branch-{{ site.data.releases.legacy-version }})
   - **NOTE:** `cuxfilter` is only available in `runtime` containers
-- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-0.12-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-0.12)
+- `xgboost` [branch](https://github.com/rapidsai/xgboost/tree/rapids-{{ site.data.releases.legacy-version }}-release), `dask-xgboost` [branch](https://github.com/rapidsai/dask-xgboost/tree/dask-cudf) `dask-cuda` [branch](https://github.com/rapidsai/dask-cuda/tree/branch-{{ site.data.releases.legacy-version }})
 
 ### Image Types
 
@@ -54,7 +54,7 @@ The [rapidsai/rapidsai-dev](https://hub.docker.com/r/rapidsai/rapidsai-dev/tags)
 
 The tag naming scheme for RAPIDS images incorporates key platform details into the tag as shown below:
 ```
-0.12-cuda10.1-runtime-ubuntu18.04-py3.7
+{{ site.data.releases.stable-version }}-cuda10.1-runtime-ubuntu18.04-py3.7
  ^       ^    ^        ^         ^
  |       |    type     |         python version
  |       |             |
@@ -100,15 +100,16 @@ $ docker run --runtime=nvidia --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 
 ### Use JupyterLab to Explore the Notebooks
 
-Notebooks can be found in the following directories within the 0.10 container:
+Notebooks can be found in the following directories within the {{ site.data.releases.stable-version }} container:
 
-* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
-* `/rapids/notebooks/cudf` - cuDF demo notebooks
-* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/clx` - CLX demo notebooks
 * `/rapids/notebooks/cugraph` - cuGraph demo notebooks
-* `/rapids/notebooks/tutorials` - Tutorials with end-to-end workflows
+* `/rapids/notebooks/cuml` - cuML demo notebooks
+* `/rapids/notebooks/cusignal` - cuSignal demo notebooks
+* `/rapids/notebooks/cuxfilter` - cuXfilter demo notebooks
+* `/rapids/notebooks/xgboost` - XGBoost demo notebooks
 
-For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-0.9/README.md) in the notebooks repository.
+For a full description of each notebook, see the [README](https://github.com/rapidsai/notebooks/blob/branch-{{ site.data.releases.stable-version }}/README.md) in the notebooks repository.
 
 ### Custom Data and Advanced Usage
 

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -23,22 +23,22 @@ Project Leads
 Operations
 {: .label .label-purple}
 
-## Release v0.14 Schedule
+## Release v{{ site.data.releases.nightly-version }} Schedule
 
 **NOTE:** *Dates are subject to change at anytime. Completed release schedules are posted [here]({% link releases/schedule.md %}).*
 
 Phase | Start | End | Duration
 -- | -- | -- | --
-Development | Mon, Mar 9th | Mon, May 18th | 51 days
-Burn Down | Tue, May 19th | Wed, May 27th | 6 days
-Code Freeze/Testing | Thu, May 28th | Tue, June 2nd | 4 days
-Release | Wed, June 3rd | Wed, June 3rd | 1 day
-
-## _PROPOSED_ - Release v0.15 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Tue, May 19th | Wed, Aug 6th | 55 days
+Development | Tue, May 19th | Wed, Aug 5th | 55 days
 Burn Down | Tue, Aug 6th | Wed, Aug 12th | 5 days
 Code Freeze/Testing | Thu, Aug 13th | Tue, Aug 18th | 4 days
 Release | Wed, Aug 19th | Wed, Aug 19th | 1 day
+
+## _PROPOSED_ - Release v0.16 Schedule
+
+Phase | Start | End | Duration
+-- | -- | -- | --
+Development | Thu, Aug 6th | Wed, Sept 23rd | 34 days
+Burn Down | Thu, Sept 24th | Wed, Sept 30th | 5 days
+Code Freeze/Testing | Thu, Oct 1st | Tue, Oct 6th | 4 days
+Release | Wed, Oct 7th | Wed, Oct 7th | 1 day

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -1,0 +1,8 @@
+# Release Checklist
+
+On release day, the following changes need to be made to the site:
+
+- **Update [\_data/releases.yml](_data/releases.yml)**: Update versions, dates
+- **Update [\_data/docs.yml](_data/docs.yml)**: Verify legacy/stable/nightly versions are enabled/disabled appropriately
+- **Update [maintainers/maintainers.md](maintainers/maintainers.md)**: Update schedule for new nightly & nightly + 1
+- **Update [releases/schedule.md](releases/schedule.md)**: Update release schedule

--- a/releases/schedule.md
+++ b/releases/schedule.md
@@ -32,6 +32,15 @@ The current release schedule is posted on the [RAPIDS Maintainers Docs]({% link 
 
 Historical list of completed releases
 
+### Release v0.14 Schedule
+
+Phase | Start | End | Duration
+-- | -- | -- | --
+Development | Mon, Mar 9th | Mon, May 18th | 51 days
+Burn Down | Tue, May 19th | Wed, May 27th | 6 days
+Code Freeze/Testing | Thu, May 28th | Tue, June 2nd | 4 days
+Release | Wed, June 3rd | Wed, June 3rd | 1 day
+
 ### Release v0.13 Schedule
 
 Phase | Start | End | Duration

--- a/start/start.md
+++ b/start/start.md
@@ -23,12 +23,12 @@ Handy PDF reference guide for handling GPU Data Frames (GDF) with cuDF.
 {: .mb-7 }
 
 ### 10 Minutes to cuDF
-#### **[cuDF Post](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/10min.html){: target="_blank"}**
+#### **[cuDF Post](/api/cudf/stable/10min.html){: target="_blank"}**
 Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF that is geared mainly for new users.
 {: .mb-7 }
 
 ### 10 Minutes to Dask-XGBoost
-#### **[Dask-XGBoost Post](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/dask-xgb-10min.html){: target="_blank"}**
+#### **[Dask-XGBoost Post](/api/cudf/stable/dask-xgb-10min.html){: target="_blank"}**
 A short introduction to XGBoost with a distributed CUDA DataFrame via Dask-cuDF.
 {: .mb-7 }
 
@@ -38,7 +38,7 @@ Getting started guide and source code for XGBoost4J-Spark, along with notebooks 
 {: .mb-7 }
 
 ### Multi-GPU with Dask-cuDF
-#### **[Dask-cuDF Post](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/dask-cudf.html){: target="_blank"}**
+#### **[Dask-cuDF Post](/api/cudf/stable/dask-cudf.html){: target="_blank"}**
 Overview of using Dask for Multi-GPU cuDF solutions, on both a single machine or multiple GPUs across many machines in a cluster.
 {: .mb-7 }
 


### PR DESCRIPTION
This PR prepares the docs for the 0.14 release. It includes the following changes:

- Updates `_data/releases.yml` to contain latest release versions/dates
- Removes the `<legacy/stable/nightly>-docs` variables from `_data/releases.yml` since they are not used anywhere and pertain to filepaths from the old `projects` repo.
- Adds `libcugraph` to the /api page
- Updates `demos/containers/rapids-demo.md ` to use site data variables so we don't have to manually update version numbers anymore
- Update `maintainers/maintainers.md` schedule
- Adds `release_checklist.md` for future release maintainers
- Updates `releases/schedule.md`
- Removes old links from `start/start.md`