### PR TITLE
Add rmm python entry

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -138,3 +138,14 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
+  rmm:
+    name: RMM
+    path: rmm
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
+    ghlink: https://github.com/rapidsai/rmm
+    cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1


### PR DESCRIPTION
This PR adds an `rmm` entry so that the RMM Python docs appear on the `/api` page.