### PR TITLE
Add RSS feed for notices

### DIFF
--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -6,94 +6,96 @@ layout: default
 <hr>
 
 {% if page.has_notice_index %}
-  {% assign notice_list = site.notices | where:"notice_type",page.notice_type | sort:"notice_id" %}
-  {% assign notice_cnt = notice_list | size %}
-    {% if notice_cnt == 0 %}
-      <h2 class="text-delta">No current Notices</h2>
-    {% else %}
-    <table>
-      <thead>
-        <tr>
-          <th>Notice</th>
-          <th>Title</th>
-          <th>Topic</th>
-          <th>RAPIDS Version</th>
-          <th>Updated</th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for notice in notice_list %}
-        <tr>
-          <td>
-            <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br/><p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
-          </td>
-          <td>
-            <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
-          </td>
-          <td>
-            {{ notice.notice_topic }}
-          </td>
-          <td>
-            {{ notice.notice_rapids_version }}
-          </td>
-          <td>
-            {% assign updated_size = notice.notice_updated | size %}
-            {% if updated_size == 0 or notice.notice_updated == "N/A" %}
-              {{ notice.notice_created }}
-            {% else %}
-              {{ notice.notice_updated }}
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
+{% assign notice_list = site.notices | where:"notice_type",page.notice_type | sort:"notice_id" %}
+{% assign notice_cnt = notice_list | size %}
+{% if notice_cnt == 0 %}
+<h2 class="text-delta">No current Notices</h2>
+{% else %}
+<table>
+  <thead>
+    <tr>
+      <th>Notice</th>
+      <th>Title</th>
+      <th>Topic</th>
+      <th>RAPIDS Version</th>
+      <th>Updated</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for notice in notice_list %}
+    <tr>
+      <td>
+        <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br />
+        <p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
+      </td>
+      <td>
+        <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
+      </td>
+      <td>
+        {{ notice.notice_topic }}
+      </td>
+      <td>
+        {{ notice.notice_rapids_version }}
+      </td>
+      <td>
+        {% assign updated_size = notice.notice_updated | size %}
+        {% if updated_size == 0 or notice.notice_updated == null %}
+        {{ notice.notice_created | date_to_long_string }}
+        {% else %}
+        {{ notice.notice_updated | date_to_long_string }}
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 {% endif %}
 
 {% if page.has_notice_pin_index %}
-  <h2>Recent and Important Notices</h2>
-  {% assign notice_list = site.notices | where:"notice_pin","true" | sort: "notice_id" | sort:"notice_type" %}
-  {% assign notice_cnt = notice_list | size %}
-  {% if notice_cnt == 0 %}
-    <h2 class="text-delta">No current Notices</h2>
-  {% else %}
-    <table>
-      <thead>
-        <tr>
-          <th>Notice</th>
-          <th>Title</th>
-          <th>Topic</th>
-          <th>RAPIDS Version</th>
-          <th>Updated</th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for notice in notice_list %}
-        <tr>
-          <td>
-            <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br/><p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
-          </td>
-          <td>
-            <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
-          </td>
-          <td>
-            {{ notice.notice_topic }}
-          </td>
-          <td>
-            {{ notice.notice_rapids_version }}
-          </td>
-          <td>
-            {% assign updated_size = notice.notice_updated | size %}
-            {% if updated_size == 0 or notice.notice_updated == "N/A" %}
-              {{ notice.notice_created }}
-            {% else %}
-              {{ notice.notice_updated }}
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
+<h2>Recent and Important Notices</h2>
+{% assign notice_list = site.notices | where:"notice_pin","true" | sort: "notice_id" | sort:"notice_type" %}
+{% assign notice_cnt = notice_list | size %}
+{% if notice_cnt == 0 %}
+<h2 class="text-delta">No current Notices</h2>
+{% else %}
+<table>
+  <thead>
+    <tr>
+      <th>Notice</th>
+      <th>Title</th>
+      <th>Topic</th>
+      <th>RAPIDS Version</th>
+      <th>Updated</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for notice in notice_list %}
+    <tr>
+      <td>
+        <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br />
+        <p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
+      </td>
+      <td>
+        <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
+      </td>
+      <td>
+        {{ notice.notice_topic }}
+      </td>
+      <td>
+        {{ notice.notice_rapids_version }}
+      </td>
+      <td>
+        {% assign updated_size = notice.notice_updated | size %}
+        {% if updated_size == 0 or notice.notice_updated == null %}
+        {{ notice.notice_created | date_to_long_string }}
+        {% else %}
+        {{ notice.notice_updated | date_to_long_string }}
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
 {% endif %}

