### PR TITLE
Update release process

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,13 +8,14 @@ baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://docs.rapids.ai"
 
 permalink: pretty
-exclude: 
+exclude:
   - CONTRIBUTING.md
   - README.md
   - release_checklist.md
   - customization/
   - update_symlinks.sh
   - _config_ignore_api.yml
+  - rm_old_docs.sh
 include:
   - _sources
   - _static
@@ -52,4 +53,3 @@ plugins:
 
 # Enable or disable the site search
 search_enabled: true
-

--- a/_config_ignore_api.yml
+++ b/_config_ignore_api.yml
@@ -16,6 +16,7 @@ exclude:
   - update_symlinks.sh
   - _config_ignore_api.yml
   - api/
+  - rm_old_docs.sh
 include:
   - _sources
   - _static
@@ -53,4 +54,3 @@ plugins:
 
 # Enable or disable the site search
 search_enabled: true
-

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -17,5 +17,5 @@ customization/customize_docs_in_folder.sh api/
 
 ```
 
-- **Delete Old Docs & Tag Release**: Run the Jenkins job below after the release PR is merged to delete old docs and tag new release
-  - <https://gpuci.gpuopenanalytics.com/job/rapidsai/job/doc-builds/job/docs-release/>
+- **Remove old docs** - Use [rm_old_docs.sh](/rm_old_docs.sh) script to remove previous legacy docs
+- **Tag Commit** - After the release PR is merged, tag the commit so it appears on the release page - https://github.com/rapidsai/docs/releases

--- a/rm_old_docs.sh
+++ b/rm_old_docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "A script to help delete old versions of RAPIDS docs"
+  echo "Example:"
+  echo "  rm_old_versions.sh 21.06"
+  exit 1
+fi
+
+VERSION=$1
+
+for FOLDER in api/*/ ; do
+  rm -rf "${FOLDER}${VERSION}"
+done


### PR DESCRIPTION
This PR adds some steps to the release process so that the previously used Jenkins job can be deleted. Since updating the site is a manual process anyway, I think it makes sense to add these two trivial steps here rather than have a separate Jenkins job to maintain.