### PR TITLE
[REVIEW] ENH Add rapids-cmake docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -172,3 +172,14 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
+  rapids-cmake:
+    name: rapids-cmake
+    path: rapids-cmake
+    desc: "This is a collection of CMake modules that are useful for all CUDA RAPIDS projects. By sharing the code in a single place it makes rolling out CMake fixes easier."
+    ghlink: https://github.com/rapidsai/rapids-cmake
+    cllink: https://github.com/rapidsai/rapids-cmake/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1


### PR DESCRIPTION
Adds `rapids-cmake` to RAPIDS docs site. API html here: https://github.com/rapidsai/docs/tree/gh-pages/api/rapids-cmake