### PR TITLE
DOC Add RAPIDS release delay notice

### DIFF
--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -37,7 +37,8 @@ layout: default
             {{ notice.notice_rapids_version }}
           </td>
           <td>
-            {% if notice.notice_updated == null or notice.notice_updated == "N/A" %}
+            {% assign updated_size = notice.notice_updated | size %}
+            {% if updated_size == 0 or notice.notice_updated == "N/A" %}
               {{ notice.notice_created }}
             {% else %}
               {{ notice.notice_updated }}
@@ -83,7 +84,8 @@ layout: default
             {{ notice.notice_rapids_version }}
           </td>
           <td>
-            {% if notice.notice_updated == "N/A" or notice.notice_updated == "" %}
+            {% assign updated_size = notice.notice_updated | size %}
+            {% if updated_size == 0 or notice.notice_updated == "N/A" %}
               {{ notice.notice_created }}
             {% else %}
               {{ notice.notice_updated }}

--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -53,7 +53,7 @@ layout: default
 
 {% if page.has_notice_pin_index %}
   <h2>Recent and Important Notices</h2>
-  {% assign notice_list = site.notices | where:"notice_pin","true" | sort:"notice_id" %}
+  {% assign notice_list = site.notices | where:"notice_pin","true" | sort: "notice_id" | sort:"notice_type" %}
   {% assign notice_cnt = notice_list | size %}
   {% if notice_cnt == 0 %}
     <h2 class="text-delta">No current Notices</h2>

--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -37,7 +37,7 @@ layout: default
             {{ notice.notice_rapids_version }}
           </td>
           <td>
-            {% if notice.notice_updated == "N/A" or notice.notice_updated == "" %}
+            {% if notice.notice_updated == null or notice.notice_updated == "N/A" %}
               {{ notice.notice_created }}
             {% else %}
               {{ notice.notice_updated }}

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -30,3 +30,7 @@ The RAPIDS `v0.15` release date has been pushed for 1 week to 26-Aug-2020 to bet
 ## Rationale
 
 Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable or release candidate versions that support CUDA 11 on or around 19-Aug-2020. Given their release dates are scheduled on the original release date for RAPIDS `v0.15`, we are delaying the release so we can ship with more stable dependencies instead.
+
+## Impact
+
+See our updated [release schedule]({% link maintainers/maintainers.md %}) for `v0.15`

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -1,0 +1,32 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 3 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v0.15 Release Delayed"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green" 
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.15"
+notice_created: 05-Aug-2020
+notice_updated:
+---
+
+## Overview
+
+The RAPIDS `v0.15` release date has been pushed for 1 week to 26-Aug-2020 to better support CUDA 11.
+
+## Rationale
+
+Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable or release candidate versions that support CUDA 11 on or around 19-Aug-2020. Given their release dates are scheduled on the original release date for RAPIDS `v0.15`, we are delaying the release so we can ship with more stable dependencies instead.

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -7,7 +7,7 @@ notice_type: rgn
 # Update meta-data for notice
 notice_id: 3 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "v0.15 Release Delayed"
+title: "v0.15 Release Extension"
 notice_author: RAPIDS Ops
 notice_status: Completed
 notice_status_color: green
@@ -25,11 +25,11 @@ notice_updated:
 
 ## Overview
 
-The RAPIDS `v0.15` release date has been pushed for 1 week to 26-Aug-2020 to better support CUDA 11.
+The RAPIDS `v0.15` release date has been extended for 1 week to 26-Aug-2020 to better support CUDA 11.
 
 ## Rationale
 
-Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable or release candidate versions that support CUDA 11 on or around 19-Aug-2020. Given their release dates are scheduled on the original release date for RAPIDS `v0.15`, we are delaying the release so we can ship with more stable dependencies instead.
+Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable or release candidate versions that support CUDA 11 on or around 19-Aug-2020. Given their release dates are scheduled on the original release date for RAPIDS `v0.15`, we are extending the release so we can ship with more stable dependencies instead.
 
 ## Impact
 

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -27,12 +27,14 @@ Operations
 
 **NOTE:** *Dates are subject to change at anytime. Completed release schedules are posted [here]({% link releases/schedule.md %}).*
 
+> See [RGN 3](/notices/rgn0003) for update on `v0.15` release
+
 Phase | Start | End | Duration
 -- | -- | -- | --
 Development | Tue, May 19th | Wed, Aug 5th | 55 days
-Burn Down | Thu, Aug 6th | Wed, Aug 12th | 5 days
-Code Freeze/Testing | Thu, Aug 13th | Tue, Aug 18th | 4 days
-Release | Wed, Aug 19th | Wed, Aug 19th | 1 day
+Burn Down | Thu, Aug 6th | Wed, Aug 12th | 10 days
+Code Freeze/Testing | Thu, Aug 20th | Tue, Aug 25th | 4 days
+Release | Wed, Aug 26th | Wed, Aug 26th | 1 day
 
 ## _PROPOSED_ - Release v0.16 Schedule
 

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -27,7 +27,7 @@ Operations
 
 **NOTE:** *Dates are subject to change at anytime. Completed release schedules are posted [here]({% link releases/schedule.md %}).*
 
-> See [RGN 3](/notices/rgn0003) for update on `v0.15` release
+**NOTICE:** See [RGN 3](/notices/rgn0003) for update on `v0.15` release extension
 
 Phase | Start | End | Duration
 -- | -- | -- | --


### PR DESCRIPTION
v0.15 release is delayed 1 week due to core dependencies shipping new versions on our original release date.