### PR TITLE
Add RAPIDS notices for gcc7 updates and release extension

### DIFF
--- a/_notices/rdn0001.md
+++ b/_notices/rdn0001.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rdn
 # Update meta-data for notice
 notice_id: 1 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "'dask-xgboost' is deprecated in v0.15 & removed v0.16"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rdn0002.md
+++ b/_notices/rdn0002.md
@@ -1,0 +1,118 @@
+---
+layout: notice
+parent: RAPIDS Developer Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rdn
+# Update meta-data for notice
+notice_id: 2 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Updates to from-source builds with conda for gcc '7.5.0'"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Build Change
+notice_rapids_version: "v0.18"
+notice_created: 2021-02-11
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-02-11
+---
+
+## Overview
+
+Recently `conda-forge` has switched to publish conda packages using the gcc/g++
+`9.3.0` build stack. RAPIDS `v0.18` has also switched to this build stack for
+our conda dependencies resulting in the following changes for developers.
+
+## Impact
+
+All from-source builds with conda dependencies for CUDA `10.1/10.2/11.0` using
+gcc `7.5.0` are affected and need changes to successfully build RAPIDS `v0.18+`
+
+>**NOTE:** CUDA `11.0` RAPIDS from-source builds with conda dependencies using
+gcc `9.3.0` are not impacted (CUDA `10.1/10.2` **do not** support gcc `9.3.0`
+for builds)
+
+### Ubuntu 16.04/18.04/20.04
+
+For all Ubuntu versions, we use this PPA to install gcc `7.5.0` and update the
+alternatives to set it as the default compiler:
+
+```
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install -y gcc-7 g++-7 libstdc++6
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
+sudo update-alternatives --set gcc /usr/bin/gcc-7
+sudo update-alternatives --set g++ /usr/bin/g++-7
+```
+>**NOTE:** The docker equivalent for this code can be found [here](https://github.com/rapidsai/gpuci-build-environment/blob/branch-0.18/rapidsai/devel.Dockerfile#L58-L68)
+
+
+With the install of gcc `7.5.0` and an updated `libstdc++6` pkg, you should be
+able to build RAPIDS from-source with conda dependencies. If you encounter any
+`GLIBC` errors during the build process, be sure the check the version of the
+`libstdc++6` package outlined below.
+
+**Check `libstdc++6` package version**
+
+In order to build with conda dependencies from `conda-forge` the installed
+`libstdc++6` package must be `>= 9.3.0`. You can verify the current installed
+version and available version through the following commands:
+
+```
+sudo apt-get update
+sudo apt-cache policy `libstdc++6`
+```
+
+If the version is not `>= 9.3.0` install the package again to update it:
+
+```
+sudo apt-get install libstdc++6
+```
+
+### CentOS 7/8 or RHEL 7/8
+
+For CentOS and RHEL we [build](https://github.com/rapidsai/gpuci-build-environment/blob/branch-0.18/builds-gcc7/Dockerfile.centos7)
+gcc `7.5.0` from source for our docker images and make it available as a
+tarball. Our public tarball is now patched to include a version of `libstdc++`
+from a gcc `9.3.0` build that allows from-source builds of RAPIDS with conda
+dependencies to work.
+
+**Installing our patched gcc `7.5.0`**
+
+Download and extract the tarball to the target machine or docker image. The
+tarball is meant to be extracted from the root and extracts into the following
+path: `/usr/local/gcc7`
+
+```
+sudo wget --quiet https://gpuci.s3.us-east-2.amazonaws.com/builds/gcc7.tgz -O /gcc7.tgz
+sudo tar xzf /gcc7.tgz
+sudo rm -f /gcc7.tgz
+```
+>**NOTE:** The docker equivalent for this code can be found [here](https://github.com/rapidsai/gpuci-build-environment/blob/branch-0.18/rapidsai/devel-centos7.Dockerfile#L118-L120)
+
+Once extracted, setup the environment variables to enable the use of the
+installed gcc `7.5.0`:
+
+```
+export GCC7_DIR=/usr/local/gcc7
+export CC=${GCC7_DIR}/bin/gcc
+export CXX=${GCC7_DIR}/bin/g++
+export CUDAHOSTCXX=${GCC7_DIR}/bin/g++
+export CUDA_HOME=/usr/local/cuda
+export LD_LIBRARY_PATH=${GCC7_DIR}/lib64:$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+export PATH=${GCC7_DIR}/bin:$PATH
+```
+>**NOTE:** The docker equivalent for this code can be found [here](https://github.com/rapidsai/gpuci-build-environment/blob/branch-0.18/rapidsai/devel-centos7.Dockerfile#L18-L24)
+
+From here all `./build.sh` scripts in RAPIDS repos should build without error.

--- a/_notices/rgn0005.md
+++ b/_notices/rgn0005.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 5 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Google Colab RAPIDS support limited to RAPIDS 0.14"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0008.md
+++ b/_notices/rgn0008.md
@@ -33,5 +33,5 @@ encountered in [RDN 2](/notices/rdn0002)
 
 - See our updated [release schedule]({% link maintainers/maintainers.md %}) for
 `v0.18`
-- Refer to [RDN 2](/notices/rdn0002) for more details on gcc `7.5.0` from-
-source build changes needed in `v0.18+`
+- Refer to [RDN 2](/notices/rdn0002) for more details on gcc `7.5.0`
+from-source build changes needed in `v0.18+`

--- a/_notices/rgn0008.md
+++ b/_notices/rgn0008.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 8 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v0.18 Release Extension"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.18"
+notice_created: 2021-02-11
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-02-11
+---
+
+## Overview
+
+The RAPIDS `v0.18` release date has been extended to 2021-02-24 due to issues
+encountered in [RDN 2](/notices/rdn0002)
+
+## Impact
+
+- See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+`v0.18`
+- Refer to [RDN 2](/notices/rdn0002) for more details on gcc `7.5.0` from-
+source build changes needed in `v0.18+`

--- a/_notices/rsn0002.md
+++ b/_notices/rsn0002.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 2 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "EOL Python 3.6 & CUDA 10.0 in v0.14"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -31,11 +31,11 @@ Phase | Start | End | Duration
 -- | -- | -- | --
 Development (cuDF/RMM) | Tue, Nov 24 | Tue, Jan 26 | 34 days
 Development (others) | Tue, Nov 24 | Tue, Feb 2 | 39 days
-Burn Down (cuDF/RMM) | Wed, Jan 27 | Tue, Feb 2 | 5 days
-Burn Down (others) | Wed, Feb 3 | Tue, Feb 9 | 5 days
-Code Freeze/Testing (cuDF/RMM) | Wed, Feb 3 | Tue, Feb 9 | 5 days
-Code Freeze/Testing (others) | Wed, Feb 10 | Tue, Feb 16 | 4 days
-Release | Wed, Feb 17 | Thu, Feb 18 | 2 days
+Burn Down (cuDF/RMM) | Wed, Jan 27 | Mon, Feb 15 | 13 days
+Burn Down (others) | Wed, Feb 3 | Mon, Feb 15 | 8 days
+Code Freeze/Testing (cuDF/RMM) | Tue, Feb 16 | Tue, Feb 23 | 6 days
+Code Freeze/Testing (others) | Tue, Feb 16 | Tue, Feb 23 | 6 days
+Release | Wed, Feb 24 | Thu, Feb 25 | 2 days
 
 ## _PROPOSED_ Release v0.19 Schedule
 

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -31,10 +31,10 @@ Phase | Start | End | Duration
 -- | -- | -- | --
 Development (cuDF/RMM) | Tue, Nov 24 | Tue, Jan 26 | 34 days
 Development (others) | Tue, Nov 24 | Tue, Feb 2 | 39 days
-Burn Down (cuDF/RMM) | Wed, Jan 27 | Mon, Feb 15 | 13 days
-Burn Down (others) | Wed, Feb 3 | Mon, Feb 15 | 8 days
-Code Freeze/Testing (cuDF/RMM) | Tue, Feb 16 | Tue, Feb 23 | 6 days
-Code Freeze/Testing (others) | Tue, Feb 16 | Tue, Feb 23 | 6 days
+Burn Down (cuDF/RMM) | Wed, Jan 27 | Tue, Feb 16 | 14 days
+Burn Down (others) | Wed, Feb 3 | Tue, Feb 16 | 9 days
+Code Freeze/Testing (cuDF/RMM) | Wed, Feb 17 | Tue, Feb 23 | 5 days
+Code Freeze/Testing (others) | Wed, Feb 17 | Tue, Feb 23 | 5 days
 Release | Wed, Feb 24 | Thu, Feb 25 | 2 days
 
 ## _PROPOSED_ Release v0.19 Schedule


### PR DESCRIPTION
- [x] Adds [RDN 2](https://deploy-preview-163--docs-rapids-ai.netlify.app/notices/rdn0002/) detailing gcc7 issues and updates needed for from-source builds
- [x] Adds [RGN 8](https://deploy-preview-163--docs-rapids-ai.netlify.app/notices/rgn0008/) detailing the release delay with an updated [schedule](https://deploy-preview-163--docs-rapids-ai.netlify.app/maintainers)