### PR TITLE
clx-repository-deprecation v23.04

### DIFF
--- a/_notices/rsn0027.md
+++ b/_notices/rsn0027.md
@@ -1,0 +1,33 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 27 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Deprecation announcement for CLX RAPIDS Repository"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v23.04"
+notice_created: 2023-02-17
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2023-02-17
+---
+
+## Overview
+
+RAPIDS CLX repository will be deprecated in our upcoming release of v23.04 scheduled for April 13 2023.  After the v23.04 release, this repository will be removed during v23.06 release.  Users should expect that support for CLX repository may be dropped after v23.06 release.
+
+
+## Impact
+Users should plan to move to the Morpheus repository @ https://github.com/nv-morpheus/Morpheus if you are looking for similar functionality as CLX since much of their functionally has moved to Morpheus

--- a/_notices/rsn0028.md
+++ b/_notices/rsn0028.md
@@ -26,7 +26,7 @@ notice_updated: 2023-02-17
 
 ## Overview
 
-RAPIDS CLX repository will be deprecated in our upcoming release of v23.04 scheduled for April 13 2023.  After the v23.04 release, this repository will be removed during v23.06 release.  Users should expect that support for CLX repository may be dropped after v23.06 release.
+RAPIDS CLX repository will be deprecated in our upcoming release of v23.04 scheduled for April 13 2023. After the v23.04 release, this repository will be archived during v23.06 release. v23.04 will be the final release of RAPIDS CLX.
 
 
 ## Impact

--- a/_notices/rsn0028.md
+++ b/_notices/rsn0028.md
@@ -5,7 +5,7 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
-notice_id: 27 # should match notice number
+notice_id: 28 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation announcement for CLX RAPIDS Repository"
 notice_author: RAPIDS Ops

--- a/_notices/rsn0028.md
+++ b/_notices/rsn0028.md
@@ -30,4 +30,4 @@ RAPIDS CLX repository will be deprecated in our upcoming release of v23.04 sched
 
 
 ## Impact
-Users should plan to move to the Morpheus repository @ https://github.com/nv-morpheus/Morpheus if you are looking for similar functionality as CLX since much of their functionally has moved to Morpheus
+Users may wish to migrate to Morpheus, which includes much of the CLX functionality: https://github.com/nv-morpheus/Morpheus


### PR DESCRIPTION
This is the deprecation notices of the RAPIDS clx repository 