### PR TITLE
Redirect /deployment to /deployment/stable

### DIFF
--- a/deployment/index.html
+++ b/deployment/index.html
@@ -1,0 +1,16 @@
+<html>
+
+<head>
+    <meta http-equiv="refresh" content="3; URL=https://docs.rapids.ai/deployment/stable" />
+</head>
+
+<body>
+    <p>
+        Redirecting to stable docs.
+    </p>
+    <p>
+        If you are not redirected in three seconds, <a href="https://docs.rapids.ai/deployment/stable">click here</a>.
+    </p>
+</body>
+
+</html>


### PR DESCRIPTION
Adding a quick redirect from `/deployment` to `/deployment/stable`.

cc @ajschmidt8 @bdice