### PR TITLE
GitHub Actions Label Updates

### DIFF
--- a/_includes/gpu-labels-table-row.html
+++ b/_includes/gpu-labels-table-row.html
@@ -1,0 +1,24 @@
+<tr>
+  <td>
+    <code
+      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-{{include.driver}}-1]</code>
+    <span class="table_br"></span>
+    <code
+      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-{{include.driver}}]</code>
+    {% if include.latest %}
+    <span class="table_br"></span>
+    <code
+      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-latest-1]</code>
+    <span class="table_br"></span>
+    <code
+      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-latest]</code>
+    <span class="table_br"></span>
+    <code class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-latest-1]</code>
+    <span class="table_br"></span>
+    <code class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-latest]</code>
+    {% endif %}
+  </td>
+  <td><code class="language-plaintext highlighter-rouge">{{include.gpu}}</code></td>
+  <td><code class="language-plaintext highlighter-rouge">{{include.driver}}</code></td>
+  <td><code class="language-plaintext highlighter-rouge">1</code></td>
+</tr>

--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -1,0 +1,17 @@
+<table>
+  <thead>
+    <tr>
+      <th>Label Combination</th>
+      <th>GPU</th>
+      <th>Driver Version</th>
+      <th># of GPUs</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="495" latest=true %}
+    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="495" latest=true %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=false %}
+    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="520" latest=false %}
+  </tbody>
+</table>

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -108,7 +108,7 @@ The GPU labeled runners are backed by lab machines and have the GPUs specified i
 
 **IMPORTANT**: GPU jobs have two requirements. If these requirements aren't met, the GitHub Actions job will fail. See the _Usage_ section below for an example.
 
-1. They must run in a container (i.e. `nvidia/cuda:11.5.0-base-ubuntu20.04`)
+1. They must run in a container (i.e. `nvidia/cuda:11.8.0-base-ubuntu22.04`)
 2. They must set the {% raw %}`NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}`{% endraw %} container environment variable.
 
 {% include gpu-labels-table.html %}

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -113,6 +113,23 @@ The GPU labeled runners are backed by lab machines and have the GPUs specified i
 
 {% include gpu-labels-table.html %}
 
+Cells with multiple labels in the table above are aliases which represent the same runner type.
+
+The GPU label names consist of the following components:
+
+```text
+gpu-a100-495-1
+    ^    ^   ^
+    |    |   |
+    |    |   Number of GPUs Available
+    |    Driver Version
+    GPU Type
+```
+
+The driver version may also be `latest`, which is a moving tag for the latest CUDA version supported by RAPIDS at any given time.
+
+Since we will periodically deprecate runners that use old driver versions, the `latest` tag is useful for users who are not concerned with the driver version used by their jobs.
+
 ### Usage
 
 The code snippet below shows how the labels above may be utilized in a GitHub Action workflow.

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -129,9 +129,9 @@ jobs:
       - name: hello
         run: echo "hello"
   job2_gpu:
-    runs-on: [self-hosted, linux, amd64, gpu-v100-495-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-520-1]
     container: # GPU jobs must run in a container
-      image: nvidia/cuda:11.5.0-base-ubuntu18.04
+      image: nvidia/cuda:11.8.0-base-ubuntu22.04
       env:
         NVIDIA_VISIBLE_DEVICES: {% raw %}${{ env.NVIDIA_VISIBLE_DEVICES }}{% endraw %} # GPU jobs must set this container env variable
     steps:

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -111,11 +111,7 @@ The GPU labeled runners are backed by lab machines and have the GPUs specified i
 1. They must run in a container (i.e. `nvidia/cuda:11.5.0-base-ubuntu20.04`)
 2. They must set the {% raw %}`NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}`{% endraw %} container environment variable.
 
-| Label Combination                                                                                                                                                                                                                                                                                                                                            | GPU    | Driver Version | # of GPUs |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ | -------------- | --------- |
-| `[linux, amd64, gpu-v100-450-1]`                                                                                                                                                                                                                                                                                                                             | `V100` | `450`          | `1`       |
-| `[linux, amd64, gpu-v100-495-1]` <span class="table_br"></span> `[linux, amd64, gpu-v100-495]` <span class="table_br"></span> `[linux, amd64, gpu-v100-latest-1]` <span class="table_br"></span> `[linux, amd64, gpu-v100-latest]` <span class="table_br"></span> `[linux, amd64, gpu-latest-1]` <span class="table_br"></span> `[linux, amd64, gpu-latest]` | `V100` | `495`          | `1`       |
-| `[linux, arm64, gpu-a100-495-1]` <span class="table_br"></span> `[linux, arm64, gpu-a100-495]` <span class="table_br"></span> `[linux, arm64, gpu-a100-latest-1]` <span class="table_br"></span> `[linux, arm64, gpu-a100-latest]` <span class="table_br"></span> `[linux, arm64, gpu-latest-1]` <span class="table_br"></span> `[linux, arm64, gpu-latest]` | `A100` | `495`          | `1`       |
+{% include gpu-labels-table.html %}
 
 ### Usage
 


### PR DESCRIPTION
This PR updates the GitHub Action label table for GPUs.

Specifically, it includes the following changes:

- adds driver `520` labels for `arm` and `amd64`
- refactors the table to use raw HTML instead of markdown tables
  - this change was necessary since we can't use Jekyll's templating features in markdown-based tables. templating was needed to keep the table readable/maintainable