### PR TITLE
cudf code freeze date change-updage

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -31,8 +31,8 @@
     },
     "cudf_codefreeze": {
       "start": "May 25 2023",
-      "end": "May 31 2023",
-      "days": 4
+      "end": "June 6 2023",
+      "days": 9
     },
     "other_codefreeze": {
       "start": "Jun 1 2023",


### PR DESCRIPTION
Updated cudf code freeze dates to June 6, 2023 from May 31st to reflect 9 days.