### PR TITLE
22.10 user support cuml/cugraph Users

### DIFF
--- a/_notices/rsn0026.md
+++ b/_notices/rsn0026.md
@@ -1,0 +1,33 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 26 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Support for 22.10 cuml/cugraph User"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v22.10"
+notice_created: 2022-12-14
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2022-12-14
+---
+
+## Overview
+
+RAPIDS 22.10 cuml/cugraph users will need to specify `libcusparse<12` `libcusolver<=11.4.1.48` in your conda install lines as a workaround to prevent dependencies errors
+
+## Impact
+
+Rapids 22.10 `cuml/cugraph` users

--- a/_notices/rsn0026.md
+++ b/_notices/rsn0026.md
@@ -35,7 +35,7 @@ conda create -n rapids-22.10 -c rapidsai -c conda-forge -c nvidia  cugraph=22.10
 
 ## Impact
 
-Rapids 22.10 `cuml` and `cugraph` users
+Impact is limited to RAPIDS 22.10 `cuml` and `cugraph` users.
 
 ## Background
 

--- a/_notices/rsn0026.md
+++ b/_notices/rsn0026.md
@@ -39,4 +39,8 @@ Impact is limited to RAPIDS 22.10 `cuml` and `cugraph` users.
 
 ## Background
 
-Since the release of RAPIDS 22.10, some packages that cuML and cuGraph depend on have upgraded and introduced incompatibilities. Conda will install these newer dependencies by default when installing 22.10 cuML or cuGraph, which will result in runtime errors.  In order to restrict conda to installing only compatible versions of these dependencies, the workaround above should be applied.  This workaround is not needed for RAPIDS releases 22.12 and beyond.
+Since the release of RAPIDS 22.10, some packages that cuML and cuGraph depend on have upgraded and introduced incompatibilities. Conda will install these newer dependencies by default when installing 22.10 cuML or cuGraph, which will result in runtime errors such as:
+
+`error while loading shared libraries: libnvJitLink.so.12: cannot open shared object file: No such file or directory`  
+
+In order to restrict conda to installing only compatible versions of these dependencies, the workaround above should be applied.  This workaround is not needed for RAPIDS releases 22.12 and beyond.

--- a/_notices/rsn0026.md
+++ b/_notices/rsn0026.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 26 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Support for 22.10 cuml/cugraph User"
+title: "Support for 22.10 cuml/cugraph Users"
 notice_author: RAPIDS Ops
 notice_status: In Progress
 notice_status_color: yellow

--- a/_notices/rsn0026.md
+++ b/_notices/rsn0026.md
@@ -26,8 +26,17 @@ notice_updated: 2022-12-14
 
 ## Overview
 
-RAPIDS 22.10 cuml/cugraph users will need to specify `libcusparse<12` `libcusolver<=11.4.1.48` in your conda install lines as a workaround to prevent dependencies errors
+RAPIDS 22.10 cuML and cuGraph users will need to add `libcusparse<12` `libcusolver<=11.4.1.48` to conda install commands for installing cuML or cuGraph.
+
+### Example
+```
+conda create -n rapids-22.10 -c rapidsai -c conda-forge -c nvidia  cugraph=22.10 python=3.8 cudatoolkit=11.5 libcusparse<12 libcusolver<=11.4.1.48
+```
 
 ## Impact
 
-Rapids 22.10 `cuml/cugraph` users
+Rapids 22.10 `cuml` and `cugraph` users
+
+## Background
+
+Since the release of RAPIDS 22.10, some packages that cuML and cuGraph depend on have upgraded and introduced incompatibilities. Conda will install these newer dependencies by default when installing 22.10 cuML or cuGraph, which will result in runtime errors.  In order to restrict conda to installing only compatible versions of these dependencies, the workaround above should be applied.  This workaround is not needed for RAPIDS releases 22.12 and beyond.


### PR DESCRIPTION
22.10 cuml/cugraph users need to specify `libcusparse<12` `libcusolver<=11.4.1.48` in your conda install lines as a workaround to prevent dependencies errors