### PR TITLE
DOC Add RGN6 notice for v0.16 release extension

### DIFF
--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 1 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Stable/Release Branch Renaming to 'main' in v0.15"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0004.md
+++ b/_notices/rgn0004.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 4 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "v0.15 Release Delay for 'cuxfilter'"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0006.md
+++ b/_notices/rgn0006.md
@@ -1,0 +1,34 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 6 # should match notice number
+notice_pin: false # set to true to pin to notice page
+title: "v0.16 Release Extension"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.16"
+notice_created: 2020-10-07
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-10-07
+---
+
+## Overview
+
+The RAPIDS `v0.16` release date has been extended for 1 week to 2020-10-21
+
+## Impact
+
+See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+`v0.16`

--- a/_notices/rgn0006.md
+++ b/_notices/rgn0006.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 6 # should match notice number
-notice_pin: false # set to true to pin to notice page
+notice_pin: true # set to true to pin to notice page
 title: "v0.16 Release Extension"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0003.md
+++ b/_notices/rsn0003.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 3 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Support for Python 3.8 in v0.15"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 4 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Support for CUDA 11.0 in v0.15"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -30,9 +30,9 @@ Operations
 Phase | Start | End | Duration
 -- | -- | -- | --
 Development | Thu, Aug 6th | Wed, Sept 30th | 39 days
-Burn Down | Thu, Oct 1st | Wed, Oct 7th | 5 days
-Code Freeze/Testing | Thu, Oct 8th | Tue, Oct 13th | 4 days
-Release | Wed, Oct 14th | Wed, Oct 14th | 1 day
+Burn Down | Thu, Oct 1st | Wed, Oct 14th | 10 days
+Code Freeze/Testing | Thu, Oct 15th | Tue, Oct 20th | 4 days
+Release | Wed, Oct 21th | Wed, Oct 21th | 1 day
 
 ## _PROPOSED_ Release v0.17 Schedule
 


### PR DESCRIPTION
- [x] Unpin old notices - current [notices](https://deploy-preview-131--docs-rapids-ai.netlify.app/notices/)
- [x] Add v0.16 release extension notice [RGN6](https://deploy-preview-131--docs-rapids-ai.netlify.app/notices/rgn0006/)
- [x] Update v0.16 release [schedule](https://deploy-preview-131--docs-rapids-ai.netlify.app/maintainers/)

Preview links will be added above once generated