### PR TITLE
Adding a note on draft PRs

### DIFF
--- a/maintainers/forward-merger.md
+++ b/maintainers/forward-merger.md
@@ -11,7 +11,8 @@ title: Forward Mergers
 
 The forward mergers are automated pull requests to merge a branch in burndown into the next versioned branch. For example merging `branch-22.12` into `branch-23.02`. This ensures all changes to the current branch are reflected in the next version.
 
-The forward merger jobs are located here: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/forward-mergers/
+The forward merger jobs are located here: 
+[https://gpuci.gpuopenanalytics.com/job/rapidsai/job/forward-mergers/](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/forward-mergers/)
 
 ### Intended audience
 

--- a/resources/style.md
+++ b/resources/style.md
@@ -36,7 +36,5 @@ See the [Git Methodology]({% link resources/git.md %}#git-commits) for further d
 
 ## GitHub Pull Requests
 
-Draft Pull Requests should be opened while work is in progress. This lets other
-developers know draft changes are coming without initialing a the review process
-immediately. Once the pull request is ready, click "Ready for review" to get
+[Draft pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) should be opened while work is in progress. This prevents review notifications from being sent to code owners before a pull request is ready to be reviewed. Once the pull request is ready, click "Ready for review" to get
 feedback on the changes.

--- a/resources/style.md
+++ b/resources/style.md
@@ -33,3 +33,10 @@ Individual projects should configure `flake8` to suit their needs, for example t
 Git commit messages should convey the change succinctly, but with enough detail to be understood without extra context.
 
 See the [Git Methodology]({% link resources/git.md %}#git-commits) for further details.
+
+## GitHub Pull Requests
+
+Draft Pull Requests should be opened while work is in progress. This lets other
+developers know draft changes are coming without initialing a the review process
+immediately. Once the pull request is ready, click "Ready for review" to get
+feedback on the changes.


### PR DESCRIPTION
Following up after the 23.02 retro to add a note to the maintainers docs on draft PRs.