### PR TITLE
fix path for dask cudf

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -15,7 +15,7 @@ apis:
       nightly: 1
   dask-cudf:
     name: dask-cuDF
-    path: dask_cudf
+    path: dask-cudf
     desc: 'Dask-cuDF extends Dask where necessary to allow its DataFrame partitions to be processed using cuDF GPU DataFrames instead of Pandas DataFrames. Dask-cuDF is used to leverage multiple gpus and multiple nodes for more performance at larger scales'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md


### PR DESCRIPTION
Path on doc.rapids.ai is incorrect for dask-cudf .  Anchor currently points to https://docs.rapids.ai/api/dask_cudf/nightly .  Instead, it should point https://docs.rapids.ai/api/dask-cudf/nightly


cc @ajschmidt8 
