### PR TITLE
DOC Add RGN 5 for RAPIDS/Colab support

### DIFF
--- a/_notices/rgn0005.md
+++ b/_notices/rgn0005.md
@@ -31,7 +31,7 @@ Python `3.6`. Google Colab will only support up to RAPIDS `0.14` until
 Colab support for Python `3.7+` is complete. Users may make use of BlazingSQL
 Notebooks at <http://app.blazingsql.com> for RAPIDS `0.15` support.
 
-**NOTE:** Refer to [RSN 2](notices/rsn0002) for more information about EOL support
+**NOTE:** Refer to [RSN 2](/notices/rsn0002) for more information about EOL support
 of Python `3.6` & CUDA `10.0`
 
 ## Status

--- a/_notices/rgn0005.md
+++ b/_notices/rgn0005.md
@@ -1,0 +1,45 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 5 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Google Colab RAPIDS support limited to RAPIDS 0.14"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Breaking Change
+notice_rapids_version: "v0.15"
+notice_created: 2020-09-11
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-09-15
+---
+
+## Overview
+
+RAPIDS `0.15` requires Python `3.7+`; Google Colab is currently limited to
+Python `3.6`. Google Colab will only support up to RAPIDS `0.14` until
+Colab support for Python `3.7+` is complete. Users may make use of BlazingSQL
+Notebooks at <http://app.blazingsql.com> for RAPIDS `0.15` support.
+
+**NOTE:** Refer to [RSN 2](notices/rsn0002) for more information about EOL support
+of Python `3.6` & CUDA `10.0`
+
+## Status
+
+- **11-Sep-2020** - Warnings have been added to links to Colab on RAPIDS
+website; links to BlazingSQL Notebooks have been added.
+
+## Impact
+
+Google Colab support for RAPIDS is currently limited to RAPIDS version `0.14`.
+Users can use BlazingSQL Notebooks for RAPIDS `0.15`.


### PR DESCRIPTION
Colab support only supports Python 3.6 which was dropped in RAPIDS `0.15`. This notice is classified as `RGN` as it is a breaking change and there are existing `RSN` notices that are linked in this article.

Preview of notice RGN 5 - https://deploy-preview-125--docs-rapids-ai.netlify.app/notices/rgn0005/