### PR TITLE
Bump driver version from 520 to 525

### DIFF
--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -9,10 +9,8 @@
   </thead>
   <tbody>
     {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="520" latest=true %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="525" latest=false %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="525" latest=true %}
     {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="525" latest=true %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="T4" driver="520" latest=false %}
     {% include gpu-labels-table-row.html arch="amd64" gpu="T4" driver="525" latest=false %}
   </tbody>
 </table>

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -118,7 +118,7 @@ Cells with multiple labels in the table above are aliases which represent the sa
 The GPU label names consist of the following components:
 
 ```text
-gpu-a100-520-1
+gpu-a100-525-1
     ^    ^   ^
     |    |   |
     |    |   Number of GPUs Available
@@ -146,7 +146,7 @@ jobs:
       - name: hello
         run: echo "hello"
   job2_gpu:
-    runs-on: [self-hosted, linux, amd64, gpu-v100-520-1]
+    runs-on: [self-hosted, linux, amd64, gpu-v100-525-1]
     container: # GPU jobs must run in a container
       image: nvidia/cuda:11.8.0-base-ubuntu22.04
       env:


### PR DESCRIPTION
To prepare for CUDA 12, we will move the driver 520 nodes to driver 525