### PR TITLE
Add `libcuspatial` to docs page

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -172,6 +172,17 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
+  libcuspatial:
+    name: libcuspatial
+    path: libcuspatial
+    desc: 'libcuspatial is a GPU accelerated C/C++ library for accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
+    ghlink: https://github.com/rapidsai/cuspatial
+    cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1
   libcuml:
     name: libcuml
     path: libcuml


### PR DESCRIPTION
This PR adds `libcuspatial` to the docs index page since they've recently started publishing documentation.