### PR TITLE
Update selector to use dashes in --extra-index-url for pip.

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -497,7 +497,7 @@
             },
             getpipCmdHtml() {
                 var pip_install = "pip install ";
-                var index_url = " --extra_index_url=https://pypi.nvidia.com";
+                var index_url = " --extra-index-url=https://pypi.nvidia.com";
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;


### PR DESCRIPTION
Fixes issue found by @tunguz / @sevagh. The pip option `--extra-index-url` needs dashes, not underscores.