### PR TITLE
DOC Update and add RAPIDS notices for v0.15 Release

### DIFF
--- a/_notices/rdn0001.md
+++ b/_notices/rdn0001.md
@@ -1,0 +1,47 @@
+---
+layout: notice
+parent: RAPIDS Developer Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rdn
+# Update meta-data for notice
+notice_id: 1 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "'dask-xgboost' is deprecated in v0.15 & removed v0.16"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Library Deprecation
+notice_rapids_version: "v0.15"
+notice_created: 2020-08-26
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-08-26
+---
+
+## Overview
+
+[`rapidsai/dask-xgboost`](https://github.com/rapidsai/dask-xgboost) is
+deprecated in `v0.15` and will be removed in `v0.16`. As of release 1.0, XGBoost
+provides a native [Dask API](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html).
+
+The native XGBoost API has all of the functionality of dask-xgboost, combined
+with an updated, clean API and much more extensive testing. All users are
+encouraged to switch to the native API. See also this [blog post](https://medium.com/rapids-ai/a-new-official-dask-api-for-xgboost-e8b10f3d1eb7)
+for an overview.
+
+## Status
+
+- Added a [deprecation warning](https://github.com/rapidsai/dask-xgboost/pull/4/files)
+to the RAPIDS [`rapidsai/dask-xgboost`](https://github.com/rapidsai/dask-xgboost)
+repo
+
+## Impact
+
+Any other projects or developers using our version of `rapidsai/dask-xgboost`
+should switch to the upstream repo [dask/dask-xgboost](https://github.com/dask/dask-xgboost)

--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -26,25 +26,43 @@ notice_updated: 2020-08-26
 
 ## Overview
 
-RAPIDS has decided to follow other Open Source projects in renaming their "default" git branch to `main`. Starting with the `v0.15` release, the existing RAPIDS stable/release branch will be removed and all references should use the `main` branch going forward.
+RAPIDS has decided to follow other Open Source projects in renaming their
+"default" git branch to `main`. Starting with the `v0.15` release, the existing
+RAPIDS stable/release branch will be removed and all references should use the
+`main` branch going forward.
 
->**NOTE:** RAPIDS uses `branch-X.Y` as our GitHub default branch for development; however, our stable/release branch is typically the "default" branch for others and new git projects.
+>**NOTE:** RAPIDS uses `branch-X.Y` as our GitHub default branch for
+development; however, our stable/release branch is typically the "default"
+branch for others and new git projects.
 
-For more information read the [GitHub docs](https://github.com/github/renaming/) detailing their plan for renaming branches.
+For more information read the [GitHub docs](https://github.com/github/renaming/)
+detailing their plan for renaming branches.
 
 ## Status
 
 ### Updates
 
-- **10-Jul-2020** - `main` branches were added to all repos with an existing stable/release branch
-- **15-Jul-2020** - Documentation with outdated references were updated with PRs to `main`
-- **Completed** - PRs to update scripts and other mentions will be merged into `branch-0.15` and then into `main`
-- **Ongoing** - Release `v0.15` is occurring and using the `main` branch; the old branches will be removed post-release
+- **10-Jul-2020** - `main` branches were added to all repos with an existing
+stable/release branch
+- **15-Jul-2020** - Documentation with outdated references were updated with PRs
+to `main`
+- **Completed** - PRs to update scripts and other mentions will be merged into
+`branch-0.15` and then into `main`
+- **Ongoing** - Release `v0.15` is occurring and using the `main` branch; the
+old branches will be removed post-release
 
 ## Impact
 
-Any other projects or developers referring to our current stable/release branch will no longer work or may redirect incorrectly. This includes search and web links that link to GitHub.
+Any other projects or developers referring to our current stable/release branch
+will no longer work or may redirect incorrectly. This includes search and web
+links that link to GitHub.
 
-From the [GitHub docs](https://github.com/github/renaming/) on renaming, there will be some redirects in place; however, they will redirect to the GitHub "default" branch which in our case means links to stable/release will redirect to our development branch. This may cause some confusion, but we will do our best to ensure the links are updated.
+From the [GitHub docs](https://github.com/github/renaming/) on renaming, there
+will be some redirects in place; however, they will redirect to the GitHub
+"default" branch which in our case means links to stable/release will redirect
+to our development branch. This may cause some confusion, but we will do our
+best to ensure the links are updated.
 
-Users that find outdated links should open an issue in the repo they have been found. For updates on this docs site or [rapids.ai](https://rapids.ai), file an issue [here](https://github.com/rapidsai/docs/issues/new/choose).
+Users that find outdated links should open an issue in the repo they have been
+found. For updates on this docs site or [rapids.ai](https://rapids.ai), file an
+issue [here](https://github.com/rapidsai/docs/issues/new/choose).

--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -39,7 +39,7 @@ For more information read the [GitHub docs](https://github.com/github/renaming/)
 - **10-Jul-2020** - `main` branches were added to all repos with an existing stable/release branch
 - **15-Jul-2020** - Documentation with outdated references were updated with PRs to `main`
 - **Completed** - PRs to update scripts and other mentions will be merged into `branch-0.15` and then into `main`
-- **On-going** - Release `v0.15` is occurring and using the `main` branch; the old branches will be removed post-release
+- **Ongoing** - Release `v0.15` is occurring and using the `main` branch; the old branches will be removed post-release
 
 ## Impact
 

--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -21,7 +21,7 @@ notice_topic: Git Repo Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-13
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2020-07-17
+notice_updated: 2020-08-26
 ---
 
 ## Overview
@@ -36,9 +36,10 @@ For more information read the [GitHub docs](https://github.com/github/renaming/)
 
 ### Updates
 
-- 10-Jul-2020 - `main` branches were added to all repos with an existing stable/release branch
-- 15-Jul-2020 - Documentation with outdated references were updated with PRs to `main`
-- On-going - PRs to update scripts and other mentions will be merged into `branch-0.15` and then into `main` upon `v0.15` release
+- **10-Jul-2020** - `main` branches were added to all repos with an existing stable/release branch
+- **15-Jul-2020** - Documentation with outdated references were updated with PRs to `main`
+- **Completed** - PRs to update scripts and other mentions will be merged into `branch-0.15` and then into `main`
+- **On-going** - Release `v0.15` is occurring and using the `main` branch; the old branches will be removed post-release
 
 ## Impact
 

--- a/_notices/rgn0002.md
+++ b/_notices/rgn0002.md
@@ -36,4 +36,5 @@ currently. The `v0.15` release of `clx` will only support `CUDA 10.1` &
 
 ## Impact
 
-Users are encouraged to use nightly `conda` packages in `v0.16` when `CUDA 11` support is available.
+Users are encouraged to use nightly `conda` packages in `v0.16` when `CUDA 11`
+support is available.

--- a/_notices/rgn0002.md
+++ b/_notices/rgn0002.md
@@ -1,0 +1,39 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 2 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v0.15 No CUDA 11 Release for 'clx'"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.15"
+notice_created: 2020-08-03
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-08-26
+---
+
+## Overview
+
+`clx` depends on PyTorch `v1.6` which does not have `CUDA 11.0` support
+currently. The `v0.15` release of `clx` will only support `CUDA 10.1` &
+`CUDA 10.2`.
+
+## Status
+
+- **26-Aug-2020** - Released `CUDA 10.1` and `CUDA 10.2` support for `clx`
+
+## Impact
+
+Users are encouraged to use nightly `conda` packages in `v0.16` when `CUDA 11` support is available.

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -26,12 +26,18 @@ notice_updated: 2020-08-05
 
 ## Overview
 
-The RAPIDS `v0.15` release date has been extended for 1 week to 26-Aug-2020 to better support CUDA 11.
+The RAPIDS `v0.15` release date has been extended for 1 week to 26-Aug-2020 to
+better support CUDA 11.
 
 ## Rationale
 
-Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable or release candidate versions that support CUDA 11 on or around 19-Aug-2020. Given their release dates are scheduled on the original release date for RAPIDS `v0.15`, we are extending the release so we can ship with more stable dependencies instead.
+Core RAPIDS dependencies like `CuPy` and `Numba` are planning to release stable
+or release candidate versions that support CUDA 11 on or around 19-Aug-2020.
+Given their release dates are scheduled on the original release date for RAPIDS
+`v0.15`, we are extending the release so we can ship with more stable
+dependencies instead.
 
 ## Impact
 
-See our updated [release schedule]({% link maintainers/maintainers.md %}) for `v0.15`
+See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+`v0.15`

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 3 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "v0.15 Release Extension"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0004.md
+++ b/_notices/rgn0004.md
@@ -1,0 +1,41 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 4 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v0.15 Release Delay for 'cuxfilter'"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.15"
+notice_created: 2020-08-26
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-08-26
+---
+
+## Overview
+
+`cuxfilter` depends on Numba `v0.51`. Currently there is only `v0.51.0` there
+are known issues with this release for other RAPIDS libraries and we need to
+wait for `v0.51.1` to release `cuxfilter`.
+
+## Status
+
+- **26-Aug-2020** - Released RAPIDS `v0.15` without `cuxfilter`
+- **On-going** - Test and release `cuxfilter` when Numba `v0.51.1` is released
+
+## Impact
+
+Users are to use the previous version of `cuxfilter` from `v0.15` until this is
+resolved.

--- a/_notices/rgn0004.md
+++ b/_notices/rgn0004.md
@@ -37,5 +37,5 @@ wait for `v0.51.1` to release `cuxfilter`.
 
 ## Impact
 
-Users are encouraged to use the previous version of `cuxfilter` from `v0.15` until this is
-resolved.
+Users are encouraged to use the previous version of `cuxfilter` from `v0.15`
+until this is resolved.

--- a/_notices/rgn0004.md
+++ b/_notices/rgn0004.md
@@ -37,5 +37,5 @@ wait for `v0.51.1` to release `cuxfilter`.
 
 ## Impact
 
-Users are to use the previous version of `cuxfilter` from `v0.15` until this is
+Users are encouraged to use the previous version of `cuxfilter` from `v0.15` until this is
 resolved.

--- a/_notices/rgn0004.md
+++ b/_notices/rgn0004.md
@@ -33,7 +33,7 @@ wait for `v0.51.1` to release `cuxfilter`.
 ## Status
 
 - **26-Aug-2020** - Released RAPIDS `v0.15` without `cuxfilter`
-- **On-going** - Test and release `cuxfilter` when Numba `v0.51.1` is released
+- **Ongoing** - Test and release `cuxfilter` when Numba `v0.51.1` is released
 
 ## Impact
 

--- a/_notices/rsn0001.md
+++ b/_notices/rsn0001.md
@@ -26,11 +26,13 @@ notice_updated: 2020-07-17
 
 ## Overview
 
-Changes in the `conda-forge` ecosystem forced RAPIDS to change from `gcc/g++ 7.3` support to `gcc/g++ 7.5` support for `v0.14` and future releases.
+Changes in the `conda-forge` ecosystem forced RAPIDS to change from
+`gcc/g++ 7.3` support to `gcc/g++ 7.5` support for `v0.14` and future releases.
 
 ## Status
 
-All `conda` and `docker` images use `gcc/g++ 7.5` to ensure compatibility with `conda-forge`
+All `conda` and `docker` images use `gcc/g++ 7.5` to ensure compatibility with
+`conda-forge`
 
 ## Impact
 

--- a/_notices/rsn0001.md
+++ b/_notices/rsn0001.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 1 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Change minimum support gcc/g++ version to 7.5"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0002.md
+++ b/_notices/rsn0002.md
@@ -26,31 +26,42 @@ notice_updated: 2020-07-13
 
 ## Overview
 
-`Python 3.6` and `CUDA 10.0` have reached end of life (EOL) in RAPIDS `v0.14` and will not be supported in the upcoming release of `v0.15`. This includes `v0.15` nightly support which ended on 13-Jul-2020.
+`Python 3.6` and `CUDA 10.0` have reached end of life (EOL) in RAPIDS `v0.14`
+and will not be supported in the upcoming release of `v0.15`. This includes
+`v0.15` nightly support which ended on 13-Jul-2020.
 
 ## Status
 
 ### Nightly support
 
 - Has ended as of **13-Jul-2020**
-  - No further `conda` packages or `docker` images will be released for these versions
+  - No further `conda` packages or `docker` images will be released for these
+  versions
 
 ### Documentation
 
 - Updates to Docker Hub and NGC repos will be reflected with the `v0.15` release
-- Updated [rapids.ai](https://rapids.ai/start#rapids-release-selector) release selector to reflect EOL
+- Updated [rapids.ai](https://rapids.ai/start#rapids-release-selector) release
+selector to reflect EOL
 
 ## Rationale
 
 ### Python 3.6 EOL
 
-Due to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) support for `Python 3.6` in a large number of our dependent libraries was removed in late June 2020. Some libraries are continuing to publish `Python 3.6` packages; however, others are working towards discontinuing them in the near future.
+Due to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) support
+for `Python 3.6` in a large number of our dependent libraries was removed in
+late June 2020. Some libraries are continuing to publish `Python 3.6` packages;
+however, others are working towards discontinuing them in the near future.
 
-Given the push of the community to focus on `Python 3.7 & 3.8` we opted to spend our resources on `Python 3.8` bring up for `v0.15`. See [RSN 3](/notices/rsn0003) for updates.
+Given the push of the community to focus on `Python 3.7 & 3.8` we opted to spend
+our resources on `Python 3.8` bring up for `v0.15`. See [RSN 3](/notices/rsn0003)
+for updates.
 
 ### CUDA 10.0 EOL
 
-Given community input and the release of `CUDA 11.0`, the team has opted to EOL `CUDA 10.0` in favor of bring up for ***beta*** support of `CUDA 11.0` in `v0.15`. See [RSN 4](/notices/rsn0004) for updates.
+Given community input and the release of `CUDA 11.0`, the team has opted to EOL
+`CUDA 10.0` in favor of bring up for ***beta*** support of `CUDA 11.0` in
+`v0.15`. See [RSN 4](/notices/rsn0004) for updates.
 
 ## Impact
 

--- a/_notices/rsn0003.md
+++ b/_notices/rsn0003.md
@@ -26,12 +26,15 @@ notice_updated: 2020-07-17
 
 ## Overview
 
-With the EOL of `Python 3.6` announced in [RSN 2](/notices/rsn0002), development effort has been redirected to support `Python 3.8` in `v0.15`.
+With the EOL of `Python 3.6` announced in [RSN 2](/notices/rsn0002), development
+effort has been redirected to support `Python 3.8` in `v0.15`.
 
 ## Status
 
-- `Python 3.8` nightly support started on 16-Jul-2020 for both `conda` and `docker`
+- `Python 3.8` nightly support started on 16-Jul-2020 for both `conda` and
+`docker`
 
 ## Impact
 
-Users are encouraged to test nightly `conda` and `docker` builds and report any issues in their respective repos.
+Users are encouraged to test nightly `conda` and `docker` builds and report any
+issues in their respective repos.

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -26,17 +26,25 @@ notice_updated: 2020-08-26
 
 ## Overview
 
-With the EOL of `CUDA 10.0` announced in [RSN 2](/notices/rsn0002), development effort has been redirected to support `CUDA 11.0` in `v0.15`. However, due to our dependency on `CuPy` we will only be able to offer support in `v0.15`.
+With the EOL of `CUDA 10.0` announced in [RSN 2](/notices/rsn0002), development
+effort has been redirected to support `CUDA 11.0` in `v0.15`.
 
-`CuPy` has released `v7.8.0` with `CUDA 11.0` support. We have temporarily built a version of the `cupy` package in `rapidsai-nightly` [channel](https://anaconda.org/rapidsai-nightly/cupy/files?version=7.8.0) that has `CUDA 11.0` support. This is a stop-gap until `conda-forge` provides support for `CUDA 11.0`. Once support is on `conda-forge` we will remove our packages.
+`CuPy` has released `v7.8.0` with `CUDA 11.0` support. We have temporarily built
+a version of the `cupy` package in `rapidsai` [channel](https://anaconda.org/rapidsai/cupy/files?version=7.8.0)
+that has `CUDA 11.0` support. This is a stop-gap until `conda-forge` provides
+support for `CUDA 11.0`. Once support is on `conda-forge` we will remove our
+packages.
 
->**NOTE:** `v0.16` nightlies will continue to use our `v7.8.0` package for `CUDA 11.0` until an update is made on `conda-forge`
+>**NOTE:** `v0.16` nightlies will continue to use our `v7.8.0` package for
+`CUDA 11.0` until an update is made on `conda-forge`
 
 ## Status
 
 ### Updates
 
-- **21-Jul-2020** - Working on getting core `conda` dependencies for `CUDA 11.0` built to enable testing and bring up
+- **21-Jul-2020** - Working on getting core `conda` dependencies for
+`CUDA 11.0` built to enable testing and bring up
 - **12-Aug-2020** - CUDA 11 packages released in `rapidsai-nightly` channel
-- **26-Aug-2020** - CUDA 11 `condatoolkit` published in `anaconda` and `defaults` channels (also available on `nvidia` channel)
+- **26-Aug-2020** - CUDA 11 `condatoolkit` published in `anaconda` and
+`defaults` channels (also available on `nvidia` channel)
 - **26-Aug-2020** - Released v0.15 with CUDA 11 support

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -7,10 +7,10 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 4 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Beta Support for CUDA 11.0 in v0.15"
+title: "Support for CUDA 11.0 in v0.15"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,19 +21,22 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-13
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2020-07-21
+notice_updated: 2020-08-26
 ---
 
 ## Overview
 
-With the EOL of `CUDA 10.0` announced in [RSN 2](/notices/rsn0002), development effort has been redirected to support `CUDA 11.0` in `v0.15`. However, due to our dependency on `CuPy` we will only be able to offer ***beta*** support in `v0.15`.
+With the EOL of `CUDA 10.0` announced in [RSN 2](/notices/rsn0002), development effort has been redirected to support `CUDA 11.0` in `v0.15`. However, due to our dependency on `CuPy` we will only be able to offer support in `v0.15`.
 
-`CuPy` is [targeting](https://github.com/cupy/cupy/issues/3627) a `RC1` in late August and a full release of `CuPy v8.0.0` with `CUDA 11.0` support in September. Both the stable release and `RC1` are past our [release date]({% link maintainers/maintainers.md %}) for `v0.15`. Our current plan is to ship with a RAPIDS supplied nightly build of `CuPy` for `CUDA 11.0`.
+`CuPy` has released `v7.8.0` with `CUDA 11.0` support. We have temporarily built a version of the `cupy` package in `rapidsai-nightly` [channel](https://anaconda.org/rapidsai-nightly/cupy/files?version=7.8.0) that has `CUDA 11.0` support. This is a stop-gap until `conda-forge` provides support for `CUDA 11.0`. Once support is on `conda-forge` we will remove our packages.
 
->**NOTE:** `v0.16` nightlies will switch to the `RC1` and stable release when available.
+>**NOTE:** `v0.16` nightlies will continue to use our `v7.8.0` package for `CUDA 11.0` until an update is made on `conda-forge`
 
 ## Status
 
 ### Updates
 
 - **21-Jul-2020** - Working on getting core `conda` dependencies for `CUDA 11.0` built to enable testing and bring up
+- **12-Aug-2020** - CUDA 11 packages released in `rapidsai-nightly` channel
+- **26-Aug-2020** - CUDA 11 `condatoolkit` published in `anaconda` and `defaults` channels (also available on `nvidia` channel)
+- **26-Aug-2020** - Released v0.15 with CUDA 11 support

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -31,9 +31,10 @@ effort has been redirected to support `CUDA 11.0` in `v0.15`.
 
 `CuPy` has released `v7.8.0` with `CUDA 11.0` support. We have temporarily built
 a version of the `cupy` package in `rapidsai` [channel](https://anaconda.org/rapidsai/cupy/files?version=7.8.0)
-that has `CUDA 11.0` support. This is a stop-gap until `conda-forge` provides
-support for `CUDA 11.0`. Once support is on `conda-forge` we will remove our
-packages.
+that has `CUDA 11.0` support. In addition we have temporarily built `faiss`,
+`faiss-gpu`, `libfaiss` to support `CUDA 11.0` in the `rapidsai` [channel](https://anaconda.org/rapidsai/faiss/files?version=7.8.0).
+These packages are a stop-gap until `conda-forge` provides support for
+`CUDA 11.0`. Once packages are up on `conda-forge` we will remove our packages.
 
 >**NOTE:** `v0.16` nightlies will continue to use our `v7.8.0` package for
 `CUDA 11.0` until an update is made on `conda-forge`

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -7,8 +7,8 @@ layout:
   <channel>
     <title>{{ site.title | xml_escape }} - Notices</title>
     <description>Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.</description>
-    <link>{% link notices/notices.md %}</link>
-    <atom:link href="{% link notices/feed.xml %}" rel="self" type="application/rss+xml"/>
+    <link>{{ "/notices" | absolute_url }}</link>
+    <atom:link href="{{ 'notices/feed.xml' | absolute_url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>

--- a/notices/notices.md
+++ b/notices/notices.md
@@ -7,7 +7,7 @@ permalink: notices
 has_notice_pin_index: true # shows pinned notices at end
 ---
 
-# RAPIDS Notices <a href="{% link notices/feed.xml %}"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
+# RAPIDS Notices <a href="{{ 'notices/feed.xml' | absolute_url }}"><i class="fas fa-rss" style="font-size: 1rem"></i></a>
 
 Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.
 {: .fs-6 .fw-300 }


### PR DESCRIPTION
- Update pinning for outdated notices
- Add notices for the following:
  - `dask-xgboost` deprecation
  - Release changes for `clx` and `cuxfilter`
- Update notices:
  - RGN 1 - status of branch renaming
  - RGN 4 - updated with final status of CUDA 11 support

Preview URL for changes https://deploy-preview-115--docs-rapids-ai.netlify.app/notices