### PR TITLE
Add CUDA Enhanced Compatibility & `devel` Container Notices

### DIFF
--- a/_notices/rdn0003.md
+++ b/_notices/rdn0003.md
@@ -1,0 +1,29 @@
+---
+layout: notice
+parent: RAPIDS Developer Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rdn
+# Update meta-data for notice
+notice_id: 3 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Devel Container Release Change"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v21.12"
+notice_created: 2021-11-18
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-11-18
+---
+
+## Overview
+
+RAPIDS `devel` containers will only support CUDA `11.5` effective with the `21.12` release.

--- a/_notices/rdn0003.md
+++ b/_notices/rdn0003.md
@@ -26,4 +26,4 @@ notice_updated: 2021-11-18
 
 ## Overview
 
-RAPIDS `devel` containers will only support CUDA `11.5` effective with the `21.12` release.
+Effective with the `21.12` release, RAPIDS `devel` packages will only be distributed for CUDA `11.5`.

--- a/_notices/rgn0019.md
+++ b/_notices/rgn0019.md
@@ -1,0 +1,33 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 19 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "CUDA Enhanced Compatibility"
+notice_author: RAPIDS TPM
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Build Change
+notice_rapids_version: "v21.12"
+notice_created: 2021-11-18
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2021-11-18
+---
+
+## Overview
+
+RAPIDS `21.12` packages will be built using the latest `11.5` version of `nvcc` and the CUDA runtime and distributed for use with any CUDA driver `>=450.80.02` via the use of CUDA Enhanced Compatibility. We strongly recommend using the CUDA `11.5` runtime. Any runtime `>=11.0` and `<11.5` is supported on a best-effort basis.
+
+## Impact
+
+One limitation this poses for users running older minor versions of the CUDA runtime is that the use of `debug=True` with the numba `@cuda.jit` decorator will result in a runtime error. Users running `11.5` will still be able to use `debug=True`.


### PR DESCRIPTION
This PR adds two RAPIDS notices. One about CUDA Enhanced Compatibility and the other about the changes to the `devel` containers.