### PR TITLE
Update GH Actions Docs & Add `Recently Updated` Check Page

### DIFF
--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -7,18 +7,27 @@ title: GitHub Actions
 ---
 
 # {{ page.title }}
+{:.no_toc}
 
 ## Overview
+{:.no_toc}
 
 The RAPIDS team is in the process of migrating from Jenkins to GitHub Actions for CI/CD. The page below outlines some helpful information pertaining to the implementation of GitHub Actions provided by the RAPIDS Ops team. The official GitHub documentation for GitHub Actions is also useful and can be viewed [here](https://docs.github.com/en/actions).
 
 ### Intended audience
+{: .no_toc }
 
 Operations
 {: .label .label-purple}
 
 Developers
 {: .label .label-green}
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
 
 ## Implementation
 

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -39,7 +39,7 @@ The gist of the strategy is that the source code from trusted pull requests can 
 
 Pull requests authored by members of the given GitHub organization are considered trusted and therefore are copied to a `pull-request/*` branch for testing automatically.
 
-Pull requests from authors outside of the GitHub organization must first be reviewed by a repository member with `write` permissions (or greater) to ensure that the code changes are legitimate and benign. That reviewer must leave an `/ok to test` (or `/okay to test`) comment on the pull request before it's code is copied to a `pull-request/*` branch for testing.
+Pull requests from authors outside of the GitHub organization must first be reviewed by a repository member with `write` permissions (or greater) to ensure that the code changes are legitimate and benign. That reviewer must leave an `/ok to test` (or `/okay to test`) comment on the pull request before its code is copied to a `pull-request/*` branch for testing.
 
 The `/ok to test` comment is only valid for a single commit. Subsequent commits must be re-reviewed and validated with another `/ok to test` comment.
 

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -54,6 +54,8 @@ git config \
   '^refs/heads/pull-request/*'
 ```
 
+Note that this `git` configuration option requires `git` version `2.29` or greater to support negative refspecs ([source](https://github.blog/2020-10-19-git-2-29-released/#user-content-negative-refspecs)).
+
 ### Skipping CI for Commits
 
 See the GitHub Actions document page below on how to prevent GitHub Actions from running on certain commits. This is useful for preventing GitHub Actions from running on pull requests that are not fully complete. This also helps preserve the finite GPU resources provided by the RAPIDS Ops team.

--- a/resources/recently-updated.md
+++ b/resources/recently-updated.md
@@ -1,0 +1,54 @@
+---
+layout: default
+nav_order: 6
+parent: Resources
+grand_parent: RAPIDS Maintainer Docs
+title: Recently Updated Check
+---
+
+# _Recently Updated_ Check
+
+## Overview
+
+Summary of _Recently Updated_ GitHub check used by some RAPIDS projects.
+
+### Intended audience
+
+Community
+{: .label .label-yellow}
+
+Developers
+{: .label .label-green}
+
+Project Leads
+{: .label .label-blue}
+
+Operations
+{: .label .label-purple}
+
+## Summary
+
+GitHub Actions are configured to run tests on the _HEAD_ commit of pull requests (e.g. not the pull request's merge commit, which would be the result of merging the pull request into the target branch).
+
+Therefore, if a pull request is not up-to-date with the latest changes in the source repository, there is a possibility that breaking changes could be introduced even if the CI tests are passing.
+
+GitHub does provide a way to ensure that pull requests are entirely up-to-date before merging, but for high volume repositories like `cudf`, this would dramatically increase the amount of time it takes to get a pull request merged.
+
+As a compromise, the _Recently Updated_ check has been introduced to ensure that pull requests are "reasonably up-to-date" with the corresponding source repository.
+
+This method doesn't guarantee that breaking changes will not be introduced, but it does help provide some assurances that pull requests aren't significantly out-of-date (similar to how testing merge commits work).
+
+Additional testing confidence comes from RAPIDS' nightly testing, which tests the _HEAD_ commit of each development branch.
+
+The _Recently Updated_ check is configurable by editing the following values in the `.github/ops-bot.yaml` file:
+
+```yaml
+# enables/disables the Recently Updated Check
+recently_updated: true
+
+# sets the threshold for how many commits behind the pull request must be to trigger a failure.
+# defaults to 5 if not set
+recently_updated_threshold: 5
+```
+
+Note that since RAPIDS uses squash commits for pull requests, the `recently_updated_threshold` value effectively means "how many pull requests have been merge into the source repository since the current pull request has last been updated".


### PR DESCRIPTION
This PR updates the GitHub Action doc page and also adds a page for the new _Recently Updated_ check.