### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/maintainers/gpuci.md
+++ b/maintainers/gpuci.md
@@ -61,7 +61,7 @@ All jobs which use Docker run inside of the `gpuci/rapidsai-base` images.
 
 #### Conda environment
 
-The images contain a common conda environment with basic tools such as `python`, `cmake`, `make`, `cython`, and `flake8`. See the full list [here](https://github.com/rapidsai/gpuci-build-environment/blob/master/Dockerfile#L66)
+The images contain a common conda environment with basic tools such as `python`, `cmake`, `make`, `cython`, and `flake8`. See the full list [here](https://github.com/rapidsai/gpuci-build-environment/blob/main/Dockerfile#L66)
 
 The conda environment can be used in the scripts with `source activate gdf`
 
@@ -200,7 +200,7 @@ This script actually builds the code inside of a container. For most RAPIDS proj
 Additionally, this script should upload packages to Anaconda if necessary. The `GIT_BRANCH` variable can be used to determine what type of build:
 - `COMMIT_HASH` for PRs
 - `branch-x.y` for development branch builds
-- `master` for release builds
+- `main` for release builds
 
 ### ci/gpu/prebuild.sh
 
@@ -223,10 +223,10 @@ If the tests output in in XML format in `test-results/*.xml` or a file named `ju
 ### ci/releases/update-version.sh
 
 - Required: Only if auto-releasing is enabled
-- Job type: Master Branch only
+- Job type: Main Branch only
 - Docker: No
 
-This script is run with a parameter of `major`, `minor`, or `patch` to indicate what to release. gpuCI determines this based on where the commit is coming from. Merge commits from `branch-*` are minor releases whereas commits directly to master are patch releases. Major releases must be manually triggered.
+This script is run with a parameter of `major`, `minor`, or `patch` to indicate what to release. gpuCI determines this based on where the commit is coming from. Merge commits from `branch-*` are minor releases whereas commits directly to main are patch releases. Major releases must be manually triggered.
 
 The script should calculate the next version and update the source code, build scripts, and documentation with the new version.
 

--- a/releases/hotfix.md
+++ b/releases/hotfix.md
@@ -65,12 +65,12 @@ Also consider the timing of when the next release is scheduled. If the freeze or
 Developers
 {: .label .label-green}
 1. Hotfix issues will be assigned to you
-2. Create your branch from `master` NOT the `M.B` branch
+2. Create your branch from `main` NOT the `M.B` branch
 3. Implement the fix succinctly
   1. Change the minimal amount of code required
   2. Update related documentation and unit tests
   3. It is acceptable to implement a quick fix and open a new issue for a more in depth solution
-4. Once complete, create a [pull request]({% link contributing/prs.md %}) targeting `master`
+4. Once complete, create a [pull request]({% link contributing/prs.md %}) targeting `main`
 5. Notify the project lead
 
 Project Leads

--- a/releases/process.md
+++ b/releases/process.md
@@ -31,7 +31,7 @@ RAPIDS uses a custom git branching model, adapted from git-flow to leverage the 
 
 ### Migrating projects
 
-For RAPIDS projects that are using another branching/development model, continue to develop with that approach until the next **minor** release. Given the version `M.A.0` (where `M` is the major version and `A` is the minor version), create a development branch `branch-M.B` where `B=A+1` from the `master` branch that has the latest minor release.
+For RAPIDS projects that are using another branching/development model, continue to develop with that approach until the next **minor** release. Given the version `M.A.0` (where `M` is the major version and `A` is the minor version), create a development branch `branch-M.B` where `B=A+1` from the `main` branch that has the latest minor release.
 
 From this point forward you can follow the git branching & release model used by the RAPIDS team.
 
@@ -105,7 +105,7 @@ Operations
 {: .label .label-purple}
 
 1. Beginning of the `release date` announce the release of `branch-M.B`
-2. Create release PR from `branch-M.B` that targets `master`
+2. Create release PR from `branch-M.B` that targets `main`
 3. Begin testing of conda, containers, and notebooks for correctness and functionality
 4. Work with development team to close outstanding PRs
 5. Review documentation to ensure version numbers and instructions are correct

--- a/resources/git.md
+++ b/resources/git.md
@@ -30,7 +30,7 @@ Developers
 
 ### Approach
 
-Our development approach involves protecting the `master` branch so that it becomes the official release record for any RAPIDS project. Development PRs will be merged into a release branch, which will be merged into master and tagged only when the release is ready. The only other merges to `master` are hotfixes.
+Our development approach involves protecting the `main` branch so that it becomes the official release record for any RAPIDS project. Development PRs will be merged into a release branch, which will be merged into main and tagged only when the release is ready. The only other merges to `main` are hotfixes.
 
 ### Development workflow
 
@@ -38,23 +38,23 @@ All PRs are merged into a release branch named `branch-M.B` where `M` is the maj
 
 To **freeze** a release branch is to stop new development for the release, and focus on completing outstanding features and any bugs discovered from testing. Once this **freeze** happens a new branch `branch-M.C` (where `C=B+1`) is created so development can continue. Updates to `branch-M.B` can be merged as needed to `branch-M.C`, but generally will wait until the release is finished. This means that `branch-M.X` (where `X` is the highest minor version) the latest and greatest code.
 
-Hotfixes (patch releases) related to the current release `M.A` are directly merged to `master` from a PR and then those changes are also merged to the current release branches in progress through an automated process. All merges to `master` trigger an automated CI job that will produce a new release and tag incrementing the patch version off of the previous highest tag in the repo. Once the tag is set, the automated CI build for conda packages creates and pushes new packages for users. This includes the version change enabling known good builds and the ability to rollback.
+Hotfixes (patch releases) related to the current release `M.A` are directly merged to `main` from a PR and then those changes are also merged to the current release branches in progress through an automated process. All merges to `main` trigger an automated CI job that will produce a new release and tag incrementing the patch version off of the previous highest tag in the repo. Once the tag is set, the automated CI build for conda packages creates and pushes new packages for users. This includes the version change enabling known good builds and the ability to rollback.
 
 Minor (and eventually, Major) release development takes place on the current release branch. PRs can be edited on GitHub to set the target base branch for merging the PR. It is the reviewer’s responsibility to ensure the PR is targeted for the correct and planned release branch. Once PRs have passed all tests, they are merged to their release branch, which triggers an automated CI build for conda packages that will be marked as development, such as M.N-dev1. These can be inspected by the team to ensure the build works as intended and perform larger testing.
 
-Once a release has been reviewed and signoff has been given, a PR is created to merge the release branch to master. After the merge, the automated tagging process tags and releases a minor version and kicks off the conda builds for the public release.
+Once a release has been reviewed and signoff has been given, a PR is created to merge the release branch to main. After the merge, the automated tagging process tags and releases a minor version and kicks off the conda builds for the public release.
 
 ### Summary
 
-- The `master` branch is the official release history (including hotfixes).
-  - The tip of `master` is intended to be always working given the testing and reviews of merged PRs.
-  - Hotfixes (patch releases) are automatically tagged for every push to `master`.
+- The `main` branch is the official release history (including hotfixes).
+  - The tip of `main` is intended to be always working given the testing and reviews of merged PRs.
+  - Hotfixes (patch releases) are automatically tagged for every push to `main`.
 - Release branches are used for development of the next releases and **all PRs except for hotfixes** are merged to the current release branch.
   - A new release branch is created from the previous release branch after the release **freeze** (see above).
   - After the **freeze** and before the release branch is merged, there are two release branches; however, active development should take place in the next release branch, while cleanup and finalization happens in the frozen branch.
   - This gives the highest numbered `branch-M.X` (modulo hot fixes and unmerged frozen release fixes) the latest and greatest code.
 - Minor releases are done by creating a PR for the minor release from the associated release branch.
-  - After review and sign off by the team, the PR is merged into master.
+  - After review and sign off by the team, the PR is merged into main.
 
 ## Git commits
 


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.