### PR TITLE
[REVIEW] Notice for 21.08 hotfix

### DIFF
--- a/_notices/rgn0016.md
+++ b/_notices/rgn0016.md
@@ -1,0 +1,39 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 16 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "cuCIM and cuDF 21.08.01 Hotfix Release"
+notice_author: RAPIDS TPM
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v21.08"
+notice_created: 2021-08-09
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-08-09
+---
+
+## Overview
+
+`cuCIM` and `cuDF` were hotfixed to version `21.08.01`.
+
+## Rationale
+
+`cucim` was hotfixed to `21.08.01` in order to ensure the compiler stack aligned with the rest of RAPIDS, [#84](https://github.com/rapidsai/cucim/pull/84).
+
+`cudf` was hotfixed to `21.08.01` in order to fix a bug ([#8984](https://github.com/rapidsai/cudf/pull/8984)) and a performance degradation in concatenate for string columns ([#8968](https://github.com/rapidsai/cudf/pull/8968)).
+
+## Impact
+
+All v21.08 users are encouraged to update `cuCIM` and `cuDF` libraries to `21.08.01` as soon as possible.

--- a/_notices/rgn0016.md
+++ b/_notices/rgn0016.md
@@ -32,7 +32,7 @@ notice_updated: 2021-08-09
 
 `cucim` was hotfixed to `21.08.01` in order to ensure the compiler stack aligned with the rest of RAPIDS, [#84](https://github.com/rapidsai/cucim/pull/84).
 
-`cudf` was hotfixed to `21.08.01` in order to fix a bug ([#8984](https://github.com/rapidsai/cudf/pull/8984)) and a performance degradation in concatenate for string columns ([#8968](https://github.com/rapidsai/cudf/pull/8968)).
+`cudf` was hotfixed to `21.08.01` in order to fix the bug, [#8984](https://github.com/rapidsai/cudf/pull/8984) and performance degradation in concatenate for string columns, [#8968](https://github.com/rapidsai/cudf/pull/8968).
 
 ## Impact
 

--- a/_notices/rgn0017.md
+++ b/_notices/rgn0017.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 17 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Hotfix release for five libraries"
+notice_author: RAPIDS TPM
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v21.08"
+notice_created: 2021-08-09
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-08-09
+---
+
+## Overview
+
+Four RAPIDSai libraires were hotfixed to version `21.08.01` and cuDF was hotfixed to version `21.08.02`.
+
+## Rationale
+
+`rmm`, `cuml`, `cugraph`, and `cuspatial` were hotfixed to `21.08.01`. `cudf` was hotfixed to `21.08.02`. These five libraries were hotfixed in order to fix the conda package location of the CMake configuration files, [#56](https://github.com/rapidsai/rapids-cmake/issues/56).
+
+## Impact
+
+All v21.08 users are encouraged to update `rmm`, `cuml`, `cugraph`, and `cuspatial` libraries to `21.08.01` and `cuDF` to `21.08.02` as soon as possible.

--- a/_notices/rgn0017.md
+++ b/_notices/rgn0017.md
@@ -26,7 +26,7 @@ notice_updated: 2021-08-09
 
 ## Overview
 
-Four RAPIDS libraires were hotfixed to version `21.08.01` and cuDF was hotfixed to version `21.08.02`.
+Four RAPIDS libraries were hotfixed to version `21.08.01` and cuDF was hotfixed to version `21.08.02`.
 
 ## Rationale
 

--- a/_notices/rgn0017.md
+++ b/_notices/rgn0017.md
@@ -7,7 +7,7 @@ notice_type: rgn
 # Update meta-data for notice
 notice_id: 17 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Hotfix release for five libraries"
+title: "Hotfix 21.08 release for five libraries"
 notice_author: RAPIDS TPM
 notice_status: Completed
 notice_status_color: green
@@ -26,7 +26,7 @@ notice_updated: 2021-08-09
 
 ## Overview
 
-Four RAPIDSai libraires were hotfixed to version `21.08.01` and cuDF was hotfixed to version `21.08.02`.
+Four RAPIDS libraires were hotfixed to version `21.08.01` and cuDF was hotfixed to version `21.08.02`.
 
 ## Rationale
 


### PR DESCRIPTION
Two new notices added for:
- `cudf` and `cucim` hotfix to v21.08.01
- `cudf` (v21.08.02), `rmm`, `cuml`, `cugraph`, and `cuspatial` (v21.08.01)