### PR TITLE
Update mathjax CDN URL to prevent mixed content warnings

### DIFF
--- a/api/libcuml/0.16/Timer_8h.html
+++ b/api/libcuml/0.16/Timer_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/Timer_8h_source.html
+++ b/api/libcuml/0.16/Timer_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/add_8cuh.html
+++ b/api/libcuml/0.16/add_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/adjgraph_2pack_8h.html
+++ b/api/libcuml/0.16/adjgraph_2pack_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/adjgraph_2pack_8h_source.html
+++ b/api/libcuml/0.16/adjgraph_2pack_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/adjustedRandIndex_8cuh.html
+++ b/api/libcuml/0.16/adjustedRandIndex_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/algo1_8cuh.html
+++ b/api/libcuml/0.16/algo1_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/algo__helper_8h.html
+++ b/api/libcuml/0.16/algo__helper_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/algo__helper_8h_source.html
+++ b/api/libcuml/0.16/algo__helper_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/allocatorAdapter_8hpp.html
+++ b/api/libcuml/0.16/allocatorAdapter_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/allocatorAdapter_8hpp_source.html
+++ b/api/libcuml/0.16/allocatorAdapter_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/annotated.html
+++ b/api/libcuml/0.16/annotated.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/arima__common_8h.html
+++ b/api/libcuml/0.16/arima__common_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/arima__common_8h_source.html
+++ b/api/libcuml/0.16/arima__common_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/arima__helpers_8cuh.html
+++ b/api/libcuml/0.16/arima__helpers_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/auto__arima_8cu.html
+++ b/api/libcuml/0.16/auto__arima_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/auto__arima_8cuh.html
+++ b/api/libcuml/0.16/auto__arima_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/auto__arima_8h.html
+++ b/api/libcuml/0.16/auto__arima_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/auto__arima_8h_source.html
+++ b/api/libcuml/0.16/auto__arima_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/barnes__hut_8cuh.html
+++ b/api/libcuml/0.16/barnes__hut_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched_2csr_8cuh.html
+++ b/api/libcuml/0.16/batched_2csr_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__arima_8cu.html
+++ b/api/libcuml/0.16/batched__arima_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__arima_8hpp.html
+++ b/api/libcuml/0.16/batched__arima_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__arima_8hpp_source.html
+++ b/api/libcuml/0.16/batched__arima_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__kalman_8cu.html
+++ b/api/libcuml/0.16/batched__kalman_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__kalman_8hpp.html
+++ b/api/libcuml/0.16/batched__kalman_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/batched__kalman_8hpp_source.html
+++ b/api/libcuml/0.16/batched__kalman_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/bh_8cu.html
+++ b/api/libcuml/0.16/bh_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/bh__kernels_8cuh.html
+++ b/api/libcuml/0.16/bh__kernels_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/binary__op_8cuh.html
+++ b/api/libcuml/0.16/binary__op_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/builder_8cuh.html
+++ b/api/libcuml/0.16/builder_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/builder__base_8cuh.html
+++ b/api/libcuml/0.16/builder__base_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cache_8cuh.html
+++ b/api/libcuml/0.16/cache_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cache__util_8cuh.html
+++ b/api/libcuml/0.16/cache__util_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/callbackSink_8hpp.html
+++ b/api/libcuml/0.16/callbackSink_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/callbackSink_8hpp_source.html
+++ b/api/libcuml/0.16/callbackSink_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cd_8cuh.html
+++ b/api/libcuml/0.16/cd_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cd__mg_8cu.html
+++ b/api/libcuml/0.16/cd__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cd__mg_8hpp.html
+++ b/api/libcuml/0.16/cd__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cd__mg_8hpp_source.html
+++ b/api/libcuml/0.16/cd__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classMLCommon_1_1TimerCPU-members.html
+++ b/api/libcuml/0.16/classMLCommon_1_1TimerCPU-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classMLCommon_1_1TimerCPU.html
+++ b/api/libcuml/0.16/classMLCommon_1_1TimerCPU.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeBase-members.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeBase-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeBase.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeBase.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeClassifier-members.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeClassifier-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeClassifier.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeClassifier.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeRegressor-members.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeRegressor-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeRegressor.html
+++ b/api/libcuml/0.16/classML_1_1DecisionTree_1_1DecisionTreeRegressor.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1HandleMap-members.html
+++ b/api/libcuml/0.16/classML_1_1HandleMap-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1HandleMap.html
+++ b/api/libcuml/0.16/classML_1_1HandleMap.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Internals_1_1Callback-members.html
+++ b/api/libcuml/0.16/classML_1_1Internals_1_1Callback-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Internals_1_1Callback.html
+++ b/api/libcuml/0.16/classML_1_1Internals_1_1Callback.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Internals_1_1GraphBasedDimRedCallback-members.html
+++ b/api/libcuml/0.16/classML_1_1Internals_1_1GraphBasedDimRedCallback-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Internals_1_1GraphBasedDimRedCallback.html
+++ b/api/libcuml/0.16/classML_1_1Internals_1_1GraphBasedDimRedCallback.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Logger-members.html
+++ b/api/libcuml/0.16/classML_1_1Logger-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Logger.html
+++ b/api/libcuml/0.16/classML_1_1Logger.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1PatternSetter-members.html
+++ b/api/libcuml/0.16/classML_1_1PatternSetter-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1PatternSetter.html
+++ b/api/libcuml/0.16/classML_1_1PatternSetter.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1SVM_1_1SVC-members.html
+++ b/api/libcuml/0.16/classML_1_1SVM_1_1SVC-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1SVM_1_1SVC.html
+++ b/api/libcuml/0.16/classML_1_1SVM_1_1SVC.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Tensor-members.html
+++ b/api/libcuml/0.16/classML_1_1Tensor-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1Tensor.html
+++ b/api/libcuml/0.16/classML_1_1Tensor.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1UMAPParams-members.html
+++ b/api/libcuml/0.16/classML_1_1UMAPParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1UMAPParams.html
+++ b/api/libcuml/0.16/classML_1_1UMAPParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1UMAP__API-members.html
+++ b/api/libcuml/0.16/classML_1_1UMAP__API-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1UMAP__API.html
+++ b/api/libcuml/0.16/classML_1_1UMAP__API.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1cachingDeviceAllocator-members.html
+++ b/api/libcuml/0.16/classML_1_1cachingDeviceAllocator-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1cachingDeviceAllocator.html
+++ b/api/libcuml/0.16/classML_1_1cachingDeviceAllocator.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1params-members.html
+++ b/api/libcuml/0.16/classML_1_1params-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1params.html
+++ b/api/libcuml/0.16/classML_1_1params.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsPCATemplate-members.html
+++ b/api/libcuml/0.16/classML_1_1paramsPCATemplate-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsPCATemplate.html
+++ b/api/libcuml/0.16/classML_1_1paramsPCATemplate.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsSolver-members.html
+++ b/api/libcuml/0.16/classML_1_1paramsSolver-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsSolver.html
+++ b/api/libcuml/0.16/classML_1_1paramsSolver.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsTSVDTemplate-members.html
+++ b/api/libcuml/0.16/classML_1_1paramsTSVDTemplate-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1paramsTSVDTemplate.html
+++ b/api/libcuml/0.16/classML_1_1paramsTSVDTemplate.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rf-members.html
+++ b/api/libcuml/0.16/classML_1_1rf-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rf.html
+++ b/api/libcuml/0.16/classML_1_1rf.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rfClassifier-members.html
+++ b/api/libcuml/0.16/classML_1_1rfClassifier-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rfClassifier.html
+++ b/api/libcuml/0.16/classML_1_1rfClassifier.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rfRegressor-members.html
+++ b/api/libcuml/0.16/classML_1_1rfRegressor-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1rfRegressor.html
+++ b/api/libcuml/0.16/classML_1_1rfRegressor.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1stdAllocatorAdapter-members.html
+++ b/api/libcuml/0.16/classML_1_1stdAllocatorAdapter-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1stdAllocatorAdapter.html
+++ b/api/libcuml/0.16/classML_1_1stdAllocatorAdapter.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1thrustAllocatorAdapter-members.html
+++ b/api/libcuml/0.16/classML_1_1thrustAllocatorAdapter-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classML_1_1thrustAllocatorAdapter.html
+++ b/api/libcuml/0.16/classML_1_1thrustAllocatorAdapter.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classes.html
+++ b/api/libcuml/0.16/classes.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classlabels_8cuh.html
+++ b/api/libcuml/0.16/classlabels_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classspdlog_1_1sinks_1_1CallbackSink-members.html
+++ b/api/libcuml/0.16/classspdlog_1_1sinks_1_1CallbackSink-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/classspdlog_1_1sinks_1_1CallbackSink.html
+++ b/api/libcuml/0.16/classspdlog_1_1sinks_1_1CallbackSink.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/coalesced__reduction_8cuh.html
+++ b/api/libcuml/0.16/coalesced__reduction_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/common__helper_8cuh.html
+++ b/api/libcuml/0.16/common__helper_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/common__kernel_8cuh.html
+++ b/api/libcuml/0.16/common__kernel_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/completenessScore_8cuh.html
+++ b/api/libcuml/0.16/completenessScore_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/contingencyMatrix_8cuh.html
+++ b/api/libcuml/0.16/contingencyMatrix_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/contractions_8cuh.html
+++ b/api/libcuml/0.16/contractions_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/coo_8cuh.html
+++ b/api/libcuml/0.16/coo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cosine_8cuh.html
+++ b/api/libcuml/0.16/cosine_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cov_8cuh.html
+++ b/api/libcuml/0.16/cov_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/csr_8cuh.html
+++ b/api/libcuml/0.16/csr_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cubAllocatorAdapter_8hpp.html
+++ b/api/libcuml/0.16/cubAllocatorAdapter_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cubAllocatorAdapter_8hpp_source.html
+++ b/api/libcuml/0.16/cubAllocatorAdapter_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cub__wrappers_8cuh.html
+++ b/api/libcuml/0.16/cub__wrappers_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuda__utils_8cuh.html
+++ b/api/libcuml/0.16/cuda__utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cudart__utils_8h.html
+++ b/api/libcuml/0.16/cudart__utils_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cudart__utils_8h_source.html
+++ b/api/libcuml/0.16/cudart__utils_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cumlHandle_8cpp.html
+++ b/api/libcuml/0.16/cumlHandle_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cumlHandle_8hpp.html
+++ b/api/libcuml/0.16/cumlHandle_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cumlHandle_8hpp_source.html
+++ b/api/libcuml/0.16/cumlHandle_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml_8hpp.html
+++ b/api/libcuml/0.16/cuml_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml_8hpp_source.html
+++ b/api/libcuml/0.16/cuml_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml__allocator_8hpp.html
+++ b/api/libcuml/0.16/cuml__allocator_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml__allocator_8hpp_source.html
+++ b/api/libcuml/0.16/cuml__allocator_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml__api_8cpp.html
+++ b/api/libcuml/0.16/cuml__api_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml__api_8h.html
+++ b/api/libcuml/0.16/cuml__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cuml__api_8h_source.html
+++ b/api/libcuml/0.16/cuml__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/curand__wrappers_8h.html
+++ b/api/libcuml/0.16/curand__wrappers_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/curand__wrappers_8h_source.html
+++ b/api/libcuml/0.16/curand__wrappers_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/custom__accum_8h.html
+++ b/api/libcuml/0.16/custom__accum_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/custom__accum_8h_source.html
+++ b/api/libcuml/0.16/custom__accum_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/cutlass__wrappers_8cuh.html
+++ b/api/libcuml/0.16/cutlass__wrappers_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2adjgraph_2algo_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2adjgraph_2algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2adjgraph_2naive_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2adjgraph_2naive_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2adjgraph_2runner_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2adjgraph_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2common_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2common_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2runner_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2vertexdeg_2algo_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2vertexdeg_2algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2vertexdeg_2naive_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2vertexdeg_2naive_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_2vertexdeg_2runner_8cuh.html
+++ b/api/libcuml/0.16/dbscan_2vertexdeg_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_8cu.html
+++ b/api/libcuml/0.16/dbscan_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_8cuh.html
+++ b/api/libcuml/0.16/dbscan_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_8hpp.html
+++ b/api/libcuml/0.16/dbscan_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan_8hpp_source.html
+++ b/api/libcuml/0.16/dbscan_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan__api_8cpp.html
+++ b/api/libcuml/0.16/dbscan__api_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan__api_8h.html
+++ b/api/libcuml/0.16/dbscan__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dbscan__api_8h_source.html
+++ b/api/libcuml/0.16/dbscan__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree_8cu.html
+++ b/api/libcuml/0.16/decisiontree_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree_8hpp.html
+++ b/api/libcuml/0.16/decisiontree_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree_8hpp_source.html
+++ b/api/libcuml/0.16/decisiontree_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree__impl_8cuh.html
+++ b/api/libcuml/0.16/decisiontree__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree__impl_8h.html
+++ b/api/libcuml/0.16/decisiontree__impl_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decisiontree__impl_8h_source.html
+++ b/api/libcuml/0.16/decisiontree__impl_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decomposition_2params_8hpp.html
+++ b/api/libcuml/0.16/decomposition_2params_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decomposition_2params_8hpp_source.html
+++ b/api/libcuml/0.16/decomposition_2params_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/decoupled__lookback_8cuh.html
+++ b/api/libcuml/0.16/decoupled__lookback_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/device__buffer_8hpp.html
+++ b/api/libcuml/0.16/device__buffer_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/device__buffer_8hpp_source.html
+++ b/api/libcuml/0.16/device__buffer_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/device__loads__stores_8cuh.html
+++ b/api/libcuml/0.16/device__loads__stores_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/device__utils_8cuh.html
+++ b/api/libcuml/0.16/device__utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/digits_8h.html
+++ b/api/libcuml/0.16/digits_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/digits_8h_source.html
+++ b/api/libcuml/0.16/digits_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000000_000021.html
+++ b/api/libcuml/0.16/dir_000000_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000000_000041.html
+++ b/api/libcuml/0.16/dir_000000_000041.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000000_000054.html
+++ b/api/libcuml/0.16/dir_000000_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000000_000056.html
+++ b/api/libcuml/0.16/dir_000000_000056.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000001_000019.html
+++ b/api/libcuml/0.16/dir_000001_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000001_000054.html
+++ b/api/libcuml/0.16/dir_000001_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000002_000003.html
+++ b/api/libcuml/0.16/dir_000002_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000004_000018.html
+++ b/api/libcuml/0.16/dir_000004_000018.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000005_000019.html
+++ b/api/libcuml/0.16/dir_000005_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000006_000010.html
+++ b/api/libcuml/0.16/dir_000006_000010.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000006_000019.html
+++ b/api/libcuml/0.16/dir_000006_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000008_000003.html
+++ b/api/libcuml/0.16/dir_000008_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000008_000017.html
+++ b/api/libcuml/0.16/dir_000008_000017.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000009_000008.html
+++ b/api/libcuml/0.16/dir_000009_000008.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000010_000003.html
+++ b/api/libcuml/0.16/dir_000010_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000010_000019.html
+++ b/api/libcuml/0.16/dir_000010_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000011_000003.html
+++ b/api/libcuml/0.16/dir_000011_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000011_000014.html
+++ b/api/libcuml/0.16/dir_000011_000014.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000011_000019.html
+++ b/api/libcuml/0.16/dir_000011_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000013_000007.html
+++ b/api/libcuml/0.16/dir_000013_000007.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000014_000003.html
+++ b/api/libcuml/0.16/dir_000014_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000014_000019.html
+++ b/api/libcuml/0.16/dir_000014_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000015_000019.html
+++ b/api/libcuml/0.16/dir_000015_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000015_000054.html
+++ b/api/libcuml/0.16/dir_000015_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000016_000003.html
+++ b/api/libcuml/0.16/dir_000016_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000016_000012.html
+++ b/api/libcuml/0.16/dir_000016_000012.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000016_000019.html
+++ b/api/libcuml/0.16/dir_000016_000019.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000018_000054.html
+++ b/api/libcuml/0.16/dir_000018_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000001.html
+++ b/api/libcuml/0.16/dir_000019_000001.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000002.html
+++ b/api/libcuml/0.16/dir_000019_000002.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000003.html
+++ b/api/libcuml/0.16/dir_000019_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000005.html
+++ b/api/libcuml/0.16/dir_000019_000005.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000006.html
+++ b/api/libcuml/0.16/dir_000019_000006.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000007.html
+++ b/api/libcuml/0.16/dir_000019_000007.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000008.html
+++ b/api/libcuml/0.16/dir_000019_000008.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000010.html
+++ b/api/libcuml/0.16/dir_000019_000010.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000012.html
+++ b/api/libcuml/0.16/dir_000019_000012.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000016.html
+++ b/api/libcuml/0.16/dir_000019_000016.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000017.html
+++ b/api/libcuml/0.16/dir_000019_000017.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000018.html
+++ b/api/libcuml/0.16/dir_000019_000018.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000019_000054.html
+++ b/api/libcuml/0.16/dir_000019_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000021_000000.html
+++ b/api/libcuml/0.16/dir_000021_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000021_000054.html
+++ b/api/libcuml/0.16/dir_000021_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000023_000000.html
+++ b/api/libcuml/0.16/dir_000023_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000023_000021.html
+++ b/api/libcuml/0.16/dir_000023_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000030_000000.html
+++ b/api/libcuml/0.16/dir_000030_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000030_000021.html
+++ b/api/libcuml/0.16/dir_000030_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000034_000000.html
+++ b/api/libcuml/0.16/dir_000034_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000034_000021.html
+++ b/api/libcuml/0.16/dir_000034_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000034_000054.html
+++ b/api/libcuml/0.16/dir_000034_000054.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000038_000000.html
+++ b/api/libcuml/0.16/dir_000038_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000038_000021.html
+++ b/api/libcuml/0.16/dir_000038_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000043_000000.html
+++ b/api/libcuml/0.16/dir_000043_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000046_000000.html
+++ b/api/libcuml/0.16/dir_000046_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000046_000034.html
+++ b/api/libcuml/0.16/dir_000046_000034.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000047_000000.html
+++ b/api/libcuml/0.16/dir_000047_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000049_000000.html
+++ b/api/libcuml/0.16/dir_000049_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000049_000021.html
+++ b/api/libcuml/0.16/dir_000049_000021.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000053_000000.html
+++ b/api/libcuml/0.16/dir_000053_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000054_000000.html
+++ b/api/libcuml/0.16/dir_000054_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000054_000001.html
+++ b/api/libcuml/0.16/dir_000054_000001.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000054_000003.html
+++ b/api/libcuml/0.16/dir_000054_000003.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_000056_000000.html
+++ b/api/libcuml/0.16/dir_000056_000000.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_00a995127770029ed96e17f9d18e9184.html
+++ b/api/libcuml/0.16/dir_00a995127770029ed96e17f9d18e9184.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_00c44c28032509675bd9d84b2d5843bc.html
+++ b/api/libcuml/0.16/dir_00c44c28032509675bd9d84b2d5843bc.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_041db6ad6a3d44280e40e5af409429cb.html
+++ b/api/libcuml/0.16/dir_041db6ad6a3d44280e40e5af409429cb.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_048019251159ab7afd4693d0f64b64f5.html
+++ b/api/libcuml/0.16/dir_048019251159ab7afd4693d0f64b64f5.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_05f972c399a235c47cfbaebf0f9d9fa2.html
+++ b/api/libcuml/0.16/dir_05f972c399a235c47cfbaebf0f9d9fa2.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_092777e7401408c052105279483e139a.html
+++ b/api/libcuml/0.16/dir_092777e7401408c052105279483e139a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_098aa72cad05701c051c004dab3b9549.html
+++ b/api/libcuml/0.16/dir_098aa72cad05701c051c004dab3b9549.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_09a06ef37cb3a33cfd06304503209832.html
+++ b/api/libcuml/0.16/dir_09a06ef37cb3a33cfd06304503209832.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_0c85c474c3213d4b8adbda8456546ea2.html
+++ b/api/libcuml/0.16/dir_0c85c474c3213d4b8adbda8456546ea2.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_0e11b2f9fffece538d1ab4e7b83f104b.html
+++ b/api/libcuml/0.16/dir_0e11b2f9fffece538d1ab4e7b83f104b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_19a4f524c2a3a9283b32763e6dbec959.html
+++ b/api/libcuml/0.16/dir_19a4f524c2a3a9283b32763e6dbec959.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_1e21591ead76704592928194773eaf60.html
+++ b/api/libcuml/0.16/dir_1e21591ead76704592928194773eaf60.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_1e29f0821a040563cd2d3dd7fd074a1b.html
+++ b/api/libcuml/0.16/dir_1e29f0821a040563cd2d3dd7fd074a1b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_246fa9bc5aa8b48d31db3ff17c6b6b0b.html
+++ b/api/libcuml/0.16/dir_246fa9bc5aa8b48d31db3ff17c6b6b0b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_25d2bb9a92ec0641a96a85b989bb9de4.html
+++ b/api/libcuml/0.16/dir_25d2bb9a92ec0641a96a85b989bb9de4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_26cb2df34f93163b16318e77e8e197b9.html
+++ b/api/libcuml/0.16/dir_26cb2df34f93163b16318e77e8e197b9.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_2898d9a80bf676e8003251eb0521386b.html
+++ b/api/libcuml/0.16/dir_2898d9a80bf676e8003251eb0521386b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_2ccca09598448983cc6f079a986539fb.html
+++ b/api/libcuml/0.16/dir_2ccca09598448983cc6f079a986539fb.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_30986ac8db47f0f200ad2904ad24dc66.html
+++ b/api/libcuml/0.16/dir_30986ac8db47f0f200ad2904ad24dc66.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_315b94e79867468f41545f9cefee499a.html
+++ b/api/libcuml/0.16/dir_315b94e79867468f41545f9cefee499a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_3638ea41b6298b97a09078d72c9fdc35.html
+++ b/api/libcuml/0.16/dir_3638ea41b6298b97a09078d72c9fdc35.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_3efff77420e5f0b2760059284d347153.html
+++ b/api/libcuml/0.16/dir_3efff77420e5f0b2760059284d347153.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_41d754b4077f3e9c8b76d7fdbfc3fde5.html
+++ b/api/libcuml/0.16/dir_41d754b4077f3e9c8b76d7fdbfc3fde5.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_44bbbf541b3447dce93e7cc8bcaaec92.html
+++ b/api/libcuml/0.16/dir_44bbbf541b3447dce93e7cc8bcaaec92.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_47db1cc48bcf3b3a42db9b926211e785.html
+++ b/api/libcuml/0.16/dir_47db1cc48bcf3b3a42db9b926211e785.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_49baa179856d8ba2b65bc483832afca2.html
+++ b/api/libcuml/0.16/dir_49baa179856d8ba2b65bc483832afca2.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_4be551ec9d3d982cab6f26a21441fd23.html
+++ b/api/libcuml/0.16/dir_4be551ec9d3d982cab6f26a21441fd23.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_4f219ae4363ca18f4ed18ab4fcb05b3e.html
+++ b/api/libcuml/0.16/dir_4f219ae4363ca18f4ed18ab4fcb05b3e.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_507177280260de4148fd249df7f35005.html
+++ b/api/libcuml/0.16/dir_507177280260de4148fd249df7f35005.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_58ffac891b0321d47012702c0b121f93.html
+++ b/api/libcuml/0.16/dir_58ffac891b0321d47012702c0b121f93.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_5c4149548af917b30c5aa6f708b0cee4.html
+++ b/api/libcuml/0.16/dir_5c4149548af917b30c5aa6f708b0cee4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_6282a1285563e1f8c8eb08bd8a4509f1.html
+++ b/api/libcuml/0.16/dir_6282a1285563e1f8c8eb08bd8a4509f1.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_680db853ce5a9cdcc8017fb3f21d8234.html
+++ b/api/libcuml/0.16/dir_680db853ce5a9cdcc8017fb3f21d8234.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_68267d1309a1af8e8297ef4c3efbcdba.html
+++ b/api/libcuml/0.16/dir_68267d1309a1af8e8297ef4c3efbcdba.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_6882366995736f38320160ad037d9c87.html
+++ b/api/libcuml/0.16/dir_6882366995736f38320160ad037d9c87.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_6eeceb7c60de3809286d0ebe2cf22f00.html
+++ b/api/libcuml/0.16/dir_6eeceb7c60de3809286d0ebe2cf22f00.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_7aee1a94c4ed8c444b03377386499a38.html
+++ b/api/libcuml/0.16/dir_7aee1a94c4ed8c444b03377386499a38.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_7cc551ff80b6a9e4ba5d985b827a1244.html
+++ b/api/libcuml/0.16/dir_7cc551ff80b6a9e4ba5d985b827a1244.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_7eea80a3d75f1ffbdbd383e7c50ba6a3.html
+++ b/api/libcuml/0.16/dir_7eea80a3d75f1ffbdbd383e7c50ba6a3.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_807cf4a88d3247f663e0fdb1eb7f85d2.html
+++ b/api/libcuml/0.16/dir_807cf4a88d3247f663e0fdb1eb7f85d2.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_8174711b32a9f0f903f34b82a7d01b9f.html
+++ b/api/libcuml/0.16/dir_8174711b32a9f0f903f34b82a7d01b9f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_81ccca730fadb3a50e1783aa07e6870f.html
+++ b/api/libcuml/0.16/dir_81ccca730fadb3a50e1783aa07e6870f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_82538c42ebf850b717c9a41482505d45.html
+++ b/api/libcuml/0.16/dir_82538c42ebf850b717c9a41482505d45.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_825cc03e83bcdede75bbfdbabb0c3eb0.html
+++ b/api/libcuml/0.16/dir_825cc03e83bcdede75bbfdbabb0c3eb0.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_873636d466a3d7dd1b36738f773b72c4.html
+++ b/api/libcuml/0.16/dir_873636d466a3d7dd1b36738f773b72c4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_87b68a543ed72e8ab95d2fdc9bc93f7b.html
+++ b/api/libcuml/0.16/dir_87b68a543ed72e8ab95d2fdc9bc93f7b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_8c708a7442b260a4b287a2d6468d8e5b.html
+++ b/api/libcuml/0.16/dir_8c708a7442b260a4b287a2d6468d8e5b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_8e28c6b78ba64faaa42a5effd15e570c.html
+++ b/api/libcuml/0.16/dir_8e28c6b78ba64faaa42a5effd15e570c.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_91d923fb416d530a050858a222ba0968.html
+++ b/api/libcuml/0.16/dir_91d923fb416d530a050858a222ba0968.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_95858edebcc6d4e8b4941970a9d504a9.html
+++ b/api/libcuml/0.16/dir_95858edebcc6d4e8b4941970a9d504a9.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_9bc01c2bb6ff90c6d12f9ab9b45d5c8f.html
+++ b/api/libcuml/0.16/dir_9bc01c2bb6ff90c6d12f9ab9b45d5c8f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_9bdc568b60634c1acc416814ae0f95de.html
+++ b/api/libcuml/0.16/dir_9bdc568b60634c1acc416814ae0f95de.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_9db4913b7e626a61ab247662f7f2e1d6.html
+++ b/api/libcuml/0.16/dir_9db4913b7e626a61ab247662f7f2e1d6.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_9dd1214dde2619e948bc8f4d32765479.html
+++ b/api/libcuml/0.16/dir_9dd1214dde2619e948bc8f4d32765479.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_a06c85308a9932bfaf6b3f29a72be2eb.html
+++ b/api/libcuml/0.16/dir_a06c85308a9932bfaf6b3f29a72be2eb.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_a43624ea61481a9a52bfdc1a5fbd9ea0.html
+++ b/api/libcuml/0.16/dir_a43624ea61481a9a52bfdc1a5fbd9ea0.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_a4c3e2242510c6f1d413120980ddf828.html
+++ b/api/libcuml/0.16/dir_a4c3e2242510c6f1d413120980ddf828.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_b01fcc5d8e783b0454a5d25996602b2d.html
+++ b/api/libcuml/0.16/dir_b01fcc5d8e783b0454a5d25996602b2d.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_b3a46aaa2f34577dd0fdf96dd7d2f5b1.html
+++ b/api/libcuml/0.16/dir_b3a46aaa2f34577dd0fdf96dd7d2f5b1.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_b3d9b8e0ee770649da49d282191a52f0.html
+++ b/api/libcuml/0.16/dir_b3d9b8e0ee770649da49d282191a52f0.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_b5cf88163cc6829298616a7ce3dc8f5b.html
+++ b/api/libcuml/0.16/dir_b5cf88163cc6829298616a7ce3dc8f5b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_c88f233300d050aeb71856f2a434359f.html
+++ b/api/libcuml/0.16/dir_c88f233300d050aeb71856f2a434359f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_c8d132f5bc530a091228879e524f626a.html
+++ b/api/libcuml/0.16/dir_c8d132f5bc530a091228879e524f626a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_d03ad1aa6845390234e016eecc006914.html
+++ b/api/libcuml/0.16/dir_d03ad1aa6845390234e016eecc006914.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_d44c64559bbebec7f509842c48db8b23.html
+++ b/api/libcuml/0.16/dir_d44c64559bbebec7f509842c48db8b23.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_df30eb710314dc68331108c866e08fab.html
+++ b/api/libcuml/0.16/dir_df30eb710314dc68331108c866e08fab.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_e9678cbc48b7e471e896b5bab3680c26.html
+++ b/api/libcuml/0.16/dir_e9678cbc48b7e471e896b5bab3680c26.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_ed68c32c8fe0d244aea225f6db35c148.html
+++ b/api/libcuml/0.16/dir_ed68c32c8fe0d244aea225f6db35c148.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_ee0a2921d8a41481a2eb4b0c39976a70.html
+++ b/api/libcuml/0.16/dir_ee0a2921d8a41481a2eb4b0c39976a70.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_f4306ba7a87ccb6f8715b426fecc1db1.html
+++ b/api/libcuml/0.16/dir_f4306ba7a87ccb6f8715b426fecc1db1.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_f6842b9efbe6c27c5fba3db4d698f486.html
+++ b/api/libcuml/0.16/dir_f6842b9efbe6c27c5fba3db4d698f486.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_fb12db7c5242be27e492c8d6fcdb6187.html
+++ b/api/libcuml/0.16/dir_fb12db7c5242be27e492c8d6fcdb6187.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dir_fdedb0aba14d44ce9d99bc100e026e6a.html
+++ b/api/libcuml/0.16/dir_fdedb0aba14d44ce9d99bc100e026e6a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/dispersion_8cuh.html
+++ b/api/libcuml/0.16/dispersion_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance_8cuh.html
+++ b/api/libcuml/0.16/distance_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__epilogue_8cuh.html
+++ b/api/libcuml/0.16/distance__epilogue_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__epilogue__functor_8cuh.html
+++ b/api/libcuml/0.16/distance__epilogue__functor_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__epilogue__traits_8h.html
+++ b/api/libcuml/0.16/distance__epilogue__traits_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__epilogue__traits_8h_source.html
+++ b/api/libcuml/0.16/distance__epilogue__traits_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__fragment__multiply__add_8cuh.html
+++ b/api/libcuml/0.16/distance__fragment__multiply__add_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__tile__traits_8h.html
+++ b/api/libcuml/0.16/distance__tile__traits_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__tile__traits_8h_source.html
+++ b/api/libcuml/0.16/distance__tile__traits_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__type_8h.html
+++ b/api/libcuml/0.16/distance__type_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distance__type_8h_source.html
+++ b/api/libcuml/0.16/distance__type_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/distances_8cuh.html
+++ b/api/libcuml/0.16/distances_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/divide_8cuh.html
+++ b/api/libcuml/0.16/divide_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/eig_8cuh.html
+++ b/api/libcuml/0.16/eig_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/eltwise2d_8cuh.html
+++ b/api/libcuml/0.16/eltwise2d_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/eltwise_8cuh.html
+++ b/api/libcuml/0.16/eltwise_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/entropy_8cuh.html
+++ b/api/libcuml/0.16/entropy_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/epsilon__neighborhood_8cuh.html
+++ b/api/libcuml/0.16/epsilon__neighborhood_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/euclidean_8cuh.html
+++ b/api/libcuml/0.16/euclidean_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/exact__kernels_8cuh.html
+++ b/api/libcuml/0.16/exact__kernels_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/exact__tsne_8cuh.html
+++ b/api/libcuml/0.16/exact__tsne_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fast__int__div_8cuh.html
+++ b/api/libcuml/0.16/fast__int__div_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fil_2common_8cuh.html
+++ b/api/libcuml/0.16/fil_2common_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fil_8cu.html
+++ b/api/libcuml/0.16/fil_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fil_8h.html
+++ b/api/libcuml/0.16/fil_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fil_8h_source.html
+++ b/api/libcuml/0.16/fil_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/files.html
+++ b/api/libcuml/0.16/files.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/flatnode_8h.html
+++ b/api/libcuml/0.16/flatnode_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/flatnode_8h_source.html
+++ b/api/libcuml/0.16/flatnode_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fragment__sqrt_8cuh.html
+++ b/api/libcuml/0.16/fragment__sqrt_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions.html
+++ b/api/libcuml/0.16/functions.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_a.html
+++ b/api/libcuml/0.16/functions_a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_b.html
+++ b/api/libcuml/0.16/functions_b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_c.html
+++ b/api/libcuml/0.16/functions_c.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_d.html
+++ b/api/libcuml/0.16/functions_d.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_e.html
+++ b/api/libcuml/0.16/functions_e.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_enum.html
+++ b/api/libcuml/0.16/functions_enum.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_eval.html
+++ b/api/libcuml/0.16/functions_eval.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_f.html
+++ b/api/libcuml/0.16/functions_f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_func.html
+++ b/api/libcuml/0.16/functions_func.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_g.html
+++ b/api/libcuml/0.16/functions_g.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_h.html
+++ b/api/libcuml/0.16/functions_h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_i.html
+++ b/api/libcuml/0.16/functions_i.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_k.html
+++ b/api/libcuml/0.16/functions_k.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_l.html
+++ b/api/libcuml/0.16/functions_l.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_m.html
+++ b/api/libcuml/0.16/functions_m.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_n.html
+++ b/api/libcuml/0.16/functions_n.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_o.html
+++ b/api/libcuml/0.16/functions_o.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_p.html
+++ b/api/libcuml/0.16/functions_p.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_q.html
+++ b/api/libcuml/0.16/functions_q.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_r.html
+++ b/api/libcuml/0.16/functions_r.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_s.html
+++ b/api/libcuml/0.16/functions_s.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_t.html
+++ b/api/libcuml/0.16/functions_t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_type.html
+++ b/api/libcuml/0.16/functions_type.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_u.html
+++ b/api/libcuml/0.16/functions_u.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_v.html
+++ b/api/libcuml/0.16/functions_v.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars.html
+++ b/api/libcuml/0.16/functions_vars.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_a.html
+++ b/api/libcuml/0.16/functions_vars_a.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_b.html
+++ b/api/libcuml/0.16/functions_vars_b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_c.html
+++ b/api/libcuml/0.16/functions_vars_c.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_d.html
+++ b/api/libcuml/0.16/functions_vars_d.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_e.html
+++ b/api/libcuml/0.16/functions_vars_e.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_f.html
+++ b/api/libcuml/0.16/functions_vars_f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_g.html
+++ b/api/libcuml/0.16/functions_vars_g.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_h.html
+++ b/api/libcuml/0.16/functions_vars_h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_i.html
+++ b/api/libcuml/0.16/functions_vars_i.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_k.html
+++ b/api/libcuml/0.16/functions_vars_k.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_l.html
+++ b/api/libcuml/0.16/functions_vars_l.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_m.html
+++ b/api/libcuml/0.16/functions_vars_m.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_n.html
+++ b/api/libcuml/0.16/functions_vars_n.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_o.html
+++ b/api/libcuml/0.16/functions_vars_o.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_p.html
+++ b/api/libcuml/0.16/functions_vars_p.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_q.html
+++ b/api/libcuml/0.16/functions_vars_q.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_r.html
+++ b/api/libcuml/0.16/functions_vars_r.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_s.html
+++ b/api/libcuml/0.16/functions_vars_s.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_t.html
+++ b/api/libcuml/0.16/functions_vars_t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_u.html
+++ b/api/libcuml/0.16/functions_vars_u.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_v.html
+++ b/api/libcuml/0.16/functions_vars_v.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_w.html
+++ b/api/libcuml/0.16/functions_vars_w.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_vars_x.html
+++ b/api/libcuml/0.16/functions_vars_x.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_w.html
+++ b/api/libcuml/0.16/functions_w.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_x.html
+++ b/api/libcuml/0.16/functions_x.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/functions_~.html
+++ b/api/libcuml/0.16/functions_~.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/fused__l2__nn_8cuh.html
+++ b/api/libcuml/0.16/fused__l2__nn_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/gather_8cuh.html
+++ b/api/libcuml/0.16/gather_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/gemm_8cuh.html
+++ b/api/libcuml/0.16/gemm_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/gemv_8cuh.html
+++ b/api/libcuml/0.16/gemv_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/gemv_8h.html
+++ b/api/libcuml/0.16/gemv_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/gemv_8h_source.html
+++ b/api/libcuml/0.16/gemv_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm_8cu.html
+++ b/api/libcuml/0.16/glm_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm_8hpp.html
+++ b/api/libcuml/0.16/glm_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm_8hpp_source.html
+++ b/api/libcuml/0.16/glm_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__api_8cpp.html
+++ b/api/libcuml/0.16/glm__api_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__api_8h.html
+++ b/api/libcuml/0.16/glm__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__api_8h_source.html
+++ b/api/libcuml/0.16/glm__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__base_8cuh.html
+++ b/api/libcuml/0.16/glm__base_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__linear_8cuh.html
+++ b/api/libcuml/0.16/glm__linear_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__logistic_8cuh.html
+++ b/api/libcuml/0.16/glm__logistic_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__regularizer_8cuh.html
+++ b/api/libcuml/0.16/glm__regularizer_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__softmax_8cuh.html
+++ b/api/libcuml/0.16/glm__softmax_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__spmg_8h.html
+++ b/api/libcuml/0.16/glm__spmg_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/glm__spmg_8h_source.html
+++ b/api/libcuml/0.16/glm__spmg_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals.html
+++ b/api/libcuml/0.16/globals.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals_defs.html
+++ b/api/libcuml/0.16/globals_defs.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals_enum.html
+++ b/api/libcuml/0.16/globals_enum.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals_eval.html
+++ b/api/libcuml/0.16/globals_eval.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals_func.html
+++ b/api/libcuml/0.16/globals_func.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/globals_type.html
+++ b/api/libcuml/0.16/globals_type.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/grammatrix_8cuh.html
+++ b/api/libcuml/0.16/grammatrix_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/graph_legend.html
+++ b/api/libcuml/0.16/graph_legend.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/grid__sync_8cuh.html
+++ b/api/libcuml/0.16/grid__sync_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__CStringFormat.html
+++ b/api/libcuml/0.16/group__CStringFormat.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__CumlLogLevels.html
+++ b/api/libcuml/0.16/group__CumlLogLevels.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DbscanC.html
+++ b/api/libcuml/0.16/group__DbscanC.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DbscanCpp.html
+++ b/api/libcuml/0.16/group__DbscanCpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DecisionTreeClassifierFit.html
+++ b/api/libcuml/0.16/group__DecisionTreeClassifierFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DecisionTreeClassifierPredict.html
+++ b/api/libcuml/0.16/group__DecisionTreeClassifierPredict.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DecisionTreeRegressorFit.html
+++ b/api/libcuml/0.16/group__DecisionTreeRegressorFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__DecisionTreeRegressorPredict.html
+++ b/api/libcuml/0.16/group__DecisionTreeRegressorPredict.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__HoltWinterFit.html
+++ b/api/libcuml/0.16/group__HoltWinterFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__HoltWinterForecast.html
+++ b/api/libcuml/0.16/group__HoltWinterForecast.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__LoggerMacros.html
+++ b/api/libcuml/0.16/group__LoggerMacros.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__MakeBlobs.html
+++ b/api/libcuml/0.16/group__MakeBlobs.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__SVM.html
+++ b/api/libcuml/0.16/group__SVM.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__glmPredict.html
+++ b/api/libcuml/0.16/group__glmPredict.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__normal.html
+++ b/api/libcuml/0.16/group__normal.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__olsFit.html
+++ b/api/libcuml/0.16/group__olsFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__paramsRPROJ.html
+++ b/api/libcuml/0.16/group__paramsRPROJ.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__qnDecisionFunction.html
+++ b/api/libcuml/0.16/group__qnDecisionFunction.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__qnFit.html
+++ b/api/libcuml/0.16/group__qnFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__qnPredict.html
+++ b/api/libcuml/0.16/group__qnPredict.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/group__ridgeFit.html
+++ b/api/libcuml/0.16/group__ridgeFit.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hierarchy.html
+++ b/api/libcuml/0.16/hierarchy.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hinge_8cuh.html
+++ b/api/libcuml/0.16/hinge_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/histogram_8cuh.html
+++ b/api/libcuml/0.16/histogram_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters_2runner_8cuh.html
+++ b/api/libcuml/0.16/holtwinters_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters_8cu.html
+++ b/api/libcuml/0.16/holtwinters_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters_8h.html
+++ b/api/libcuml/0.16/holtwinters_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters_8h_source.html
+++ b/api/libcuml/0.16/holtwinters_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters__api_8cpp.html
+++ b/api/libcuml/0.16/holtwinters__api_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters__api_8h.html
+++ b/api/libcuml/0.16/holtwinters__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters__api_8h_source.html
+++ b/api/libcuml/0.16/holtwinters__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters__params_8h.html
+++ b/api/libcuml/0.16/holtwinters__params_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/holtwinters__params_8h_source.html
+++ b/api/libcuml/0.16/holtwinters__params_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/homogeneityScore_8cuh.html
+++ b/api/libcuml/0.16/homogeneityScore_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/host__buffer_8hpp.html
+++ b/api/libcuml/0.16/host__buffer_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/host__buffer_8hpp_source.html
+++ b/api/libcuml/0.16/host__buffer_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hw__decompose_8cuh.html
+++ b/api/libcuml/0.16/hw__decompose_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hw__eval_8cuh.html
+++ b/api/libcuml/0.16/hw__eval_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hw__forecast_8cuh.html
+++ b/api/libcuml/0.16/hw__forecast_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hw__optim_8cuh.html
+++ b/api/libcuml/0.16/hw__optim_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/hw__utils_8cuh.html
+++ b/api/libcuml/0.16/hw__utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/index.html
+++ b/api/libcuml/0.16/index.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/infer_8cu.html
+++ b/api/libcuml/0.16/infer_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/information__criterion_8cuh.html
+++ b/api/libcuml/0.16/information__criterion_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/inherits.html
+++ b/api/libcuml/0.16/inherits.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/init_8h.html
+++ b/api/libcuml/0.16/init_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/init_8h_source.html
+++ b/api/libcuml/0.16/init_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/input_8cuh.html
+++ b/api/libcuml/0.16/input_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/internals_8h.html
+++ b/api/libcuml/0.16/internals_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/internals_8h_source.html
+++ b/api/libcuml/0.16/internals_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/iota_8cuh.html
+++ b/api/libcuml/0.16/iota_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/jones__transform_8cuh.html
+++ b/api/libcuml/0.16/jones__transform_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernelcache_8cuh.html
+++ b/api/libcuml/0.16/kernelcache_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernelfactory_8cuh.html
+++ b/api/libcuml/0.16/kernelfactory_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernelmatrices_8cuh.html
+++ b/api/libcuml/0.16/kernelmatrices_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernelparams_8h.html
+++ b/api/libcuml/0.16/kernelparams_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernelparams_8h_source.html
+++ b/api/libcuml/0.16/kernelparams_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kernels_8cuh.html
+++ b/api/libcuml/0.16/kernels_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/klDivergence_8cuh.html
+++ b/api/libcuml/0.16/klDivergence_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans_2common_8cuh.html
+++ b/api/libcuml/0.16/kmeans_2common_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans_8cu.html
+++ b/api/libcuml/0.16/kmeans_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans_8hpp.html
+++ b/api/libcuml/0.16/kmeans_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans_8hpp_source.html
+++ b/api/libcuml/0.16/kmeans_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans__mg_8cu.html
+++ b/api/libcuml/0.16/kmeans__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans__mg_8hpp.html
+++ b/api/libcuml/0.16/kmeans__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans__mg_8hpp_source.html
+++ b/api/libcuml/0.16/kmeans__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kmeans__mg__impl_8cuh.html
+++ b/api/libcuml/0.16/kmeans__mg__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn_8cu.html
+++ b/api/libcuml/0.16/knn_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn_8cuh.html
+++ b/api/libcuml/0.16/knn_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn_8hpp.html
+++ b/api/libcuml/0.16/knn_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn_8hpp_source.html
+++ b/api/libcuml/0.16/knn_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__api_8h.html
+++ b/api/libcuml/0.16/knn__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__api_8h_source.html
+++ b/api/libcuml/0.16/knn__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__classify__mg_8cu.html
+++ b/api/libcuml/0.16/knn__classify__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__mg_8cu.html
+++ b/api/libcuml/0.16/knn__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__mg_8hpp.html
+++ b/api/libcuml/0.16/knn__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__mg_8hpp_source.html
+++ b/api/libcuml/0.16/knn__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__opg__common_8cu.html
+++ b/api/libcuml/0.16/knn__opg__common_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__opg__common_8cuh.html
+++ b/api/libcuml/0.16/knn__opg__common_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/knn__regress__mg_8cu.html
+++ b/api/libcuml/0.16/knn__regress__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/kselection_8cuh.html
+++ b/api/libcuml/0.16/kselection_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/l1_8cuh.html
+++ b/api/libcuml/0.16/l1_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/learning__rate_8h.html
+++ b/api/libcuml/0.16/learning__rate_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/learning__rate_8h_source.html
+++ b/api/libcuml/0.16/learning__rate_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelfunc__classifier_8cuh.html
+++ b/api/libcuml/0.16/levelfunc__classifier_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelfunc__regressor_8cuh.html
+++ b/api/libcuml/0.16/levelfunc__regressor_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelhelper__classifier_8cuh.html
+++ b/api/libcuml/0.16/levelhelper__classifier_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelhelper__regressor_8cuh.html
+++ b/api/libcuml/0.16/levelhelper__regressor_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelkernel__classifier_8cuh.html
+++ b/api/libcuml/0.16/levelkernel__classifier_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/levelkernel__regressor_8cuh.html
+++ b/api/libcuml/0.16/levelkernel__regressor_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/linalg_2batched_2matrix_8cuh.html
+++ b/api/libcuml/0.16/linalg_2batched_2matrix_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/linearReg_8cuh.html
+++ b/api/libcuml/0.16/linearReg_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/linear__scaling__sqrt_8cuh.html
+++ b/api/libcuml/0.16/linear__scaling__sqrt_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/log_8cuh.html
+++ b/api/libcuml/0.16/log_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/logger_8cpp.html
+++ b/api/libcuml/0.16/logger_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/logger_8hpp.html
+++ b/api/libcuml/0.16/logger_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/logger_8hpp_source.html
+++ b/api/libcuml/0.16/logger_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/logisticReg_8cuh.html
+++ b/api/libcuml/0.16/logisticReg_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/lstsq_8cuh.html
+++ b/api/libcuml/0.16/lstsq_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__arima_8cu.html
+++ b/api/libcuml/0.16/make__arima_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__arima_8cuh.html
+++ b/api/libcuml/0.16/make__arima_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__arima_8hpp.html
+++ b/api/libcuml/0.16/make__arima_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__arima_8hpp_source.html
+++ b/api/libcuml/0.16/make__arima_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__blobs_8cu.html
+++ b/api/libcuml/0.16/make__blobs_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__blobs_8cuh.html
+++ b/api/libcuml/0.16/make__blobs_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__blobs_8hpp.html
+++ b/api/libcuml/0.16/make__blobs_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__blobs_8hpp_source.html
+++ b/api/libcuml/0.16/make__blobs_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__regression_8cu.html
+++ b/api/libcuml/0.16/make__regression_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__regression_8cuh.html
+++ b/api/libcuml/0.16/make__regression_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__regression_8hpp.html
+++ b/api/libcuml/0.16/make__regression_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__regression_8hpp_source.html
+++ b/api/libcuml/0.16/make__regression_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/make__symm_8cuh.html
+++ b/api/libcuml/0.16/make__symm_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/map__then__reduce_8cuh.html
+++ b/api/libcuml/0.16/map__then__reduce_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/math_8cuh.html
+++ b/api/libcuml/0.16/math_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/matrix_2matrix_8cuh.html
+++ b/api/libcuml/0.16/matrix_2matrix_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/matrix__vector__op_8cuh.html
+++ b/api/libcuml/0.16/matrix__vector__op_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/mean_8cuh.html
+++ b/api/libcuml/0.16/mean_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/mean__center_8cuh.html
+++ b/api/libcuml/0.16/mean__center_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/mean__squared__error_8cuh.html
+++ b/api/libcuml/0.16/mean__squared__error_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/memory_8cuh.html
+++ b/api/libcuml/0.16/memory_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/memory_8h.html
+++ b/api/libcuml/0.16/memory_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/memory_8h_source.html
+++ b/api/libcuml/0.16/memory_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metric_8cuh.html
+++ b/api/libcuml/0.16/metric_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metric__def_8cuh.html
+++ b/api/libcuml/0.16/metric__def_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metrics_8cu.html
+++ b/api/libcuml/0.16/metrics_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metrics_8cuh.html
+++ b/api/libcuml/0.16/metrics_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metrics_8hpp.html
+++ b/api/libcuml/0.16/metrics_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/metrics_8hpp_source.html
+++ b/api/libcuml/0.16/metrics_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/minmax_8cuh.html
+++ b/api/libcuml/0.16/minmax_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ml__cuda__utils_8h.html
+++ b/api/libcuml/0.16/ml__cuda__utils_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ml__cuda__utils_8h_source.html
+++ b/api/libcuml/0.16/ml__cuda__utils_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ml__mg__utils_8cuh.html
+++ b/api/libcuml/0.16/ml__mg__utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/modules.html
+++ b/api/libcuml/0.16/modules.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/multiply_8cuh.html
+++ b/api/libcuml/0.16/multiply_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/mutualInfoScore_8cuh.html
+++ b/api/libcuml/0.16/mutualInfoScore_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/mvg_8cuh.html
+++ b/api/libcuml/0.16/mvg_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceDbscan.html
+++ b/api/libcuml/0.16/namespaceDbscan.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceDbscan_1_1AdjGraph.html
+++ b/api/libcuml/0.16/namespaceDbscan_1_1AdjGraph.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceDbscan_1_1VertexDeg.html
+++ b/api/libcuml/0.16/namespaceDbscan_1_1VertexDeg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML.html
+++ b/api/libcuml/0.16/namespaceML.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon.html
+++ b/api/libcuml/0.16/namespaceMLCommon.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1Datasets.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1Datasets.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1Datasets_1_1Digits.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1Datasets_1_1Digits.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1Distance.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1Distance.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1LinAlg.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1LinAlg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1Matrix.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1Matrix.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceMLCommon_1_1Random.html
+++ b/api/libcuml/0.16/namespaceMLCommon_1_1Random.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1CD.html
+++ b/api/libcuml/0.16/namespaceML_1_1CD.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1CD_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1CD_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Datasets.html
+++ b/api/libcuml/0.16/namespaceML_1_1Datasets.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1DecisionTree.html
+++ b/api/libcuml/0.16/namespaceML_1_1DecisionTree.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Distance.html
+++ b/api/libcuml/0.16/namespaceML_1_1Distance.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1GLM.html
+++ b/api/libcuml/0.16/namespaceML_1_1GLM.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1GLM_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1GLM_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1HoltWinters.html
+++ b/api/libcuml/0.16/namespaceML_1_1HoltWinters.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Internals.html
+++ b/api/libcuml/0.16/namespaceML_1_1Internals.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1KNN.html
+++ b/api/libcuml/0.16/namespaceML_1_1KNN.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1KNN_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1KNN_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Metrics.html
+++ b/api/libcuml/0.16/namespaceML_1_1Metrics.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1OLS.html
+++ b/api/libcuml/0.16/namespaceML_1_1OLS.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1OLS_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1OLS_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1PCA.html
+++ b/api/libcuml/0.16/namespaceML_1_1PCA.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1PCA_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1PCA_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Ridge.html
+++ b/api/libcuml/0.16/namespaceML_1_1Ridge.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Ridge_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1Ridge_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1SVM.html
+++ b/api/libcuml/0.16/namespaceML_1_1SVM.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Solver.html
+++ b/api/libcuml/0.16/namespaceML_1_1Solver.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Spectral.html
+++ b/api/libcuml/0.16/namespaceML_1_1Spectral.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1Stationarity.html
+++ b/api/libcuml/0.16/namespaceML_1_1Stationarity.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1TSVD.html
+++ b/api/libcuml/0.16/namespaceML_1_1TSVD.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1TSVD_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1TSVD_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1detail.html
+++ b/api/libcuml/0.16/namespaceML_1_1detail.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1fil.html
+++ b/api/libcuml/0.16/namespaceML_1_1fil.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1kmeans.html
+++ b/api/libcuml/0.16/namespaceML_1_1kmeans.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceML_1_1kmeans_1_1opg.html
+++ b/api/libcuml/0.16/namespaceML_1_1kmeans_1_1opg.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers.html
+++ b/api/libcuml/0.16/namespacemembers.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_b.html
+++ b/api/libcuml/0.16/namespacemembers_b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_c.html
+++ b/api/libcuml/0.16/namespacemembers_c.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_d.html
+++ b/api/libcuml/0.16/namespacemembers_d.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_e.html
+++ b/api/libcuml/0.16/namespacemembers_e.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_enum.html
+++ b/api/libcuml/0.16/namespacemembers_enum.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_eval.html
+++ b/api/libcuml/0.16/namespacemembers_eval.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_f.html
+++ b/api/libcuml/0.16/namespacemembers_f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func.html
+++ b/api/libcuml/0.16/namespacemembers_func.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_b.html
+++ b/api/libcuml/0.16/namespacemembers_func_b.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_c.html
+++ b/api/libcuml/0.16/namespacemembers_func_c.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_d.html
+++ b/api/libcuml/0.16/namespacemembers_func_d.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_e.html
+++ b/api/libcuml/0.16/namespacemembers_func_e.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_f.html
+++ b/api/libcuml/0.16/namespacemembers_func_f.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_g.html
+++ b/api/libcuml/0.16/namespacemembers_func_g.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_h.html
+++ b/api/libcuml/0.16/namespacemembers_func_h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_i.html
+++ b/api/libcuml/0.16/namespacemembers_func_i.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_j.html
+++ b/api/libcuml/0.16/namespacemembers_func_j.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_k.html
+++ b/api/libcuml/0.16/namespacemembers_func_k.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_m.html
+++ b/api/libcuml/0.16/namespacemembers_func_m.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_n.html
+++ b/api/libcuml/0.16/namespacemembers_func_n.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_o.html
+++ b/api/libcuml/0.16/namespacemembers_func_o.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_p.html
+++ b/api/libcuml/0.16/namespacemembers_func_p.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_q.html
+++ b/api/libcuml/0.16/namespacemembers_func_q.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_r.html
+++ b/api/libcuml/0.16/namespacemembers_func_r.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_s.html
+++ b/api/libcuml/0.16/namespacemembers_func_s.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_t.html
+++ b/api/libcuml/0.16/namespacemembers_func_t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_func_v.html
+++ b/api/libcuml/0.16/namespacemembers_func_v.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_g.html
+++ b/api/libcuml/0.16/namespacemembers_g.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_h.html
+++ b/api/libcuml/0.16/namespacemembers_h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_i.html
+++ b/api/libcuml/0.16/namespacemembers_i.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_j.html
+++ b/api/libcuml/0.16/namespacemembers_j.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_k.html
+++ b/api/libcuml/0.16/namespacemembers_k.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_l.html
+++ b/api/libcuml/0.16/namespacemembers_l.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_m.html
+++ b/api/libcuml/0.16/namespacemembers_m.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_n.html
+++ b/api/libcuml/0.16/namespacemembers_n.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_o.html
+++ b/api/libcuml/0.16/namespacemembers_o.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_p.html
+++ b/api/libcuml/0.16/namespacemembers_p.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_q.html
+++ b/api/libcuml/0.16/namespacemembers_q.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_r.html
+++ b/api/libcuml/0.16/namespacemembers_r.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_s.html
+++ b/api/libcuml/0.16/namespacemembers_s.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_t.html
+++ b/api/libcuml/0.16/namespacemembers_t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_type.html
+++ b/api/libcuml/0.16/namespacemembers_type.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_u.html
+++ b/api/libcuml/0.16/namespacemembers_u.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_v.html
+++ b/api/libcuml/0.16/namespacemembers_v.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacemembers_vars.html
+++ b/api/libcuml/0.16/namespacemembers_vars.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaceraft.html
+++ b/api/libcuml/0.16/namespaceraft.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespaces.html
+++ b/api/libcuml/0.16/namespaces.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacespdlog.html
+++ b/api/libcuml/0.16/namespacespdlog.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/namespacespdlog_1_1sinks.html
+++ b/api/libcuml/0.16/namespacespdlog_1_1sinks.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/node_8cuh.html
+++ b/api/libcuml/0.16/node_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/norm_8cuh.html
+++ b/api/libcuml/0.16/norm_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/nvtx_8cu.html
+++ b/api/libcuml/0.16/nvtx_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/nvtx_8hpp.html
+++ b/api/libcuml/0.16/nvtx_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/nvtx_8hpp_source.html
+++ b/api/libcuml/0.16/nvtx_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ols_8cuh.html
+++ b/api/libcuml/0.16/ols_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ols__mg_8cu.html
+++ b/api/libcuml/0.16/ols__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ols__mg_8hpp.html
+++ b/api/libcuml/0.16/ols__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ols__mg_8hpp_source.html
+++ b/api/libcuml/0.16/ols__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/optimize_8cuh.html
+++ b/api/libcuml/0.16/optimize_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/optimize__batch__kernel_8cuh.html
+++ b/api/libcuml/0.16/optimize__batch__kernel_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pages.html
+++ b/api/libcuml/0.16/pages.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pairwiseDistance_8cuh.html
+++ b/api/libcuml/0.16/pairwiseDistance_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca_8cu.html
+++ b/api/libcuml/0.16/pca_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca_8cuh.html
+++ b/api/libcuml/0.16/pca_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca_8hpp.html
+++ b/api/libcuml/0.16/pca_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca_8hpp_source.html
+++ b/api/libcuml/0.16/pca_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca__mg_8cu.html
+++ b/api/libcuml/0.16/pca__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca__mg_8hpp.html
+++ b/api/libcuml/0.16/pca__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/pca__mg_8hpp_source.html
+++ b/api/libcuml/0.16/pca__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/penalty_8cuh.html
+++ b/api/libcuml/0.16/penalty_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/permute_8cuh.html
+++ b/api/libcuml/0.16/permute_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/power_8cuh.html
+++ b/api/libcuml/0.16/power_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/preprocess_8cuh.html
+++ b/api/libcuml/0.16/preprocess_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/preprocess__mg_8cu.html
+++ b/api/libcuml/0.16/preprocess__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/preprocess__mg_8hpp.html
+++ b/api/libcuml/0.16/preprocess__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/preprocess__mg_8hpp_source.html
+++ b/api/libcuml/0.16/preprocess__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/processing_8cuh.html
+++ b/api/libcuml/0.16/processing_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/qn_8cuh.html
+++ b/api/libcuml/0.16/qn_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/qn__linesearch_8cuh.html
+++ b/api/libcuml/0.16/qn__linesearch_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/qn__solvers_8cuh.html
+++ b/api/libcuml/0.16/qn__solvers_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/qn__util_8cuh.html
+++ b/api/libcuml/0.16/qn__util_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/qr_8cuh.html
+++ b/api/libcuml/0.16/qr_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/quantile_8cuh.html
+++ b/api/libcuml/0.16/quantile_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/quantile_8h.html
+++ b/api/libcuml/0.16/quantile_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/quantile_8h_source.html
+++ b/api/libcuml/0.16/quantile_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randIndex_8cuh.html
+++ b/api/libcuml/0.16/randIndex_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/random__algo_8cuh.html
+++ b/api/libcuml/0.16/random__algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest_8cu.html
+++ b/api/libcuml/0.16/randomforest_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest_8hpp.html
+++ b/api/libcuml/0.16/randomforest_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest_8hpp_source.html
+++ b/api/libcuml/0.16/randomforest_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest__impl_8cuh.html
+++ b/api/libcuml/0.16/randomforest__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest__impl_8h.html
+++ b/api/libcuml/0.16/randomforest__impl_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/randomforest__impl_8h_source.html
+++ b/api/libcuml/0.16/randomforest__impl_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/reduce_8cuh.html
+++ b/api/libcuml/0.16/reduce_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/reduce__cols__by__key_8cuh.html
+++ b/api/libcuml/0.16/reduce__cols__by__key_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/reduce__rows__by__key_8cuh.html
+++ b/api/libcuml/0.16/reduce__rows__by__key_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/results_8cuh.html
+++ b/api/libcuml/0.16/results_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/reverse_8cuh.html
+++ b/api/libcuml/0.16/reverse_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ridge_8cuh.html
+++ b/api/libcuml/0.16/ridge_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ridge__mg_8cu.html
+++ b/api/libcuml/0.16/ridge__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ridge__mg_8hpp.html
+++ b/api/libcuml/0.16/ridge__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ridge__mg_8hpp_source.html
+++ b/api/libcuml/0.16/ridge__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rng_8cuh.html
+++ b/api/libcuml/0.16/rng_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rng__impl_8cuh.html
+++ b/api/libcuml/0.16/rng__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rproj_8cu.html
+++ b/api/libcuml/0.16/rproj_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rproj_8cuh.html
+++ b/api/libcuml/0.16/rproj_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rproj__c_8h.html
+++ b/api/libcuml/0.16/rproj__c_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rproj__c_8h_source.html
+++ b/api/libcuml/0.16/rproj__c_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rproj__utils_8cuh.html
+++ b/api/libcuml/0.16/rproj__utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/rsvd_8cuh.html
+++ b/api/libcuml/0.16/rsvd_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/scatter_8cuh.html
+++ b/api/libcuml/0.16/scatter_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/scores_8cuh.html
+++ b/api/libcuml/0.16/scores_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/seive_8cuh.html
+++ b/api/libcuml/0.16/seive_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sg__impl_8cuh.html
+++ b/api/libcuml/0.16/sg__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sgd_8cuh.html
+++ b/api/libcuml/0.16/sgd_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/shuffle_8h.html
+++ b/api/libcuml/0.16/shuffle_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/shuffle_8h_source.html
+++ b/api/libcuml/0.16/shuffle_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sigmoid_8cuh.html
+++ b/api/libcuml/0.16/sigmoid_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sign_8cuh.html
+++ b/api/libcuml/0.16/sign_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sign__flip__mg_8cu.html
+++ b/api/libcuml/0.16/sign__flip__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sign__flip__mg_8hpp.html
+++ b/api/libcuml/0.16/sign__flip__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sign__flip__mg_8hpp_source.html
+++ b/api/libcuml/0.16/sign__flip__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/silhouetteScore_8cuh.html
+++ b/api/libcuml/0.16/silhouetteScore_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/simple__mat_8cuh.html
+++ b/api/libcuml/0.16/simple__mat_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/smo__sets_8cuh.html
+++ b/api/libcuml/0.16/smo__sets_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/smoblocksolve_8cuh.html
+++ b/api/libcuml/0.16/smoblocksolve_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/smosolver_8cuh.html
+++ b/api/libcuml/0.16/smosolver_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/softThres_8cuh.html
+++ b/api/libcuml/0.16/softThres_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/solver_8cu.html
+++ b/api/libcuml/0.16/solver_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/solver_8hpp.html
+++ b/api/libcuml/0.16/solver_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/solver_8hpp_source.html
+++ b/api/libcuml/0.16/solver_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/solvers_2params_8hpp.html
+++ b/api/libcuml/0.16/solvers_2params_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/solvers_2params_8hpp_source.html
+++ b/api/libcuml/0.16/solvers_2params_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/spectral_8cu.html
+++ b/api/libcuml/0.16/spectral_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/spectral_8cuh.html
+++ b/api/libcuml/0.16/spectral_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/spectral_8hpp.html
+++ b/api/libcuml/0.16/spectral_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/spectral_8hpp_source.html
+++ b/api/libcuml/0.16/spectral_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/spectral__algo_8cuh.html
+++ b/api/libcuml/0.16/spectral__algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/split_8cuh.html
+++ b/api/libcuml/0.16/split_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sqrt_8cuh.html
+++ b/api/libcuml/0.16/sqrt_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/stationarity_8cu.html
+++ b/api/libcuml/0.16/stationarity_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/stationarity_8cuh.html
+++ b/api/libcuml/0.16/stationarity_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/stationarity_8h.html
+++ b/api/libcuml/0.16/stationarity_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/stationarity_8h_source.html
+++ b/api/libcuml/0.16/stationarity_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/stddev_8cuh.html
+++ b/api/libcuml/0.16/stddev_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/strided__reduction_8cuh.html
+++ b/api/libcuml/0.16/strided__reduction_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structDbscan_1_1AdjGraph_1_1Pack-members.html
+++ b/api/libcuml/0.16/structDbscan_1_1AdjGraph_1_1Pack-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structDbscan_1_1AdjGraph_1_1Pack.html
+++ b/api/libcuml/0.16/structDbscan_1_1AdjGraph_1_1Pack.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structDbscan_1_1VertexDeg_1_1Pack-members.html
+++ b/api/libcuml/0.16/structDbscan_1_1VertexDeg_1_1Pack-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structDbscan_1_1VertexDeg_1_1Pack.html
+++ b/api/libcuml/0.16/structDbscan_1_1VertexDeg_1_1Pack.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1BoolEpilogueTraitsHelper-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1BoolEpilogueTraitsHelper-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1BoolEpilogueTraitsHelper.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1BoolEpilogueTraitsHelper.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits_1_1ThreadOffset-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits_1_1ThreadOffset-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits_1_1ThreadOffset.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileAATraits_1_1ThreadOffset.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits_1_1ThreadOffset-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits_1_1ThreadOffset-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits_1_1ThreadOffset.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Distance_1_1DistanceGlobalTileBBTraits_1_1ThreadOffset.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadDiffSquaredAdd-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadDiffSquaredAdd-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadDiffSquaredAdd.html
+++ b/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadDiffSquaredAdd.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadL1NormAdd-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadL1NormAdd-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadL1NormAdd.html
+++ b/api/libcuml/0.16/structMLCommon_1_1LinAlg_1_1ThreadL1NormAdd.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Matrix_1_1KernelParams-members.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Matrix_1_1KernelParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structMLCommon_1_1Matrix_1_1KernelParams.html
+++ b/api/libcuml/0.16/structMLCommon_1_1Matrix_1_1KernelParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1ARIMAOrder-members.html
+++ b/api/libcuml/0.16/structML_1_1ARIMAOrder-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1ARIMAOrder.html
+++ b/api/libcuml/0.16/structML_1_1ARIMAOrder.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1ARIMAParams-members.html
+++ b/api/libcuml/0.16/structML_1_1ARIMAParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1ARIMAParams.html
+++ b/api/libcuml/0.16/structML_1_1ARIMAParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1DataInfo-members.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1DataInfo-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1DataInfo.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1DataInfo.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1DecisionTreeParams-members.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1DecisionTreeParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1DecisionTreeParams.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1DecisionTreeParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1TreeMetaDataNode-members.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1TreeMetaDataNode-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1DecisionTree_1_1TreeMetaDataNode.html
+++ b/api/libcuml/0.16/structML_1_1DecisionTree_1_1TreeMetaDataNode.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1OptimParams-members.html
+++ b/api/libcuml/0.16/structML_1_1OptimParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1OptimParams.html
+++ b/api/libcuml/0.16/structML_1_1OptimParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RF__metrics-members.html
+++ b/api/libcuml/0.16/structML_1_1RF__metrics-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RF__metrics.html
+++ b/api/libcuml/0.16/structML_1_1RF__metrics.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RF__params-members.html
+++ b/api/libcuml/0.16/structML_1_1RF__params-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RF__params.html
+++ b/api/libcuml/0.16/structML_1_1RF__params.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RandomForestMetaData-members.html
+++ b/api/libcuml/0.16/structML_1_1RandomForestMetaData-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1RandomForestMetaData.html
+++ b/api/libcuml/0.16/structML_1_1RandomForestMetaData.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1SVM_1_1svmModel-members.html
+++ b/api/libcuml/0.16/structML_1_1SVM_1_1svmModel-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1SVM_1_1svmModel.html
+++ b/api/libcuml/0.16/structML_1_1SVM_1_1svmModel.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1SVM_1_1svmParameter-members.html
+++ b/api/libcuml/0.16/structML_1_1SVM_1_1svmParameter-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1SVM_1_1svmParameter.html
+++ b/api/libcuml/0.16/structML_1_1SVM_1_1svmParameter.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1dense__node__t-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1dense__node__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1dense__node__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1dense__node__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1forest__params__t-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1forest__params__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1forest__params__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1forest__params__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1CATEGORICAL__LEAF_01_4-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1CATEGORICAL__LEAF_01_4-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1CATEGORICAL__LEAF_01_4.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1CATEGORICAL__LEAF_01_4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1FLOAT__UNARY__BINARY_01_4-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1FLOAT__UNARY__BINARY_01_4-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1FLOAT__UNARY__BINARY_01_4.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1FLOAT__UNARY__BINARY_01_4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__FEW__CLASSES_01_4-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__FEW__CLASSES_01_4-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__FEW__CLASSES_01_4.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__FEW__CLASSES_01_4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__MANY__CLASSES_01_4-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__MANY__CLASSES_01_4-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__MANY__CLASSES_01_4.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1leaf__output__t_3_01leaf__algo__t_1_1GROVE__PER__CLASS__MANY__CLASSES_01_4.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__extra__data-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__extra__data-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__extra__data.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__extra__data.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__t-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node16__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node8__t-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node8__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1sparse__node8__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1sparse__node8__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1treelite__params__t-members.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1treelite__params__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1fil_1_1treelite__params__t.html
+++ b/api/libcuml/0.16/structML_1_1fil_1_1treelite__params__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1kmeans_1_1KMeansParams-members.html
+++ b/api/libcuml/0.16/structML_1_1kmeans_1_1KMeansParams-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1kmeans_1_1KMeansParams.html
+++ b/api/libcuml/0.16/structML_1_1kmeans_1_1KMeansParams.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1paramsRPROJ-members.html
+++ b/api/libcuml/0.16/structML_1_1paramsRPROJ-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1paramsRPROJ.html
+++ b/api/libcuml/0.16/structML_1_1paramsRPROJ.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1rand__mat-members.html
+++ b/api/libcuml/0.16/structML_1_1rand__mat-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1rand__mat.html
+++ b/api/libcuml/0.16/structML_1_1rand__mat.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1stdAllocatorAdapter_1_1rebind-members.html
+++ b/api/libcuml/0.16/structML_1_1stdAllocatorAdapter_1_1rebind-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structML_1_1stdAllocatorAdapter_1_1rebind.html
+++ b/api/libcuml/0.16/structML_1_1stdAllocatorAdapter_1_1rebind.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structSparseTreeNode-members.html
+++ b/api/libcuml/0.16/structSparseTreeNode-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structSparseTreeNode.html
+++ b/api/libcuml/0.16/structSparseTreeNode.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structTemporaryMemory-members.html
+++ b/api/libcuml/0.16/structTemporaryMemory-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/structTemporaryMemory.html
+++ b/api/libcuml/0.16/structTemporaryMemory.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/subtract_8cuh.html
+++ b/api/libcuml/0.16/subtract_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/sum_8cuh.html
+++ b/api/libcuml/0.16/sum_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/supervised_8cuh.html
+++ b/api/libcuml/0.16/supervised_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svc_8cu.html
+++ b/api/libcuml/0.16/svc_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svc_8hpp.html
+++ b/api/libcuml/0.16/svc_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svc_8hpp_source.html
+++ b/api/libcuml/0.16/svc_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svc__impl_8cuh.html
+++ b/api/libcuml/0.16/svc__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svd_8cuh.html
+++ b/api/libcuml/0.16/svd_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__api_8cpp.html
+++ b/api/libcuml/0.16/svm__api_8cpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__api_8h.html
+++ b/api/libcuml/0.16/svm__api_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__api_8h_source.html
+++ b/api/libcuml/0.16/svm__api_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__model_8h.html
+++ b/api/libcuml/0.16/svm__model_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__model_8h_source.html
+++ b/api/libcuml/0.16/svm__model_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__parameter_8h.html
+++ b/api/libcuml/0.16/svm__parameter_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svm__parameter_8h_source.html
+++ b/api/libcuml/0.16/svm__parameter_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svr_8cu.html
+++ b/api/libcuml/0.16/svr_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svr_8hpp.html
+++ b/api/libcuml/0.16/svr_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svr_8hpp_source.html
+++ b/api/libcuml/0.16/svr_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/svr__impl_8cuh.html
+++ b/api/libcuml/0.16/svr__impl_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tensor_8hpp.html
+++ b/api/libcuml/0.16/tensor_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tensor_8hpp_source.html
+++ b/api/libcuml/0.16/tensor_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ternary__op_8cuh.html
+++ b/api/libcuml/0.16/ternary__op_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/todo.html
+++ b/api/libcuml/0.16/todo.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/transpose_8h.html
+++ b/api/libcuml/0.16/transpose_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/transpose_8h_source.html
+++ b/api/libcuml/0.16/transpose_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/treelite__defs_8hpp.html
+++ b/api/libcuml/0.16/treelite__defs_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/treelite__defs_8hpp_source.html
+++ b/api/libcuml/0.16/treelite__defs_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/trustworthiness_8cu.html
+++ b/api/libcuml/0.16/trustworthiness_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/trustworthiness_8cuh.html
+++ b/api/libcuml/0.16/trustworthiness_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/trustworthiness__c_8h.html
+++ b/api/libcuml/0.16/trustworthiness__c_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/trustworthiness__c_8h_source.html
+++ b/api/libcuml/0.16/trustworthiness__c_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsne_8cu.html
+++ b/api/libcuml/0.16/tsne_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsne_8h.html
+++ b/api/libcuml/0.16/tsne_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsne_8h_source.html
+++ b/api/libcuml/0.16/tsne_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd_8cu.html
+++ b/api/libcuml/0.16/tsvd_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd_8cuh.html
+++ b/api/libcuml/0.16/tsvd_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd_8hpp.html
+++ b/api/libcuml/0.16/tsvd_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd_8hpp_source.html
+++ b/api/libcuml/0.16/tsvd_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd__mg_8cu.html
+++ b/api/libcuml/0.16/tsvd__mg_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd__mg_8hpp.html
+++ b/api/libcuml/0.16/tsvd__mg_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd__mg_8hpp_source.html
+++ b/api/libcuml/0.16/tsvd__mg_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd__spmg_8h.html
+++ b/api/libcuml/0.16/tsvd__spmg_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/tsvd__spmg_8h_source.html
+++ b/api/libcuml/0.16/tsvd__spmg_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2fuzzy__simpl__set_2naive_8cuh.html
+++ b/api/libcuml/0.16/umap_2fuzzy__simpl__set_2naive_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2fuzzy__simpl__set_2runner_8cuh.html
+++ b/api/libcuml/0.16/umap_2fuzzy__simpl__set_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2init__embed_2runner_8cuh.html
+++ b/api/libcuml/0.16/umap_2init__embed_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2knn__graph_2algo_8cuh.html
+++ b/api/libcuml/0.16/umap_2knn__graph_2algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2knn__graph_2runner_8cuh.html
+++ b/api/libcuml/0.16/umap_2knn__graph_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2runner_8cuh.html
+++ b/api/libcuml/0.16/umap_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2simpl__set__embed_2algo_8cuh.html
+++ b/api/libcuml/0.16/umap_2simpl__set__embed_2algo_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_2simpl__set__embed_2runner_8cuh.html
+++ b/api/libcuml/0.16/umap_2simpl__set__embed_2runner_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_8cu.html
+++ b/api/libcuml/0.16/umap_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_8hpp.html
+++ b/api/libcuml/0.16/umap_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umap_8hpp_source.html
+++ b/api/libcuml/0.16/umap_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umapparams_8h.html
+++ b/api/libcuml/0.16/umapparams_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/umapparams_8h_source.html
+++ b/api/libcuml/0.16/umapparams_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/unary__op_8cuh.html
+++ b/api/libcuml/0.16/unary__op_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/unionML_1_1fil_1_1val__t-members.html
+++ b/api/libcuml/0.16/unionML_1_1fil_1_1val__t-members.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/unionML_1_1fil_1_1val__t.html
+++ b/api/libcuml/0.16/unionML_1_1fil_1_1val__t.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/utils_8cuh.html
+++ b/api/libcuml/0.16/utils_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/utils_8hpp.html
+++ b/api/libcuml/0.16/utils_8hpp.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/utils_8hpp_source.html
+++ b/api/libcuml/0.16/utils_8hpp_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/vMeasure_8cuh.html
+++ b/api/libcuml/0.16/vMeasure_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/vectorized_8cuh.html
+++ b/api/libcuml/0.16/vectorized_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/vertexdeg_2pack_8h.html
+++ b/api/libcuml/0.16/vertexdeg_2pack_8h.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/vertexdeg_2pack_8h_source.html
+++ b/api/libcuml/0.16/vertexdeg_2pack_8h_source.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/weighted__mean_8cuh.html
+++ b/api/libcuml/0.16/weighted__mean_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/workingset_8cuh.html
+++ b/api/libcuml/0.16/workingset_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ws__util_8cu.html
+++ b/api/libcuml/0.16/ws__util_8cu.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>

