### PR TITLE
DOC Add RSN 5 announcing CUDA 10.X deprecation

### DIFF
--- a/_notices/rgn0008.md
+++ b/_notices/rgn0008.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 8 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "v0.18 Release Extension"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0005.md
+++ b/_notices/rsn0005.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 5 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Deprecation announcement for CUDA 10.1 & 10.2 in v0.19"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v0.19+"
+notice_created: 2021-02-25
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-02-25
+---
+
+## Overview
+
+`CUDA 10.1` & `10.2` will be deprecated in our upcoming release of `v0.19`
+scheduled for April 2021. After `v0.19` support will be dropped entirely for
+`CUDA 10.X`. More details will be released when they are available.
+
+## Impact
+
+Users should migrate to plan to move to `CUDA 11.0+` as soon as possible. More
+versions of `CUDA 11.X` will be supported in upcoming releases with further
+details shared in RSN notices as they become available.

--- a/_notices/rsn0005.md
+++ b/_notices/rsn0005.md
@@ -34,5 +34,5 @@ that support for `CUDA 10.X` may be dropped at any point.
 
 Users should plan to move to `CUDA 11.0+` as soon as possible. Future
 support of additinal `CUDA 11.X` versions are being worked on for upcoming
-releases. Further details shared in future RSN notices as they become
+releases. Further details will be shared in RSN notices as they become
 available.

--- a/_notices/rsn0005.md
+++ b/_notices/rsn0005.md
@@ -34,4 +34,5 @@ that support for `CUDA 10.X` may be dropped at any point.
 
 Users should plan to move to `CUDA 11.0+` as soon as possible. Future
 support of additinal `CUDA 11.X` versions are being worked on for upcoming
-releases. Further details shared in RSN notices as they become available.
+releases. Further details shared in future RSN notices as they become
+available.

--- a/_notices/rsn0005.md
+++ b/_notices/rsn0005.md
@@ -27,11 +27,11 @@ notice_updated: 2021-02-25
 ## Overview
 
 `CUDA 10.1` & `10.2` will be deprecated in our upcoming release of `v0.19`
-scheduled for April 2021. After `v0.19` support will be dropped entirely for
-`CUDA 10.X`. More details will be released when they are available.
+scheduled for April 2021. After the `v0.19` release, users should expect 
+that support for `CUDA 10.X` may be dropped at any point.
 
 ## Impact
 
-Users should migrate to plan to move to `CUDA 11.0+` as soon as possible. More
-versions of `CUDA 11.X` will be supported in upcoming releases with further
-details shared in RSN notices as they become available.
+Users should plan to move to `CUDA 11.0+` as soon as possible. Future
+support of additinal `CUDA 11.X` versions are being worked on for upcoming
+releases. Further details shared in RSN notices as they become available.


### PR DESCRIPTION
Add RAPIDS RSN notice for deprecation of CUDA 10.X starting in v0.19