### PR TITLE
Extend v0.19 release

### DIFF
--- a/_notices/rgn0009.md
+++ b/_notices/rgn0009.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 9 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v0.19 Release Extension"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v0.19"
+notice_created: 2021-04-14
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-04-14
+---
+
+## Overview
+
+The RAPIDS `v0.19` release date has been extended for 1 week to 21-Apr-2021.
+
+## Rationale
+
+The release is being extended in order to fix a [bug](https://github.com/rapidsai/cudf/issues/7114) in the parquet file reader.
+
+## Impact
+
+See our updated [release schedule]({% link maintainers/maintainers.md %}) for `v0.19`

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -34,8 +34,8 @@ Development (others) | Wed, Feb 3 | Wed, Mar 31 | 40 days
 [Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Mar 25 | Wed, Mar 31 | 5 days
 [Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Apr 1 | Wed, Apr 7 | 5 days
 [Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Apr 1 | Wed, Apr 7 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 8 | Tue, Apr 13 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Apr 14 | Thu, Apr 15 | 2 days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 8 | Tue, Apr 13 | 9 days
+[Release]({% link releases/process.md %}#releasing) | Wed, Apr 21 | Thu, Apr 22 | 2 days
 
 ## _PROPOSED_ Release v0.20 Schedule
 

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -34,7 +34,7 @@ Development (others) | Wed, Feb 3 | Wed, Mar 31 | 40 days
 [Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Mar 25 | Wed, Mar 31 | 5 days
 [Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Apr 1 | Wed, Apr 7 | 5 days
 [Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Apr 1 | Wed, Apr 7 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 8 | Tue, Apr 13 | 9 days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 8 | Tue, Apr 20 | 9 days
 [Release]({% link releases/process.md %}#releasing) | Wed, Apr 21 | Thu, Apr 22 | 2 days
 
 ## _PROPOSED_ Release v0.20 Schedule


### PR DESCRIPTION
Adds an RGN to notify about the release date extension. Also updates the release schedule with the new date.