### PR TITLE
Update `latest` labels for GHAs

### DIFF
--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -9,8 +9,7 @@
   </thead>
   <tbody>
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="495" latest=true %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=false %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=true %}
     {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="520" latest=true %}
   </tbody>
 </table>


### PR DESCRIPTION
This PR updates the `latest` label for `amd64` machines for GHAs.

Additionally, it removes the `495` labels since that driver version is no longer in use.