### PR TITLE
Update GHAs self-hosted runner docs for `arc-v2`

### DIFF
--- a/_includes/gpu-labels-table-row.html
+++ b/_includes/gpu-labels-table-row.html
@@ -1,22 +1,7 @@
 <tr>
   <td>
     <code
-      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-{{include.driver}}-1]</code>
-    <span class="table_br"></span>
-    <code
-      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-{{include.driver}}]</code>
-    {% if include.latest %}
-    <span class="table_br"></span>
-    <code
-      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-latest-1]</code>
-    <span class="table_br"></span>
-    <code
-      class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-{{include.gpu|downcase}}-latest]</code>
-    <span class="table_br"></span>
-    <code class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-latest-1]</code>
-    <span class="table_br"></span>
-    <code class="language-plaintext highlighter-rouge">[linux, {{include.arch}}, gpu-latest]</code>
-    {% endif %}
+      class="language-plaintext highlighter-rouge">linux-{{include.arch}}-gpu-{{include.gpu|downcase}}-{{include.version}}-1</code>
   </td>
   <td><code class="language-plaintext highlighter-rouge">{{include.gpu}}</code></td>
   <td><code class="language-plaintext highlighter-rouge">{{include.driver}}</code></td>

--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -1,16 +1,16 @@
 <table>
   <thead>
     <tr>
-      <th>Label Combination</th>
+      <th>Label</th>
       <th>GPU</th>
       <th>Driver Version</th>
       <th># of GPUs</th>
     </tr>
   </thead>
   <tbody>
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="450" latest=false %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver="525" latest=true %}
-    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver="525" latest=true %}
-    {% include gpu-labels-table-row.html arch="amd64" gpu="T4" driver="525" latest=false %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver=earliest_driver_version version="earliest" %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="V100" driver=latest_driver_version   version="latest" %}
+    {% include gpu-labels-table-row.html arch="arm64" gpu="A100" driver=latest_driver_version   version="latest" %}
+    {% include gpu-labels-table-row.html arch="amd64" gpu="T4"   driver=latest_driver_version   version="latest" %}
   </tbody>
 </table>

--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -126,6 +126,14 @@ The GPU labeled runners are backed by lab machines and have the GPUs specified i
 1. They must run in a container (i.e. `nvidia/cuda:11.8.0-base-ubuntu22.04`)
 2. They must set the {% raw %}`NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}`{% endraw %} container environment variable
 
+Due to our limited GPU capacity and the overhead associated with manually rotating self-hosted runner labels when GPU drivers are updated, there are no driver-specific self-hosted runner labels (e.g. `linux-amd64-gpu-t4-525-1`).
+
+Instead, the driver-version designators `earliest` and `latest` are used. The values of these designators represent the GPU driver version that RAPIDS uses for testing.
+
+The chart below will be kept up-to-date with the corresponding driver versions at any given time.
+
+Supported organizations will be notified whenever these versions are scheduled to be updated.
+
 {% include gpu-labels-table.html %}
 
 The GPU label names consist of the following components:
@@ -141,19 +149,6 @@ linux-amd64-gpu-t4-latest-1
 |     Architecture
 Operating System
 ```
-
-Due to our limited GPU capacity and the overhead associated with manually rotating self-hosted runner labels when GPU drivers are updated, there are no driver-specific self-hosted runner labels (e.g. `linux-amd64-gpu-t4-525-1`).
-
-Instead, the driver-version designators `earliest` and `latest` are used. The values of these designators represent the GPU driver version that RAPIDS uses for testing.
-
-The chart below will be kept up-to-date with the corresponding driver versions at any given time.
-
-| Version Designator | Corresponding GPU Driver Version |
-| ------------------ | -------------------------------- |
-| `earliest`         | `{{ earliest_driver_version }}`  |
-| `latest`           | `{{ latest_driver_version }}`    |
-
-Supported organizations will be notified whenever these versions are scheduled to be updated.
 
 ### Usage
 


### PR DESCRIPTION
## Changes

This PR updates our GitHub Action self-hosted runner docs in anticipation of our [actions-runner-controller](https://github.com/actions/actions-runner-controller/) `v2` rollout.

## Background Context

One of the big changes from `v1` to `v2` is related to how self-hosted runner labels are handled.

`v1` allowed us to assign multiple labels to a particular runner set. For example `gpu-a100-525-1` and `gpu-a100-latest-1` could point to the same set of runners.

For `v2`, this is not possible. From speaking with the `actions-runner-controller` devs, this change is intentional. There is an open issue about it [here](https://github.com/actions/actions-runner-controller/issues/2445) that I am tracking.

As a result of this change, we had to decide whether to strictly use either `gpu-a100-525-1`-type labels or `gpu-a100-{latest,earliest}-1`-type labels.

Because of our finite GPU capacity and the overhead associated with manually updating driver-specific labels (e.g. `gpu-a100-525-1`) across all supported GitHub organizations, we've opted to adopt using the `earliest`/`latest` label types.

We will update our runners accordingly if this changes in the future.