### PR TITLE
Add `raft` to docs site

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -112,6 +112,17 @@ apis:
       legacy: 0
       stable: 0
       nightly: 1
+  raft:
+    name: RAFT
+    path: raft
+    desc: "RAFT contains fundamental widely-used algorithms and primitives for data science, graph and machine learning. The algorithms are CUDA-accelerated and form building-blocks for rapidly composing analytics."
+    ghlink: https://github.com/rapidsai/raft
+    cllink: https://github.com/rapidsai/raft/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1
   dask-cuda:
     name: Dask-CUDA
     path: dask-cuda


### PR DESCRIPTION
This PR adds `raft` to the docs site.