### PR TITLE
Remove Google Groups

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,10 +35,6 @@ nav_external_links:
     url: /deployment/stable/
 
 social:
-  google-groups:
-    name: Google Groups
-    url: https://groups.google.com/forum/#!forum/rapidsai
-    fa-icon-class: fas fa-users
   twitter:
     name: Twitter
     username: rapidsai

--- a/_config_ignore_api.yml
+++ b/_config_ignore_api.yml
@@ -21,6 +21,7 @@ include:
   - _sources
   - _static
   - _images
+  - _sphinx_javascript_frameworks_compat.js
 
 collections:
   notices:
@@ -30,11 +31,11 @@ aux_links:
   "View Docs on GitHub":
     - "https://github.com/rapidsai/docs"
 
+nav_external_links:
+  - title: Deployment
+    url: /deployment/stable/
+
 social:
-  google-groups:
-    name: Google Groups
-    url: https://groups.google.com/forum/#!forum/rapidsai
-    fa-icon-class: fas fa-users
   twitter:
     name: Twitter
     username: rapidsai
@@ -42,7 +43,7 @@ social:
     fa-icon-class: fab fa-twitter
   slack:
     name: Slack
-    url: https://join.slack.com/t/rapids-goai/shared_invite/zt-h54mq1uv-KHeHDVCYs8xvZO5AB~ctTQ
+    url: https://join.slack.com/t/rapids-goai/shared_invite/zt-trnsul8g-Sblci8dk6dIoEeGpoFcFOQ
     fa-icon-class: fab fa-slack
   stack-overflow:
     name: Stack Overflow


### PR DESCRIPTION
The Google Group for rapidsai is shutting down October 31, 2022. https://groups.google.com/g/rapidsai/c/kxQufCW1NeU

This PR removes references to that Google Group from the website.

I also updated the `_config_ignore_api.yml` to match recent changes in `_config.yml`.

cc: @robocopnixon