### PR TITLE
release update

### DIFF
--- a/_notices/rgn0026.md
+++ b/_notices/rgn0026.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS General Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rgn
+# Update meta-data for notice
+notice_id: 26 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "v22.06 Release Update"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Release Change
+notice_rapids_version: "v22.06"
+notice_created: 2022-06-07
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-06-07
+---
+
+## Overview
+
+`v22.06 Release Update`.
+
+## Rationale
+
+`22.06 release will be bifurcated--all containers other than devel going out on schedule on Wednesdy 6/8/22, with devel containers coming next week on Wednesday 6/15/22.
+
+## Impact
+
+N/A

--- a/_notices/rgn0026.md
+++ b/_notices/rgn0026.md
@@ -30,7 +30,7 @@ notice_updated: 2022-06-07
 
 ## Rationale
 
-`22.06 release will be bifurcated--all containers other than devel going out on schedule on Wednesday 6/8/22, with devel containers coming next week on Wednesday 6/15/22.
+22.06 release artifacts will be bifurcated--conda packages and `base` containers (i.e. those other than `devel`) will be released on Wednesday 6/8/22. `devel` containers will be released on Wednesday 6/15/22.
 
 ## Impact
 

--- a/_notices/rgn0026.md
+++ b/_notices/rgn0026.md
@@ -26,7 +26,7 @@ notice_updated: 2022-06-07
 
 ## Overview
 
-`v22.06 Release Update`.
+22.06 `devel` containers will be released on Wednesday 6/15/22. Conda packages and `base` container release dates will remain unchanged.
 
 ## Rationale
 

--- a/_notices/rgn0026.md
+++ b/_notices/rgn0026.md
@@ -30,7 +30,7 @@ notice_updated: 2022-06-07
 
 ## Rationale
 
-`22.06 release will be bifurcated--all containers other than devel going out on schedule on Wednesdy 6/8/22, with devel containers coming next week on Wednesday 6/15/22.
+`22.06 release will be bifurcated--all containers other than devel going out on schedule on Wednesday 6/8/22, with devel containers coming next week on Wednesday 6/15/22.
 
 ## Impact
 


### PR DESCRIPTION
22.06 release will be bifurcated--all containers other than devel going out on schedule on Wednesday 6/8/22, with devel containers coming next week on Wednesday 6/15/22.
