### PR TITLE
Add CubinLinker license

### DIFF
--- a/licenses/CubinLinker.txt
+++ b/licenses/CubinLinker.txt
@@ -1,0 +1,139 @@
+NVIDIA SOFTWARE LICENSE
+=======================
+
+This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA")
+and governs your use of the NVIDIA CubinLinker software and materials provided
+hereunder (“SOFTWARE”).
+
+By taking delivery of the SOFTWARE, you affirm that you have reached the legal
+age of majority, you accept the terms of this license, and you take legal and
+financial responsibility for the actions of your permitted users. 
+
+You agree to use the SOFTWARE only for purposes that are permitted by
+
+(a) this license, and 
+(b) any applicable law, regulation or generally accepted practices or guidelines
+    in the relevant jurisdictions.
+
+
+1. LICENSE. Subject to the terms of this license, NVIDIA grants you a
+   revocable, non-exclusive limited license to:
+
+   (a) install and use the SOFTWARE, and
+   (b) distribute the SOFTWARE subject to the distribution requirements
+       described in this license. NVIDIA reserves all rights, title and
+       interest in and to the SOFTWARE not expressly granted to you under this
+       license.
+
+2. DISTRIBUTION REQUIREMENTS. These are the distribution requirements for you
+   to exercise the distribution grant:
+
+   a. The terms under which you distribute the SOFTWARE must be consistent with
+      the terms of this license, including (without limitation) terms relating
+      to the license grant and license restrictions and protection of NVIDIA’s
+      intellectual property rights.
+   b. You agree to notify NVIDIA in writing of any known or suspected
+      distribution or use of the SOFTWARE not in compliance with the
+      requirements of this license, and to enforce the terms of your agreements
+      with respect to distributed SOFTWARE. 
+
+3. LIMITATIONS. Your license to use the SOFTWARE is restricted as follows:
+
+   a. The SOFTWARE is licensed for you to develop applications only for use in
+      systems with NVIDIA GPUs.
+   b. You may not reverse engineer, decompile or disassemble, modify, create
+      derivative works of, remove copyright or other proprietary notices from
+      any portion of the SOFTWARE or copies of the SOFTWARE.
+   c. You may not bypass, disable, or circumvent any technical measure,
+      encryption, security, digital rights management or authentication
+      mechanism in the SOFTWARE.
+   d. You may not use the SOFTWARE in any manner that would cause it to become
+      subject to an open source software license. As examples, licenses that
+      require as a condition of use, modification, and/or distribution that the
+      SOFTWARE be
+
+      (i) disclosed or distributed in source code form;
+      (ii) licensed for the purpose of making derivative works; or
+      (iii) redistributable at no charge.
+
+4. OWNERSHIP. The SOFTWARE and the related intellectual property rights therein
+   are and will remain the sole and exclusive property of NVIDIA or its
+   licensors. 
+
+5. FEEDBACK. You may, but are not obligated to, provide Feedback to NVIDIA.
+   “Feedback” means all suggestions, fixes, modifications, feature requests or
+   other feedback regarding the SDK. Feedback, even if designated as
+   confidential by you, shall not create any confidentiality obligation for
+   NVIDIA. NVIDIA and its designees have a perpetual, non-exclusive, worldwide,
+   irrevocable license to use, reproduce, publicly display, modify, create
+   derivative works of, license, sublicense, and otherwise distribute and
+   exploit Feedback as NVIDIA sees fit without payment and without obligation
+   or restriction of any kind on account of intellectual property rights or
+   otherwise.
+
+6. NO WARRANTIES. THE SOFTWARE IS PROVIDED "AS IS" WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTY OF ANY KIND INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF
+   MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE.
+   NVIDIA DOES NOT WARRANT THAT THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR
+   THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR THAT ALL
+   ERRORS WILL BE CORRECTED. 
+
+7. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND
+   ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR
+   CONSEQUENTIAL DAMAGES, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR
+   THE USE OR PERFORMANCE OF THE SOFTWARE, WHETHER SUCH LIABILITY ARISES FROM
+   ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING
+   NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF
+   LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD
+   REASONABLY HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL
+   NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT
+   OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER
+   OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT. 
+
+8. TERMINATION. Your rights under this license will terminate automatically
+   without notice from NVIDIA if you fail to comply with any term and condition
+   of this license or if you commence or participate in any legal proceeding
+   against NVIDIA with respect to the SOFTWARE. Additionally, NVIDIA may
+   terminate this license with advance written notice to you. Upon any
+   termination of this license, you agree to promptly discontinue use of the
+   SOFTWARE and destroy all copies in your possession or control. Your prior
+   distributions in accordance with this license are not affected by the
+   termination of this license. All provisions of this license will survive
+   termination, except for the license granted to you. 
+
+9. APPLICABLE LAW. This license will be governed in all respects by the laws of
+   the United States and of the State of Delaware, without regard to the
+   conflicts of laws principles. The United Nations Convention on Contracts for
+   the International Sale of Goods is specifically disclaimed. The state or
+   federal courts residing in Santa Clara County, California shall have
+   exclusive jurisdiction over any dispute or claim arising out of this
+   license.  Notwithstanding this, you agree that NVIDIA shall still be allowed
+   to apply for injunctive remedies or an equivalent type of urgent legal
+   relief in any jurisdiction. 
+
+10. NO ASSIGNMENT. This license and your rights and obligations thereunder may
+    not be assigned by you by any means or operation of law without NVIDIA’s
+    permission. Any attempted assignment not approved by NVIDIA in writing
+    shall be void and of no effect. 
+ 
+11. EXPORT. The SOFTWARE is subject to United States export laws and
+    regulations. You agree that you will not ship, transfer or export the
+    SOFTWARE into any country, or use the SOFTWARE in any manner, prohibited by
+    the United States Bureau of Industry and Security or economic sanctions
+    regulations administered by the U.S. Department of Treasury’s Office of
+    Foreign Assets Control (OFAC), or any applicable export laws, restrictions
+    or regulations.  These laws include restrictions on destinations, end users
+    and end use. By accepting this license, you confirm that you are not a
+    resident or citizen of any country currently embargoed by the U.S. and that
+    you are not otherwise prohibited from receiving the SOFTWARE.
+
+12. ENTIRE AGREEMENT. This license is the final, complete and exclusive
+    agreement between the parties relating to the subject matter of this
+    license and supersedes all prior or contemporaneous understandings and
+    agreements relating to this subject matter, whether oral or written. If any
+    court of competent jurisdiction determines that any provision of this
+    license is illegal, invalid or unenforceable, the remaining provisions will
+    remain in full force and effect. This license may only be modified in a
+    writing signed by an authorized representative of each party.
+
+(v. July 28, 2022)


### PR DESCRIPTION
CubinLinker will support linking cubins with Minor Version Compatibility (MVC) so that [String UDFs](https://github.com/rapidsai/cudf/pull/11319) and other functionality can be supported with MVC - an additional function on top of what [PTXCompiler](https://github.com/rapidsai/ptxcompiler) does. When it is released, it will be under the CubinLinker License Agreement. Installation of the CubinLinker conda package must print out a message stating:

> By downloading and using the MVCLinker conda packages, you accept the terms and conditions of the MVCLinker License Agreement: [https://docs.rapids.ai/licenses/MVCLinker.txt](https://docs.rapids.ai/licenses/MVCLinker.txt)

This PR adds the text of the CubinLinker license agreement at the URL specified above.