### PR TITLE
Update pip instructions for 23.04GA

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -252,7 +252,7 @@
                         </div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method != 'pip'">
+                <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">CUDA</div>
                     <template x-for="version in cuda_vers">
                         <div x-on:click="(e) => cudaClickHandler(e, version)"
@@ -260,7 +260,7 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method != 'pip'">
+                <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
@@ -498,13 +498,15 @@
             getpipCmdHtml() {
                 var pip_install = "pip install ";
                 var index_url = " --extra_index_url=https://pypi.nvidia.com";
-                var pkgs = String(this.active_packages).replaceAll(",", "-cu11 ").toLowerCase() + "-cu11";
+                var libraryToPkg = (pkg) => {
+                    pkg = pkg.toLowerCase();
+                    if (pkg === "cucim") return pkg;
+                    return pkg + "-cu11"
+                }
+                var pkgs = this.active_packages.map(libraryToPkg).join(" ");
                 var isArm = this.active_arch === "arm";
                 var cupy_inst = "";
 
-                if (pkgs.includes("cucim")) {
-                    pkgs = pkgs.replaceAll("cucim-cu11", "cucim");
-                }
                 if (pkgs === "cucim") {
                     index_url = "";
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -252,7 +252,7 @@
                         </div>
                     </template>
                 </div>
-                <div class="options-section">
+                <div class="options-section" x-show="active_method != 'pip'">
                     <div class="option-label">CUDA</div>
                     <template x-for="version in cuda_vers">
                         <div x-on:click="(e) => cudaClickHandler(e, version)"
@@ -630,7 +630,8 @@
             getpipNotes() {
                 var notes = [];
                 notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, and <code>cuGraph</code> pip packages are hosted on the NVIDIA Index<br>",
-                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code>'];
+                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code><br>',
+                         'pip installation supports CUDA <code>11.2</code> - <code>11.8</code>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -260,7 +260,7 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method != 'Pip'"">
+                <div class="options-section" x-show="active_method != 'Pip'">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -260,7 +260,7 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section">
+                <div class="options-section" x-show="active_method != 'Pip'"">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
@@ -293,6 +293,17 @@
                             <div x-on:click="(e) => additionalPackagesClickHandler(e, package)"
                                 x-bind:class="{'active': active_additional_packages.includes(package)}" class="option"
                                 x-text="package"></div>
+                        </template>
+                    </div>
+                </div>
+                <div class="pip-options-container" x-show="active_method === 'Pip'">
+                    <div class="options-section">
+                        <div class="option-label">Packages</div>
+                        <template x-for="package in pip_packages">
+                            <div x-on:click="(e) => packagesClickHandler(e, package)"
+                                x-bind:class="{'active': active_packages.includes(package)}" class="option"
+                                x-html="getPackageHTML(package)">
+                            </div>
                         </template>
                     </div>
                 </div>
@@ -373,12 +384,13 @@
             python_vers: ["3.8", "3.10"],
             cuda_vers: ["11.2", "11.4", "11.5", "11.8"],
             os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
-            methods: ["Conda", "Docker", "Source"],
+            methods: ["Conda", "Pip", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["core", "standard", "clx"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
+            pip_packages: ["cuDF", "cuML", "cuGraph", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "PyCaret", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
@@ -482,6 +494,26 @@
                 ].filter(Boolean).join(" \\\n");
 
                 return lines;
+            },
+            getPipCmdHtml() {
+                var pip_install = "pip install ";
+                var index_url = " --extra_index_url=https://pypi.nvidia.com";
+                var pkgs = String(this.active_packages).replaceAll(",", "-cu11 ").toLowerCase() + "-cu11";
+                var isArm = this.active_arch === "arm";
+                var cupy_inst = "";
+
+                if (pkgs.includes("cucim")) {
+                    pkgs = pkgs.replaceAll("cucim-cu11", "cucim");
+                }
+                if (pkgs === "cucim") {
+                    index_url = "";
+                }
+
+                if (isArm) {
+                    cupy_inst = "\npip install cupy-cuda11x -f https://pip.cupy.dev/aarch64";
+                }
+                
+                return pip_install + pkgs + index_url + cupy_inst;
             },
             getDockerCmdHtml() {
                 var hasNotebooks = this.active_img_options.includes("notebooks");
@@ -594,6 +626,13 @@
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
+            getPipNotes() {
+                var notes = [];
+                notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, and <code>cuGraph</code> pip packages are hosted on the NVIDIA Index<br>",
+                         'Pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code>'];
+
+                return notes.map(note => this.note_prefix + " " + note);
+            },
             getArmNotes() {
                 return [this.note_prefix + " ARM support does not currently include Jetson products."];
             },
@@ -612,6 +651,10 @@
                     notes.push(...this.getCondaNotes());
                 }
 
+                if (this.active_method === "Pip") {
+                    notes.push(...this.getPipNotes());
+                }
+
                 return notes.map(note => `<div class="option-note">${note}</div>`).join("");
             },
             getCmdHtml() {
@@ -619,6 +662,8 @@
                     return this.getDockerCmdHtml();
                 if (this.active_method === "Conda")
                     return this.getCondaCmdHtml();
+                if (this.active_method === "Pip")
+                    return this.getPipCmdHtml();
                 if (this.active_method === "Source")
                     return this.getSourceCmdHtml();
                 return "Not implemented yet!";
@@ -629,6 +674,7 @@
             disableUnsupportedRelease(release) {
                 var isDisabled = false;
                 if (this.active_img_loc === "NGC" && this.active_method === "Docker" && release === "Nightly") isDisabled = true;
+                if (this.active_method === "Pip" && release === "Nightly") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedCuda(cuda_version) {
@@ -638,6 +684,8 @@
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
                 if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
+                if (this.active_method === 'Pip' && cuda_version !== '11.8') isDisabled = true;
+
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -698,6 +746,11 @@
                 }
                 if (method !== "Conda") {
                     this.active_additional_packages = [];
+                }
+                if (method === "Pip") {
+                    this.active_cuda_ver = '11.8';
+                    this.active_release = 'Stable';
+                    this.active_packages = ['cuDF']
                 }
                 if (method === "Docker") {
                     this.active_release = "Stable"

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -260,7 +260,7 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method != 'Pip'">
+                <div class="options-section" x-show="active_method != 'pip'">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
@@ -296,7 +296,7 @@
                         </template>
                     </div>
                 </div>
-                <div class="pip-options-container" x-show="active_method === 'Pip'">
+                <div class="pip-options-container" x-show="active_method === 'pip'">
                     <div class="options-section">
                         <div class="option-label">Packages</div>
                         <template x-for="package in pip_packages">
@@ -384,7 +384,7 @@
             python_vers: ["3.8", "3.10"],
             cuda_vers: ["11.2", "11.4", "11.5", "11.8"],
             os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
-            methods: ["Conda", "Pip", "Docker", "Source"],
+            methods: ["Conda", "pip", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
@@ -495,7 +495,7 @@
 
                 return lines;
             },
-            getPipCmdHtml() {
+            getpipCmdHtml() {
                 var pip_install = "pip install ";
                 var index_url = " --extra_index_url=https://pypi.nvidia.com";
                 var pkgs = String(this.active_packages).replaceAll(",", "-cu11 ").toLowerCase() + "-cu11";
@@ -509,6 +509,7 @@
                     index_url = "";
                 }
 
+                // This should be unnecessary and removed after 23.06
                 if (isArm) {
                     cupy_inst = "\npip install cupy-cuda11x -f https://pip.cupy.dev/aarch64";
                 }
@@ -626,10 +627,10 @@
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
-            getPipNotes() {
+            getpipNotes() {
                 var notes = [];
                 notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, and <code>cuGraph</code> pip packages are hosted on the NVIDIA Index<br>",
-                         'Pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code>'];
+                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
@@ -651,8 +652,8 @@
                     notes.push(...this.getCondaNotes());
                 }
 
-                if (this.active_method === "Pip") {
-                    notes.push(...this.getPipNotes());
+                if (this.active_method === "pip") {
+                    notes.push(...this.getpipNotes());
                 }
 
                 return notes.map(note => `<div class="option-note">${note}</div>`).join("");
@@ -662,8 +663,8 @@
                     return this.getDockerCmdHtml();
                 if (this.active_method === "Conda")
                     return this.getCondaCmdHtml();
-                if (this.active_method === "Pip")
-                    return this.getPipCmdHtml();
+                if (this.active_method === "pip")
+                    return this.getpipCmdHtml();
                 if (this.active_method === "Source")
                     return this.getSourceCmdHtml();
                 return "Not implemented yet!";
@@ -674,7 +675,7 @@
             disableUnsupportedRelease(release) {
                 var isDisabled = false;
                 if (this.active_img_loc === "NGC" && this.active_method === "Docker" && release === "Nightly") isDisabled = true;
-                if (this.active_method === "Pip" && release === "Nightly") isDisabled = true;
+                if (this.active_method === "pip" && release === "Nightly") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedCuda(cuda_version) {
@@ -684,7 +685,7 @@
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
                 if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
-                if (this.active_method === 'Pip' && cuda_version !== '11.8') isDisabled = true;
+                if (this.active_method === 'pip' && cuda_version !== '11.8') isDisabled = true;
 
                 return isDisabled;
             },
@@ -747,7 +748,7 @@
                 if (method !== "Conda") {
                     this.active_additional_packages = [];
                 }
-                if (method === "Pip") {
+                if (method === "pip") {
                     this.active_cuda_ver = '11.8';
                     this.active_release = 'Stable';
                     this.active_packages = ['cuDF']

--- a/install/install.md
+++ b/install/install.md
@@ -75,7 +75,7 @@ Several services also offer **free and limited** trials with GPU resources:
 For most installations, you will need a Conda or Docker environments installed for RAPIDS. Note, these examples are structured for installing on **Ubuntu**. Please modify appropriately for CentOS / Rocky Linux. **Windows 11** has a [WSL2 specific install](#WSL2). Jump to your preferred environment:
 - [Conda](#conda) 
 - [Docker](#docker)
-- [pip (Experimental)](#pip)
+- [pip](#pip)
 - [Build from Source](#source)
 - [Within WSL2](#WSL2)
 
@@ -163,8 +163,8 @@ bash /rapids/utils/stop-jupyter.sh
 
 <br/>
 
-### **pip (Experimental)**
-The package installer for python (pip) is currently in experimental mode, but available to try in both WSL2 or Ubuntu. See below for details.
+### **pip**
+The package installer for python (pip) is generally available as of RAPIDS release 23.04. See below for details.
 
 
 <br/>
@@ -184,7 +184,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 ### **WSL Enhanced Prerequisites**
 <i class="fas fa-desktop text-white"></i> **OS:** Windows 11 with Ubuntu 22.04 instance for WSL2. <br/>
-<i class="fas fa-info-circle text-white"></i> **WSL Version:** WSL12 (WSL1 not supported). <br/>
+<i class="fas fa-info-circle text-white"></i> **WSL Version:** WSL2 (WSL1 not supported). <br/>
 <i class="fas fa-microchip text-white"></i> **GPU:** GPUs with [Compute Capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0 or higher (16GB+ GPU RAM is recommended).
 
 <br/>
@@ -197,6 +197,8 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 ### **Troubleshooting**
 <i class="fas fa-info-circle text-white"></i> When installing with conda, if an `http 000 connection error` occurs when accessing the repository data, run `wsl --shutdown` and then [restart the WSL instance](https://stackoverflow.com/questions/67923183/miniconda-on-wsl2-ubuntu-20-04-fails-with-condahttperror-http-000-connection){: target="_blank"}.
+
+<i class="fas fa-info-circle text-white"></i> When installing with Docker Desktop, if the container pull command is successful, but the run command hangs indefinitely, [ensure you're on Docker Desktop <= 4.15](https://github.com/docker/for-win/issues/13165){: target="_blank"}.
 
 <br/>
 
@@ -231,7 +233,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 1. Install WSL2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
-4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then [install the CUDA Toolkit without drivers](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_network){: target="_blank"} into the WSL2 instance.
+4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then [install the CUDA Toolkit without drivers](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} into the WSL2 instance.
 5. Install RAPIDS pip packages on the WSL2 Linux Instance using the [pip instructions](#pip).
 6. Run this code to check that the RAPIDS installation is working:
 	```
@@ -254,8 +256,8 @@ Use the selector tool below to select your preferred method, packages, and envir
 <br/>
 <div id="pip"></div>
 
-## 3B. Install RAPIDS with pip (Experimental)
-This is an experimental release supporting single GPU usage. cuDF, dask-cuDF, cuML, cuGraph, RMM and RAFT release 22.10 pip packages are now available. The team is excited to get these packages out into the wild and see the RAPIDS community uses them.
+## 3B. Install RAPIDS with pip
+Beginning with the release of 23.04: cuDF, dask-cuDF, cuML, cuGraph, RMM, RAFT, and cuSpatial CUDA 11 pip packages are generally available.
 
 <br/>
 
@@ -263,12 +265,12 @@ This is an experimental release supporting single GPU usage. cuDF, dask-cuDF, cu
 <i class="fas fa-info-circle"></i> **Glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
 <i class="fas fa-info-circle"></i> **Glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.31 (only ARM Server Base System Architecture is supported). <br/>
 <i class="fas fa-download"></i> **CUDA >= 11.8**, with at least the **v520.61.05** driver. To use older CUDA 11.x versions, please see Troubleshooting and Known Issues. <br/>
-<i class="fab fa-python"></i> **Python and pip version:** Python 3.8 or 3.10 using pip 20.3+ with [PEP600 support](https://peps.python.org/pep-0600/){: target="_blank"}.
+<i class="fab fa-python"></i> **Python and pip version:** Python 3.8, 3.9, or 3.10 using pip 20.3+ with [PEP600 support](https://peps.python.org/pep-0600/){: target="_blank"}.
 
 <br/>
 
 ### **pip Install**
-The RAPIDS pip packages are hosted on NVIDIA NGC index via:
+RAPIDS pip packages are hosted on the NVIDIA index via:
 ```
 pip install cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
 pip install cuml-cu11 --extra-index-url=https://pypi.nvidia.com
@@ -294,7 +296,8 @@ ERROR: Could not find a version that satisfies the requirement cudf-cu11 (from v
 ERROR: No matching distribution found for cudf-cu11
 ```
 Check the suggestions below for possible resolutions:
-- Your Python version must be 3.8 or 3.10.
+- The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
+- Your Python version must be 3.8, 3.9, or 3.10.
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip` <br/>
 
 <i class="fas fa-info-circle"></i> Dask / Jupyter / Tornado 6.2 dependency conflicts can occur. Install jupyter-client 7.3.4 if the error below occurs: <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -257,7 +257,7 @@ Use the selector tool below to select your preferred method, packages, and envir
 <div id="pip"></div>
 
 ## 3B. Install RAPIDS with pip
-Beginning with the release of 23.04: cuDF, dask-cuDF, cuML, cuGraph, RMM, RAFT, and cuSpatial CUDA 11 pip packages are generally available.
+Beginning with the release of 23.04: cuDF, dask-cuDF, cuML, cuGraph, RMM, and RAFT CUDA 11 pip packages are available on the NVIDIA Index.
 
 <br/>
 

--- a/install/install.md
+++ b/install/install.md
@@ -164,7 +164,7 @@ bash /rapids/utils/stop-jupyter.sh
 <br/>
 
 ### **pip**
-The package installer for python (pip) is generally available as of RAPIDS release 23.04. See below for details.
+The package installer for python (pip) is available as of RAPIDS release 23.04. See below for details.
 
 
 <br/>
@@ -264,7 +264,7 @@ Beginning with the release of 23.04: cuDF, dask-cuDF, cuML, cuGraph, RMM, and RA
 ### **pip Enhanced Prerequisites**
 <i class="fas fa-info-circle"></i> **Glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
 <i class="fas fa-info-circle"></i> **Glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.31 (only ARM Server Base System Architecture is supported). <br/>
-<i class="fas fa-download"></i> **CUDA >= 11.8**, with at least the **v520.61.05** driver. To use older CUDA 11.x versions, please see Troubleshooting and Known Issues. <br/>
+<i class="fas fa-download"></i> **CUDA >= 11.2**, with at least the **v460.27.03** driver. <br/>
 <i class="fab fa-python"></i> **Python and pip version:** Python 3.8, 3.9, or 3.10 using pip 20.3+ with [PEP600 support](https://peps.python.org/pep-0600/){: target="_blank"}.
 
 <br/>


### PR DESCRIPTION
This PR updates the install page to:
- Remove mentions of pip being experimental
- Solidify pip as GA as of 23.04 (and which libraries specifically)
- Add mention of support for Python 3.9 wheels
- Add a troubleshooting step making sure they are pointing the `--extra-index-url` to the right place since it moved from EA

I also used it to:
- Add a troubleshooting step on WSL where if the `docker run` command hangs indefinitely to downgrade Docker Desktop to <= 4.15

### 4/4 Edit
`Selector.html` has been updated to support pip install commands 🎉 