### PR TITLE
Remove `body` `background-color` style from `custom.css`

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -183,7 +183,6 @@ body {
   font-size: inherit;
   line-height: 1.4;
   color: #5c5962;
-  background-color: #fff;
 }
 
 h1,


### PR DESCRIPTION
This PR removes the `background-color` style for the `body` element from our `custom.css` file. I'm not sure why we are overriding the `background-color` style (the `git` history didn't shed any light), but it seems to be causing issues related to #284.

Seems to be safe to remove.