### PR TITLE
Add notice for calver & dropping ubuntu 16.04

### DIFF
--- a/_notices/rgn0013.md
+++ b/_notices/rgn0013.md
@@ -7,7 +7,7 @@ notice_type: rgn
 # Update meta-data for notice
 notice_id: 13 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "RAPIDS switching to CalVer in v0.20"
+title: "RAPIDS switching to CalVer in v0.20 (now v21.06)"
 notice_author: RAPIDS Ops
 notice_status: In Progress
 notice_status_color: yellow
@@ -18,7 +18,7 @@ notice_status_color: yellow
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Release Version Change
-notice_rapids_version: "v0.20"
+notice_rapids_version: "v0.20 / v21.06"
 notice_created: 2021-05-05
 # 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2021-05-05
@@ -27,6 +27,8 @@ notice_updated: 2021-05-05
 ## Overview
 
 All RAPIDS projects are switching their versioning scheme to [Calendar Versioning](https://calver.org).
+
+This versioning will apply to both the overall RAPIDS release and each core library, so we will release `cuDF` `21.06.00`, `cuML` `21.06.00`, etc. as part of the overall RAPIDS `21.06.00` release.
 
 ## Impact
 

--- a/_notices/rgn0013.md
+++ b/_notices/rgn0013.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 13 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "RAPIDS switching to CalVer in v0.20"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Version Change
+notice_rapids_version: "v0.20"
+notice_created: 2021-05-05
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-05-05
+---
+
+## Overview
+
+All RAPIDS projects are switching versioning scheme to [Calendar Versioning](https://calver.org).
+
+## Impact
+
+Instead of a `0.20.0` release in June 2021, we will release `21.06.00`
+
+New version format for release: `YY.MM.PP`
+New version format for nightlies: `YY.MM.PPaYYMMDD`
+Where `PP` is the two digit patch number not day.

--- a/_notices/rgn0013.md
+++ b/_notices/rgn0013.md
@@ -26,12 +26,16 @@ notice_updated: 2021-05-05
 
 ## Overview
 
-All RAPIDS projects are switching versioning scheme to [Calendar Versioning](https://calver.org).
+All RAPIDS projects are switching their versioning scheme to [Calendar Versioning](https://calver.org).
 
 ## Impact
 
 Instead of a `0.20.0` release in June 2021, we will release `21.06.00`
 
-New version format for release: `YY.MM.PP`
-New version format for nightlies: `YY.MM.PPaYYMMDD`
+New version format for release: `YY.MM.PP`, for example `21.06.00`
+
+New version format for nightlies: `YY.MM.PPaYYMMDD`, for example `21.06.00a210505`
+
 Where `PP` is the two digit patch number not day.
+
+ABI & API compatibility will be maintained within each `YY.MM.xx` release.

--- a/_notices/rsn0008.md
+++ b/_notices/rsn0008.md
@@ -18,10 +18,10 @@ notice_status_color: green
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
-notice_rapids_version: "v0.20"
+notice_rapids_version: "v0.20 / v21.06"
 notice_created: 2021-04-29
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-04-29
+notice_updated: 2021-05-05
 ---
 
 ## Overview
@@ -32,7 +32,7 @@ This also aligns RAPIDS with the current conda-forge build stack.
 
 ## Status
 
-All `conda` builds and `docker` images use `gcc/g++ 9.3` starting with `v0.20`.
+All `conda` builds and `docker` images use `gcc/g++ 9.3` starting with `v0.20` (now `v21.06`).
 
 ## Impact
 

--- a/_notices/rsn0009.md
+++ b/_notices/rsn0009.md
@@ -1,0 +1,43 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 9 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Drop Ubuntu 16.04 in v0.20"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v0.20"
+notice_created: 2021-05-05
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-05-05
+---
+
+## Overview
+
+Ubuntu 16.04 is now at end-of-life, which means RAPIDS will no longer publish any images built on Ubuntu 16.04.
+
+Additionally, gpuCI CPU builds will be converted over to use CentOS 7 instead of Ubuntu 16.04.
+
+## Status
+
+Dropping full suport for Ubuntu 16.04 is on-going effort.
+
+## Impact
+
+Users should consider switching to any of the following supporting operating systems for any `rapidsai/rapidsai` image:
+  - Ubuntu 18.04
+  - Ubuntu 20.04
+  - CentOS 7
+  - CentOS 8

--- a/_notices/rsn0009.md
+++ b/_notices/rsn0009.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 9 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Drop Ubuntu 16.04 in v0.20"
+title: "Stop supporting Ubuntu 16.04 in v0.20/v21.06"
 notice_author: RAPIDS Ops
 notice_status: In Progress
 notice_status_color: yellow
@@ -32,11 +32,11 @@ Additionally, gpuCI CPU builds will be converted over to use CentOS 7 instead of
 
 ## Status
 
-Dropping full suport for Ubuntu 16.04 is on-going effort.
+Dropping full support for Ubuntu 16.04 is an ongoing effort.
 
 ## Impact
 
-Users should consider switching to any of the following supporting operating systems for any `rapidsai/rapidsai` image:
+Users should consider switching to any of the following supported operating systems for any `rapidsai/rapidsai` image:
   - Ubuntu 18.04
   - Ubuntu 20.04
   - CentOS 7

--- a/_notices/rsn0009.md
+++ b/_notices/rsn0009.md
@@ -18,7 +18,7 @@ notice_status_color: yellow
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
-notice_rapids_version: "v0.20"
+notice_rapids_version: "v0.20 / v21.06"
 notice_created: 2021-05-05
 # 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2021-05-05


### PR DESCRIPTION
Adds two new notices:
- Switch to CalVer
- Dropping Ubuntu 16.04