--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -6,96 +6,94 @@ layout: default
 <hr>
 
 {% if page.has_notice_index %}
-{% assign notice_list = site.notices | where:"notice_type",page.notice_type | sort:"notice_id" %}
-{% assign notice_cnt = notice_list | size %}
-{% if notice_cnt == 0 %}
-<h2 class="text-delta">No current Notices</h2>
-{% else %}
-<table>
-  <thead>
-    <tr>
-      <th>Notice</th>
-      <th>Title</th>
-      <th>Topic</th>
-      <th>RAPIDS Version</th>
-      <th>Updated</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for notice in notice_list %}
-    <tr>
-      <td>
-        <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br />
-        <p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
-      </td>
-      <td>
-        <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
-      </td>
-      <td>
-        {{ notice.notice_topic }}
-      </td>
-      <td>
-        {{ notice.notice_rapids_version }}
-      </td>
-      <td>
-        {% assign updated_size = notice.notice_updated | size %}
-        {% if updated_size == 0 or notice.notice_updated == null %}
-        {{ notice.notice_created | date_to_long_string }}
-        {% else %}
-        {{ notice.notice_updated | date_to_long_string }}
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-{% endif %}
+  {% assign notice_list = site.notices | where:"notice_type",page.notice_type | sort:"notice_id" %}
+  {% assign notice_cnt = notice_list | size %}
+    {% if notice_cnt == 0 %}
+      <h2 class="text-delta">No current Notices</h2>
+    {% else %}
+    <table>
+      <thead>
+        <tr>
+          <th>Notice</th>
+          <th>Title</th>
+          <th>Topic</th>
+          <th>RAPIDS Version</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for notice in notice_list %}
+        <tr>
+          <td>
+            <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br/><p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
+          </td>
+          <td>
+            <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
+          </td>
+          <td>
+            {{ notice.notice_topic }}
+          </td>
+          <td>
+            {{ notice.notice_rapids_version }}
+          </td>
+          <td>
+            {% assign updated_size = notice.notice_updated | size %}
+            {% if updated_size == 0 or notice.notice_updated == null %}
+              {{ notice.notice_created | date_to_long_string }}
+            {% else %}
+              {{ notice.notice_updated | date_to_long_string }}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endif %}
 
 {% if page.has_notice_pin_index %}
-<h2>Recent and Important Notices</h2>
-{% assign notice_list = site.notices | where:"notice_pin","true" | sort: "notice_id" | sort:"notice_type" %}
-{% assign notice_cnt = notice_list | size %}
-{% if notice_cnt == 0 %}
-<h2 class="text-delta">No current Notices</h2>
-{% else %}
-<table>
-  <thead>
-    <tr>
-      <th>Notice</th>
-      <th>Title</th>
-      <th>Topic</th>
-      <th>RAPIDS Version</th>
-      <th>Updated</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for notice in notice_list %}
-    <tr>
-      <td>
-        <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br />
-        <p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
-      </td>
-      <td>
-        <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
-      </td>
-      <td>
-        {{ notice.notice_topic }}
-      </td>
-      <td>
-        {{ notice.notice_rapids_version }}
-      </td>
-      <td>
-        {% assign updated_size = notice.notice_updated | size %}
-        {% if updated_size == 0 or notice.notice_updated == null %}
-        {{ notice.notice_created | date_to_long_string }}
-        {% else %}
-        {{ notice.notice_updated | date_to_long_string }}
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-{% endif %}
+  <h2>Recent and Important Notices</h2>
+  {% assign notice_list = site.notices | where:"notice_pin","true" | sort: "notice_id" | sort:"notice_type" %}
+  {% assign notice_cnt = notice_list | size %}
+  {% if notice_cnt == 0 %}
+    <h2 class="text-delta">No current Notices</h2>
+  {% else %}
+    <table>
+      <thead>
+        <tr>
+          <th>Notice</th>
+          <th>Title</th>
+          <th>Topic</th>
+          <th>RAPIDS Version</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for notice in notice_list %}
+        <tr>
+          <td>
+            <b>{{ notice.notice_type | upcase }} {{ notice.notice_id}}</b><br/><p class="label label-title label-{{ notice.notice_status_color }}">{{ notice.notice_status }}</p>
+          </td>
+          <td>
+            <a href="{{ notice.url | relative_url }}">{{ notice.title }}</a>
+          </td>
+          <td>
+            {{ notice.notice_topic }}
+          </td>
+          <td>
+            {{ notice.notice_rapids_version }}
+          </td>
+          <td>
+            {% assign updated_size = notice.notice_updated | size %}
+            {% if updated_size == 0 or notice.notice_updated == null %}
+              {{ notice.notice_created | date_to_long_string }}
+            {% else %}
+              {{ notice.notice_updated | date_to_long_string }}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endif %}