--- a/api/libcuml/0.16/ws__util_8cuh.html
+++ b/api/libcuml/0.16/ws__util_8cuh.html
@@ -19,7 +19,7 @@
     jax: ["input/TeX","output/HTML-CSS"],
 });
 </script>
-<script async="async" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
+<script async="async" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js" type="text/javascript"></script>
 <link href="doxygen.css" rel="stylesheet" type="text/css"/>
 <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" id="rapids-fa-tag" rel="stylesheet"/><link href="/assets/css/custom.css" id="rapids-selector-css" rel="stylesheet"/></head>
 <body>


### PR DESCRIPTION
This is a continuation of the fix in https://github.com/rapidsai/cuml/pull/3073. That fix was applied to `branch-0.17`, however there are still URLs from the `0.16` docs that need to be updated. This PR updates all of the mathjax URLs from the `0.16` version docs to use `https` instead of `http`. Fixing this will also prevent Netlify from sending me emails everytime we re-deploy the docs site:

![image](https://user-images.githubusercontent.com/7400326/101924412-a724a400-3b9e-11eb-8706-9dd093955b5a.png)


The changes in this PR are the result of running the following shell script:


```sh
#!/bin/bash


SEARCH_STR="http://cdn.mathjax.org"
REPL_STR="https://cdn.mathjax.org"
FILES=$(grep -irl "${SEARCH_STR}" api/)


for FILE in ${FILES}; do
  echo file: $FILE
  sed -i "s#${SEARCH_STR}#${REPL_STR}#" "${FILE}"
done

```