### PR TITLE
Add `--no-squash` flag to forward-merger instructions

### DIFF
--- a/maintainers/gpuci.md
+++ b/maintainers/gpuci.md
@@ -127,7 +127,7 @@ git pull <rapidsai remote>
 git checkout branch-{{ site.data.releases.nightly.version }}
 git pull <rapidsai remote>
 git checkout -b branch-{{ site.data.releases.nightly.version }}-merge-{{ site.data.releases.stable.version }}
-git merge branch-{{ site.data.releases.stable.version }}
+git merge --no-squash branch-{{ site.data.releases.stable.version }}
 # Fix any merge conflicts caused by this merge
 git commit -am "Merge branch-{{ site.data.releases.stable.version }} into branch-{{ site.data.releases.nightly.version }}"
 git push <personal fork> branch-{{ site.data.releases.nightly.version }}-merge-{{ site.data.releases.stable.version }}


### PR DESCRIPTION
This PR adds a `--no-squash` flag to the forward merger instructions to prevent squashed merges from occurring.