--- a/_layouts/notice.html
+++ b/_layouts/notice.html
@@ -11,7 +11,9 @@ layout: default
     </tr>
     <tr>
       <td><strong>Status</strong></td>
-      <td><p class="label label-title label-{{ page.notice_status_color }}">{{ page.notice_status }}</p></td>
+      <td>
+        <p class="label label-title label-{{ page.notice_status_color }}">{{ page.notice_status }}</p>
+      </td>
     </tr>
     <tr>
       <td><strong>Topic</strong></td>
@@ -23,11 +25,13 @@ layout: default
     </tr>
     <tr>
       <td><strong>Created</strong></td>
-      <td>{{ page.notice_created }}</td>
+      <td>{{ page.notice_created | date_to_long_string }}</td>
     </tr>
     <tr>
       <td><strong>Updated</strong></td>
-      <td>{{ page.notice_updated }}</td>
+      <td>
+        {% if page.notice_updated != null %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}
+      </td>
     </tr>
   </tbody>
 </table>

--- a/_layouts/notice.html
+++ b/_layouts/notice.html
@@ -11,9 +11,7 @@ layout: default
     </tr>
     <tr>
       <td><strong>Status</strong></td>
-      <td>
-        <p class="label label-title label-{{ page.notice_status_color }}">{{ page.notice_status }}</p>
-      </td>
+      <td><p class="label label-title label-{{ page.notice_status_color }}">{{ page.notice_status }}</p></td>
     </tr>
     <tr>
       <td><strong>Topic</strong></td>
@@ -29,9 +27,7 @@ layout: default
     </tr>
     <tr>
       <td><strong>Updated</strong></td>
-      <td>
-        {% if page.notice_updated != null %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}
-      </td>
+      <td>{% if page.notice_updated != null %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}</td>
     </tr>
   </tbody>
 </table>

--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -13,14 +13,14 @@ notice_status: In Progress
 notice_status_color: yellow
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Git Repo Change
 notice_rapids_version: "v0.15"
-notice_created: 13-Jul-2020
-notice_updated: 17-Jul-2020
+notice_created: 2020-07-13
+notice_updated: 2020-07-17
 ---
 
 ## Overview
