### PR TITLE
Update doc customization scripts

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,9 +1,8 @@
 <nav role="navigation" aria-label="Main navigation">
   <ul class="navigation-list">
     {% assign pages_list = site.html_pages | sort:"nav_order" %}
-    {% assign prev_page = "" %}
     {% for node in pages_list %}
-      {% unless node.nav_exclude and prev_page != node.title %}
+      {% unless node.nav_exclude %}
         {% if node.parent == nil %}
           <li class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
             {% if page.parent == node.title or page.grand_parent == node.title %}
@@ -42,7 +41,6 @@
           </li>
         {% endif %}
       {% endunless %}
-      {% assign prev_page = node.title %}
     {% endfor %}
   </ul>
 </nav>

--- a/_plugins/version_selector.rb
+++ b/_plugins/version_selector.rb
@@ -1,0 +1,108 @@
+module Jekyll
+  module VersionSelector
+
+
+    # Given a string input of "nightly", "stable", "legacy", or "doc",
+    # outputs a formatted string that looks like one of the following
+    # (where "0.xx" is a RAPIDS version):
+    #  - "nightly (0.xx)"
+    #  - "stable (0.xx)"
+    #  - "legacy (0.xx)"
+    # The "doc" input returns a string based on the document version
+    # that the filter was used on.
+    def version_selector(input)
+      releases = @context.registers[:site].data["releases"]
+      doc_version = get_doc_version(@context.registers[:page])
+
+      if input === "nightly"
+        version = releases["nightly"]["version"]
+        return "nightly (#{version})"
+      end
+
+      if input === "stable"
+        version = releases["stable"]["version"]
+        return "stable (#{version})"
+      end
+
+      if input === "legacy"
+        legacy_version = releases["legacy"]["version"]
+
+        if is_very_old(legacy_version, doc_version)
+          return "legacy (#{doc_version})"
+        end
+        return "legacy (#{legacy_version})"
+      end
+
+      if input === "doc"
+        ["nightly", "stable", "legacy"].each do |term|
+          term_version = releases[term]["version"]
+          if doc_version == term_version
+            return "#{term} (#{term_version})"
+          end
+        end
+
+        return "legacy (#{doc_version})"
+      end
+
+      raise "'version_selector' filter only supports the following inputs: 'nightly', 'stable', 'legacy', 'doc'"
+    end
+
+    # Uses the filter input and document version to determine whether
+    # or not an "active" class should be added to the menu item.
+    def add_active_class(input)
+      releases = @context.registers[:site].data["releases"]
+      doc_version = get_doc_version(@context.registers[:page])
+      active_class = "rapids-selector__menu-item--selected"
+      return_str = ""
+
+      if input === "stable"
+        if doc_version === releases["stable"]["version"]
+          return_str = active_class
+        end
+      end
+
+      if input === "nightly"
+        if doc_version === releases["nightly"]["version"]
+          return_str = active_class
+        end
+      end
+
+      if input === "legacy"
+        legacy_version = releases["legacy"]["version"]
+
+        if doc_version === releases["legacy"]["version"]
+          return_str = active_class
+        end
+        if is_very_old(legacy_version, doc_version)
+          return_str = active_class
+        end
+      end
+
+      return return_str
+
+    end
+
+    private
+
+    # Returns true if the doc_version is older than the current
+    # RAPIDS legacy version
+    def is_very_old(site_legacy, doc_version)
+      site_num = Integer(site_legacy[2..])
+      doc_num = Integer(doc_version[2..])
+      return doc_num < site_num
+    end
+
+    # Gets the RAPIDS version number (i.e. "0.15") from the page
+    # frontmatter or throws an error if it doesn't exist
+    def get_doc_version(page_obj)
+      doc_version = page_obj["doc_version"]
+
+      if doc_version
+        return doc_version
+      end
+      raise "Couldn't find RAPIDS version number in page frontmatter"
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::VersionSelector)

--- a/customization/README.md
+++ b/customization/README.md
@@ -48,17 +48,17 @@ An excerpt of the generated JSON file is shown below:
 ```json
 {
   "clx": {
-    "nightly": "/clx/en/nightly/api.html",
-    "stable": "/clx/en/stable/api.html",
+    "nightly": "/clx/nightly/api.html",
+    "stable": "/clx/stable/api.html",
     "legacy": null
   },
   "cuml": {
-    "nightly": "/cuml/en/nightly/api.html",
-    "stable": "/cuml/en/stable/api.html",
-    "legacy": "/cuml/en/legacy/api.html"
+    "nightly": "/cuml/nightly/api.html",
+    "stable": "/cuml/stable/api.html",
+    "legacy": "/cuml/legacy/api.html"
   },
   "cuxfilter": {
-    "nightly": "/cuxfilter/en/nightly",
+    "nightly": "/cuxfilter/nightly",
     "stable": null,
     "legacy": null
   },
@@ -88,7 +88,7 @@ An excerpt of the generated JSON file is shown below:
 > Before running the script, it is important that [update_symlinks.sh](/update_symlinks.sh) and [lib_map.sh](lib_map.sh) have been run.
 
 ```sh
