### PR TITLE
DOC Add RGN7 for docker image updates with Blazing

### DIFF
--- a/_notices/rgn0002.md
+++ b/_notices/rgn0002.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 2 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "v0.15 No CUDA 11 Release for 'clx'"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0006.md
+++ b/_notices/rgn0006.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 6 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "v0.16 Release Extension"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0007.md
+++ b/_notices/rgn0007.md
@@ -1,0 +1,53 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 7 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "RAPIDS docker image changes in v0.17"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Docker Image Change
+notice_rapids_version: "v0.17"
+notice_created: 2020-12-10
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-12-10
+---
+
+## Overview
+
+The RAPIDS `v0.17` docker images have been updated to include [BlazingSQL](https://blazingsql.com/)
+by default using existing images and tags. New images with the root name of
+`rapidsai-core` have been created that only contain RAPIDS libraries.
+
+## Status
+
+- **10-Dec-2020** - Changes have been pushed with the `v0.17` release
+
+## Impact
+
+Refer to the tables below for a comparison of `v0.16` & `v0.17` behavior and options
+
+### Stable (Release) Images
+
+Docker Repo | Image Type | Previous Behavior | v0.17+ Behavior | Options
+--- | --- | --- | --- | ---
+`rapidsai/rapidsai` | `base` & `runtime` **conda-based** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core` for RAPIDS ***ONLY*** images
+`rapidsai/rapidsai-dev` | `devel` **from-source** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core-dev` for RAPIDS ***ONLY*** images
+
+### Nighlty Images
+
+Docker Repo | Image Type | Previous Behavior | v0.17+ Behavior | Options
+--- | --- | --- | --- | ---
+`rapidsai/rapidsai-nightly` | `base` & `runtime` **conda-based** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core-nightly` for RAPIDS ***ONLY*** images
+`rapidsai/rapidsai-dev-nightly` | `devel` **from-source** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core-dev-nightly` for RAPIDS ***ONLY*** images

--- a/_notices/rgn0007.md
+++ b/_notices/rgn0007.md
@@ -45,7 +45,7 @@ Docker Repo | Image Type | Previous Behavior | v0.17+ Behavior | Options
 `rapidsai/rapidsai` | `base` & `runtime` **conda-based** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core` for RAPIDS ***ONLY*** images
 `rapidsai/rapidsai-dev` | `devel` **from-source** images | ***ONLY*** RAPIDS | RAPIDS ***AND*** BlazingSQL | Switch to `rapidsai/rapidsai-core-dev` for RAPIDS ***ONLY*** images
 
-### Nighlty Images
+### Nightly Images
 
 Docker Repo | Image Type | Previous Behavior | v0.17+ Behavior | Options
 --- | --- | --- | --- | ---


### PR DESCRIPTION
Notice for the new docker image changes that include Blazing as well as a guide on which docker repos to use to revert to the previous behavior