### PR TITLE
Add driver `525` GHAs labels

### DIFF
--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -10,7 +10,8 @@
   <tbody>
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=true %}
-    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="520" latest=true %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="525" latest=false %}
+    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="525" latest=true %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="T4" driver="520" latest=false %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="T4" driver="525" latest=false %}
   </tbody>


### PR DESCRIPTION
This PR updates the GitHub Actions label table to include driver `525` machines.