-python customization/customize_docs.py ${ABS_PATH_TO_HTML_FILE} ${CURRENT_RAPIDS_VERSION}
+python customization/customize_docs.py ${ABS_PATH_TO_HTML_FILE}
 ```
 
 #### Helper Script
@@ -100,13 +100,12 @@ python customization/customize_docs.py ${ABS_PATH_TO_HTML_FILE} ${CURRENT_RAPIDS
 > **Note:** This script is intended to be run from the project's root.
 
 ```sh
-NIGHTLY_VERSION=13
 
-customization/customize_docs_in_folder.sh api/ ${NIGHTLY_VERSION}
+customization/customize_docs_in_folder.sh api/
 
 # or
 
-customization/customize_docs_in_folder.sh api/rmm ${NIGHTLY_VERSION}
+customization/customize_docs_in_folder.sh api/rmm
 ```
 
 ### TL;DR
@@ -120,6 +119,6 @@ update_symlinks.sh ${NIGHTLY_VERSION} # ensures symlink accuracy
 
 customization/lib_map.sh # generates a JSON file needed by customize_docs.py
 
-customization/customize_docs_in_folder.sh api/rmm ${NIGHTLY_VERSION}
+customization/customize_docs_in_folder.sh api/rmm
 
 ```

--- a/customization/customize_docs_in_folder.sh
+++ b/customization/customize_docs_in_folder.sh
@@ -33,7 +33,7 @@ for FILE in $(grep "${SPHINX_SEARCH_TERM}\|${DOXYGEN_SEARCH_TERM}" -rl \
   --exclude-dir=latest \
   --exclude-dir=legacy \
   ${FOLDER_TO_CUSTOMIZE} ); do
-  python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})
+  python3 ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})
   echo "" # line break for readability
 done
 IFS="$OIFS"

--- a/customization/customize_docs_in_folder.sh
+++ b/customization/customize_docs_in_folder.sh
@@ -5,16 +5,14 @@
 # root directory
 #
 # Usage:
-# customization/customize_docs_in_folder.sh api/ 13
+# customization/customize_docs_in_folder.sh api/
 #
 # Positional Arguments:
 #   1) FOLDER_TO_CUSTOMIZE: project root relative folder to customize (i.e. api/, api/rmm, etc.)
-#   2) CURRENT_NIGHTLY_VERSION: current RAPIDS nightly version (i.e. 13, 14, 15, etc.)
 #######################################
 set -e
 
 FOLDER_TO_CUSTOMIZE=$1
-CURRENT_NIGHTLY_VERSION=$2
 
 if [ ! -d "${FOLDER_TO_CUSTOMIZE}" ]; then
   echo "Couldn't find subfolder: ${FOLDER_TO_CUSTOMIZE}"
@@ -35,7 +33,7 @@ for FILE in $(grep "${SPHINX_SEARCH_TERM}\|${DOXYGEN_SEARCH_TERM}" -rl \
   --exclude-dir=latest \
   --exclude-dir=legacy \
   ${FOLDER_TO_CUSTOMIZE} ); do
-  python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE}) ${CURRENT_NIGHTLY_VERSION}
+  python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})
   echo "" # line break for readability
 done
 IFS="$OIFS"


### PR DESCRIPTION
This PR updates the documentation customization scripts to utilize Jekyll's templating engine for the dropdown selector so that older documentation files do not have to be re-processed during every release.

The changes include:

- Moving the logic for determining the dropdown text from the `customization/customize_doc.py` script into two new [Jekyll filters](https://jekyllrb.com/docs/plugins/filters/) located in `_plugins/version_selector.rb`
- Adding frontmatter to the docs so that it can be correctly interpreted by Jekyll's templating engine ([src](https://jekyllrb.com/docs/front-matter/)).



## Generated doc file changes

The snippets below show the resulting, relevant HTML snippets after these changes

**Before (hardcoded values)**:
```html
<!-- no frontmatter -->

<!-- other HTML... -->

<!-- version selector -->
<div class="rapids-selector__container rapids-selector--hidden">
  <div class="rapids-selector__selected">
    stable (0.15)
  </div>
  <div class="rapids-selector__menu">
    <a
      class="rapids-selector__menu-item"
      href="/api/clx/nightly/api.html"
      >nightly (0.16)</a
    >
    <a
      class="rapids-selector__menu-item rapids-selector__menu-item--selected"
      href="/api/clx/stable/api.html"
      >stable (0.15)</a
    >
    <a
      class="rapids-selector__menu-item"
      href="/api/clx/legacy/api.html"
      >legacy (0.14)</a
    >
  </div>
</div>
```

**After (uses Jekyll's templating)**:
```html
---
permalink: /:path/:basename
doc_version: '0.15'
nav_exclude: true
---

<!-- other HTML... -->

<!-- version selector -->
<div class="rapids-selector__container rapids-selector--hidden">
  <div class="rapids-selector__selected">
    {{ "doc" | version_selector }}
  </div>
  <div class="rapids-selector__menu">
    <a
      class="rapids-selector__menu-item {{ 'nightly' | add_active_class }}"
      href="/api/clx/nightly/api.html"
      >{{ "nightly" | version_selector }}</a
    >
    <a
      class="rapids-selector__menu-item {{ 'stable' | add_active_class }}"
      href="/api/clx/stable/api.html"
      >{{ "stable" | version_selector }}</a
    >
    <a
      class="rapids-selector__menu-item {{ 'legacy' | add_active_class }}"
      href="/api/clx/legacy/api.html"
      >{{ "legacy" | version_selector }}</a
    >
  </div>
</div>
```