### PR TITLE
completed-updated-notices

### DIFF
--- a/_notices/rsn0009.md
+++ b/_notices/rsn0009.md
@@ -9,8 +9,8 @@ notice_id: 9 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Stop supporting Ubuntu 16.04 in v21.08"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v21.08"
 notice_created: 2021-05-05
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-06-22
+notice_updated: 2022-02-17
 ---
 
 ## Overview

--- a/_notices/rsn0010.md
+++ b/_notices/rsn0010.md
@@ -9,8 +9,8 @@ notice_id: 10 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Support for CUDA 11.4 in v21.08"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v21.08+"
 notice_created: 2021-07-09
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-07-28
+notice_updated: 2022-02-17
 ---
 
 ## Overview

--- a/_notices/rsn0012.md
+++ b/_notices/rsn0012.md
@@ -9,8 +9,8 @@ notice_id: 12 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "SQL migration in v21.12"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v21.12+"
 notice_created: 2021-10-13
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2021-10-13
+notice_updated: 2022-02-17
 ---
 
 ## Overview


### PR DESCRIPTION
Completed RSN notices for "Stop supporting Ubuntu 16.04 in v21.08". "Support for CUDA 11.4 in v21.08", and "SQL migration in v21.12". 