### PR TITLE
Add `--pull=always` flag to CI doc

### DIFF
--- a/resources/reproducing-ci.md
+++ b/resources/reproducing-ci.md
@@ -50,6 +50,7 @@ docker run \
   --rm \
   -it \
   --gpus all \
+  --pull=always \
   --network=host \
   --volume $PWD:/repo \
   --workdir /repo \


### PR DESCRIPTION
This PR adds the `--pull=always` flag to the doc page that talks about reproducing CI issues locally.

This flag will ensure that users will always pull the latest CI images when running the `docker run` command locally.