### PR TITLE
Add dask-cudf 

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -13,6 +13,17 @@ apis:
       legacy: 1
       stable: 1
       nightly: 1
+  dask-cudf:
+    name: dask-cuDF
+    path: dask_cudf
+    desc: 'Dask-cuDF extends Dask where necessary to allow its DataFrame partitions to be processed using cuDF GPU DataFrames instead of Pandas DataFrames.  Dask-cuDF is used to leverage multiple gpus and multiple nodes for more performance at larger scales'
+    ghlink: https://github.com/rapidsai/cudf
+    cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
   cuml:
     name: cuML
     path: cuml


### PR DESCRIPTION
PR adds dask-cudf to the API section of https://docs.rapids.ai/api .  Follow up PR for https://github.com/rapidsai/cudf/pull/12725 and https://github.com/rapidsai/cudf/pull/12982

cc @wence- 