### PR TITLE
Update GHA `arm` labels

### DIFF
--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -10,8 +10,7 @@
   <tbody>
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="495" latest=true %}
-    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="495" latest=true %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=false %}
-    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="520" latest=false %}
+    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="520" latest=true %}
   </tbody>
 </table>

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -118,7 +118,7 @@ Cells with multiple labels in the table above are aliases which represent the sa
 The GPU label names consist of the following components:
 
 ```text
-gpu-a100-495-1
+gpu-a100-520-1
     ^    ^   ^
     |    |   |
     |    |   Number of GPUs Available


### PR DESCRIPTION
There are no more driver `495` machines for `arm`.

Therefore, this PR removes the `495` runner labels and updates the `latest` labael to `520`.