### PR TITLE
add-drop-ubuntu-python support v22.12 and v23.02

### DIFF
--- a/_notices/rsn0022.md
+++ b/_notices/rsn0022.md
@@ -1,0 +1,53 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 22 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "EOL Python 3.8 in v22.12"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.12"
+notice_created: 2022-11-21
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-11-21
+---
+
+## Overview
+
+`Python 3.8` has reached end of life (EOL) in RAPIDS `v22.12` and will
+not be supported in the `v22.12` stable release nor the upcoming release of `v23.02`. This includes `v22.12`
+nightly support which ended on 2022-12-08.
+
+​
+## Status
+​
+### Release support - `v22.12`
+​
+- Final release of `conda` packages or `docker` images supporting `Python 3.8`
+​
+### Nightly support - `v23.02`
+​
+- No further `conda` packages or `docker` images supported for `Python 3.8`
+​
+### Documentation
+​
+- Updates to Docker Hub and NGC repos will be reflected with the `v22.12` release
+- Updated [rapids.ai](https://rapids.ai/start#rapids-release-selector) release
+selector to reflect EOL changes and available install options
+​
+## Impact
+​
+Users should migrate to `Python 3.9` or `Python 3.10` for RAPIDS.
+

--- a/_notices/rsn0023.md
+++ b/_notices/rsn0023.md
@@ -1,0 +1,40 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 23 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Support for Python 3.10 in v22.12"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.12+"
+notice_created: 2022-11-21
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-11-21
+---
+
+## Overview
+
+With the EOL of `Python 3.8` announced in [RSN 22](/notices/rsn0022), development
+effort has been redirected to support `Python 3.10` in `v22.12` stable and `v23.02` nightly releases.
+
+## Status
+
+- `Python 3.10` nightly support started on 16-Nov-022 for both `conda` and
+`docker`
+
+## Impact
+
+Users are encouraged to test nightly `conda` and `docker` builds and report any
+issues in their respective repos.

--- a/_notices/rsn0024.md
+++ b/_notices/rsn0024.md
@@ -1,0 +1,43 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 24 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Stop supporting Ubuntu 18.04 in v22.12"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.12"
+notice_created: 2022-11-21
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-11-21
+---
+
+## Overview
+
+Ubuntu 18.04 is now at end-of-life, which means RAPIDS will no longer publish any images built on Ubuntu 18.04.
+
+Additionally, gpuCI CPU builds will be converted over to use CentOS 7 instead of Ubuntu 16.04.
+
+## Status
+
+Dropping full support for Ubuntu 18.04 is an ongoing effort.
+
+## Impact
+
+Users should consider switching to any of the following supported operating systems for any `rapidsai/rapidsai` image:
+  - Ubuntu 20.04
+  - Ubuntu 22.04
+  - CentOS 7
+  - CentOS 8

--- a/_notices/rsn0025.md
+++ b/_notices/rsn0025.md
@@ -1,0 +1,42 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 25 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Support for Ubuntu 22.04 in v22.12"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.12"
+notice_created: 2021-11-21
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-11-21
+---
+
+## Overview
+
+With the EOL of `Ubuntu 18.04` announced in [RSN 24](/notices/rsn0024), development
+effort has been redirected to support `Unbuntu 22.04` in `v22.12` stable and `v23.02` nightly releases.
+
+## Status
+
+Dropping full support for Ubuntu 18.04 is an ongoing effort.
+
+## Impact
+
+Users should consider switching to any of the following supported operating systems for any `rapidsai/rapidsai` image:
+  - Ubuntu 20.04
+  - Ubuntu 22.04
+  - CentOS 7
+  - CentOS 8


### PR DESCRIPTION
Adding and Dropping support for Ubuntu and Python.  