### PR TITLE
Updated always shows N/A

### DIFF
--- a/_layouts/notice.html
+++ b/_layouts/notice.html
@@ -27,7 +27,7 @@ layout: default
     </tr>
     <tr>
       <td><strong>Updated</strong></td>
-      <td>{% if notice.notice_updated != null and notice.notice_created != notice.notice_updated %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}</td>
+      <td>{% if page.notice_updated != null and page.notice_created != page.notice_updated %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fixes the `notice_updated` references so that the update date will show instead of always being N/A