@@ -41,7 +41,7 @@ For more information read the [GitHub docs](https://github.com/github/renaming/)
 
 ## Impact
 
-Any other projects or developers referring to our current stable/release branch will no longer work or may redirect incorrectly. This includes search and web links that link to GitHub. 
+Any other projects or developers referring to our current stable/release branch will no longer work or may redirect incorrectly. This includes search and web links that link to GitHub.
 
 From the [GitHub docs](https://github.com/github/renaming/) on renaming, there will be some redirects in place; however, they will redirect to the GitHub "default" branch which in our case means links to stable/release will redirect to our development branch. This may cause some confusion, but we will do our best to ensure the links are updated.
 

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -13,13 +13,13 @@ notice_status: Completed
 notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Release Change
 notice_rapids_version: "v0.15"
-notice_created: 05-Aug-2020
+notice_created: 2020-08-05
 notice_updated:
 ---
 

--- a/_notices/rsn0001.md
+++ b/_notices/rsn0001.md
@@ -13,14 +13,14 @@ notice_status: Completed
 notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
-notice_created: 17-Jul-2020
-notice_updated: N/A
+notice_created: 2020-07-17
+notice_updated: null
 ---
 
 ## Overview

--- a/_notices/rsn0002.md
+++ b/_notices/rsn0002.md
@@ -13,14 +13,14 @@ notice_status: Completed
 notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.14 & v0.15"
-notice_created: 13-Jul-2020
-notice_updated: N/A
+notice_created: 2020-07-13
+notice_updated: null
 ---
 
 ## Overview

--- a/_notices/rsn0003.md
+++ b/_notices/rsn0003.md
@@ -13,14 +13,14 @@ notice_status: Completed
 notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
-notice_created: 13-Jul-2020
-notice_updated: 17-Jul-2020
+notice_created: 2020-07-13
+notice_updated: 2020-07-17
 ---
 
 ## Overview

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -13,14 +13,14 @@ notice_status: In Progress
 notice_status_color: yellow
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
-#   "Completed" - "green" 
+#   "Completed" - "green"
 #   "Review" - "purple"
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
-notice_created: 13-Jul-2020
-notice_updated: 21-Jul-2020
+notice_created: 2020-07-13
+notice_updated: 2020-07-21
 ---
 
 ## Overview

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -1,0 +1,32 @@
+---
+layout:
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }} - Notices</title>
+    <description>Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.</description>
+    <link>{{ site.url }}{{ site.baseurl }}notices</link>
+    <atom:link href="{{ "notices/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% assign notices = site.notices | sort: 'notice_created' | reverse %}
+    {% for post in notices %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.notice_created | date_to_rfc822 }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+        {% for cat in post.categories %}
+        <category>{{ cat | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/notices/notices.md
+++ b/notices/notices.md
@@ -7,7 +7,7 @@ permalink: notices
 has_notice_pin_index: true # shows pinned notices at end
 ---
 
-# RAPIDS Notices <a href="feed.xml"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
+# RAPIDS Notices <a href="{% link notices/feed.xml %}"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
 
 Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.
 

--- a/notices/notices.md
+++ b/notices/notices.md
@@ -7,9 +7,12 @@ permalink: notices
 has_notice_pin_index: true # shows pinned notices at end
 ---
 
-# RAPIDS Notices
+# RAPIDS Notices <a href="feed.xml"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
 
 Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.
+
+
+
 {: .fs-6 .fw-300 }
 
 ## Notice Types

--- a/notices/notices.md
+++ b/notices/notices.md
@@ -11,8 +11,6 @@ has_notice_pin_index: true # shows pinned notices at end
 
 Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.
 
-
-
 {: .fs-6 .fw-300 }
 
 ## Notice Types

--- a/notices/notices.md
+++ b/notices/notices.md
@@ -10,7 +10,6 @@ has_notice_pin_index: true # shows pinned notices at end
 # RAPIDS Notices <a href="{% link notices/feed.xml %}"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
 
 Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.
-
 {: .fs-6 .fw-300 }
 
 ## Notice Types


### PR DESCRIPTION
I spotted @mike-wendt's message about tweeting notices with the #rapidsnotices hashtag and thought it would also be useful to have an RSS feed. I would be more confident in not missing notices if they came up in my feed reader.

This PR changes the following:
- Add RSS feed template at `/notices/feed.xml`
- Switch notices to use Jekyll date format (`YYYY-MM-DD`) to enable sorting in Jekyll templates
- Update templates to render dates in human readable format (as they were stored previously `DD MON YYYY`)
- Change use of `"N/A"` string to Jekyll `null` type and update template to show `N/A` for null values
- Add link to RSS feed from notices page

![Updated Notices page with RSS icon and date format](https://user-images.githubusercontent.com/1610850/90408791-411c8a00-e0a0-11ea-932a-0312bf49b8ce.png)
![RSS feed example](https://user-images.githubusercontent.com/1610850/90408830-4da0e280-e0a0-11ea-8388-607dd1a65ad3.png)

