### PR TITLE
Clarify EOL of Python 3.7 ends with 22.02 Nightly and add Support for Python 3.9

### DIFF
--- a/_notices/rsn0014.md
+++ b/_notices/rsn0014.md
@@ -21,14 +21,14 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v22.02"
 notice_created: 2022-02-03
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2022-02-03
+notice_updated: 2022-02-04
 ---
 
 ## Overview
 
 `Python 3.7` has reached end of life (EOL) in RAPIDS `v22.02` and will
-not be supported in the upcoming release of `v22.04`. This includes `v22.04`
-nightly support which ends on 2022-02-03.
+not be supported in the `v22.02` stable release nor the upcoming release of `v22.04`. This includes `v22.02`
+nightly support which ended on 2022-02-03.
 
 ​
 ## Status

--- a/_notices/rsn0015.md
+++ b/_notices/rsn0015.md
@@ -1,0 +1,40 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 15 # should match notice number
+notice_pin: false # set to true to pin to notice page
+title: "Support for Python 3.9 in v22.02"
+notice_author: RAPIDS Ops
+notice_status: Completed
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.02"
+notice_created: 2022-02-04
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-02-04
+---
+
+## Overview
+
+With the EOL of `Python 3.7` announced in [RSN 14](/notices/rsn0014), development
+effort has been redirected to support `Python 3.9` in `v22.02` stable and `v22.04` nightly releases.
+
+## Status
+
+- `Python 3.9` nightly support started on 04-Feb-2022 for both `conda` and
+`docker`
+
+## Impact
+
+Users are encouraged to test nightly `conda` and `docker` builds and report any
+issues in their respective repos.


### PR DESCRIPTION
Updated RSN0014 to clarify that Python 3.7 EOL to include not being in 22.02 stable, but ended with 22.02 nightly