### PR TITLE
Updates to several RAPIDS Notices

### DIFF
--- a/_notices/rgn0011.md
+++ b/_notices/rgn0011.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 11 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "cuDF & cuXfilter v0.19.1 Hotfix Release"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rgn0014.md
+++ b/_notices/rgn0014.md
@@ -1,0 +1,39 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 14 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "cuML v21.06.02 Hotfix Release"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v21.06"
+notice_created: 2021-06-10
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-06-22
+---
+
+## Overview
+
+`cuML` was hotfixed to version `21.06.02`.
+
+## Rationale
+
+`cuML` was hotfixed (`21.06.01`) to fix a bug with batch sizes larger than 32 bits, [#3971](https://github.com/rapidsai/cuml/pull/3971).
+
+`cuML` was hotfixed (`21.06.02`) to fix a bug with missing OpenMP support, [#3988](https://github.com/rapidsai/cuml/issues/3988).
+
+## Impact
+
+All v21.06 users are encouraged to update `cuML` libraries to `21.06.02` as soon as possible.

--- a/_notices/rgn0015.md
+++ b/_notices/rgn0015.md
@@ -5,9 +5,9 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
-notice_id: 12 # should match notice number
-notice_pin: false # set to true to pin to notice page
-title: "cuDF v0.19.2 Hotfix Release"
+notice_id: 15 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "cuDF v21.06.01 Hotfix Release"
 notice_author: RAPIDS Ops
 notice_status: Completed
 notice_status_color: green
@@ -18,20 +18,20 @@ notice_status_color: green
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Release Change
-notice_rapids_version: "v0.19"
-notice_created: 2021-04-28
+notice_rapids_version: "v21.06"
+notice_created: 2021-06-17
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-04-28
+notice_updated: 2021-06-22
 ---
 
 ## Overview
 
-`cuDF` was hotfixed to version `0.19.2`.
+`cuDF` was hotfixed to version `21.06.01`.
 
 ## Rationale
 
-`cuDF` was hotfixed to fix a deadlock that could occur in decompression in cuIO, [#8073](https://github.com/rapidsai/cudf/pull/8073).
+`cuDF` was hotfixed to fix an offset error when reading ORC files which lead to corrupted data, [#8538](https://github.com/rapidsai/cudf/pull/8538).
 
 ## Impact
 
-All v0.19 users are encouraged to update `cudf` libraries to `0.19.2` as soon as possible.
+All v21.06 users are encouraged to update `cuDF` libraries to `21.06.01` as soon as possible.

--- a/_notices/rgn0015.md
+++ b/_notices/rgn0015.md
@@ -30,7 +30,7 @@ notice_updated: 2021-06-22
 
 ## Rationale
 
-`cuDF` was hotfixed to fix an offset error when reading ORC files which lead to corrupted data, [#8538](https://github.com/rapidsai/cudf/pull/8538).
+`cuDF` was hotfixed to fix an offset error which could lead to data corruption when writing ORC files with multiple large string columns, [#8538](https://github.com/rapidsai/cudf/pull/8538).
 
 ## Impact
 

--- a/_notices/rsn0006.md
+++ b/_notices/rsn0006.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 6 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "EOL CUDA 10.1 & 10.2 in v0.19"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0007.md
+++ b/_notices/rsn0007.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 7 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Support for CUDA 11.2 in v0.19"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0009.md
+++ b/_notices/rsn0009.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 9 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Stop supporting Ubuntu 16.04 in v0.20/v21.06"
+title: "Stop supporting Ubuntu 16.04 in v21.08"
 notice_author: RAPIDS Ops
 notice_status: In Progress
 notice_status_color: yellow
@@ -18,10 +18,10 @@ notice_status_color: yellow
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
-notice_rapids_version: "v0.20 / v21.06"
+notice_rapids_version: "v21.08"
 notice_created: 2021-05-05
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-05-05
+notice_updated: 2021-06-22
 ---
 
 ## Overview


### PR DESCRIPTION
Demotes several notices from being pinned

Adds a notice for cuml & cudf hotfixes.

Updates the Ubuntu 16.04 notice to be in 21.08.