### PR TITLE
Cuda 12 pip wheels release

### DIFF
--- a/_notices/rsn0031.md
+++ b/_notices/rsn0031.md
@@ -1,0 +1,34 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 30 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "CUDA 12 PIP Wheels Release in v23.06"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v23.06"
+notice_created: 2023-05-16
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2023-05-16
+---
+
+## Overview
+
+The core RAPIDS packages that build pip wheels (rmm, cudf, raft, cuml, cugraph, cuopt, ucx-py) are now building pip wheels with `CUDA 12 support`.  We plan to release these packages in release v23.06.
+
+
+## Impact
+
+Users should be aware we now are building pip wheels with `CUDA 12 support` as noted above.

--- a/_notices/rsn0031.md
+++ b/_notices/rsn0031.md
@@ -5,7 +5,7 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
-notice_id: 30 # should match notice number
+notice_id: 31 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "CUDA 12 PIP Wheels Release in v23.06"
 notice_author: RAPIDS TPM

--- a/_notices/rsn0031.md
+++ b/_notices/rsn0031.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 31 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "CUDA 12 PIP Wheels Release in v23.06"
+title: "CUDA 12 pip Wheels Release in v23.06"
 notice_author: RAPIDS TPM
 notice_status: In Progress
 notice_status_color: yellow
@@ -26,9 +26,11 @@ notice_updated: 2023-05-16
 
 ## Overview
 
-The core RAPIDS packages that build pip wheels (rmm, cudf, raft, cuml, cugraph, cuopt, ucx-py) are now building pip wheels with `CUDA 12 support`.  We plan to release these packages in release v23.06.
+RAPIDS packages that build pip wheels (rmm, cudf, raft, cuml, cugraph, cuopt, ucx-py) are now building pip wheels with CUDA 12 support. We plan to release these packages in release v23.06.
+
+CUDA 12 wheels are named with a `-cu12` suffix to distinguish them from CUDA 11 wheels which have a `-cu11` suffix.
 
 
 ## Impact
 
-Users should be aware we now are building pip wheels with `CUDA 12 support` as noted above.
+Users should be aware we now are building pip wheels with CUDA 12 support as noted above.

--- a/maintainers/maintainers.md
+++ b/maintainers/maintainers.md
@@ -29,11 +29,11 @@ Operations
 
 Phase | Start | End | Duration
 -- | -- | -- | --
-Development (cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.nightly.cudf_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_dev.days }} days
+Development (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.nightly.cudf_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_dev.days }} days
 Development (others) | {{ site.data.releases.nightly.other_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_dev.days }} days
-[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.nightly.cudf_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_burndown.days }} days
+[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.nightly.cudf_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_burndown.days }} days
 [Burn Down]({% link releases/process.md %}#burn-down) (others) | {{ site.data.releases.nightly.other_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_burndown.days }} days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.nightly.cudf_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_codefreeze.days }} days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.nightly.cudf_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.cudf_codefreeze.days }} days
 [Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) [^1] | {{ site.data.releases.nightly.other_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.other_codefreeze.days }} days
 [Release]({% link releases/process.md %}#releasing) | {{ site.data.releases.nightly.release.start | date: "%a, %b %e" }} | {{ site.data.releases.nightly.release.end | date: "%a, %b %e" }} | {{ site.data.releases.nightly.release.days }} days
 
@@ -41,11 +41,11 @@ Development (others) | {{ site.data.releases.nightly.other_dev.start | date: "%a
 
 Phase | Start | End | Duration
 -- | -- | -- | --
-Development (cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.next_nightly.cudf_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_dev.days }} days
+Development (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.next_nightly.cudf_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_dev.days }} days
 Development (others) | {{ site.data.releases.next_nightly.other_dev.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_dev.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_dev.days }} days
-[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.next_nightly.cudf_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_burndown.days }} days
+[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.next_nightly.cudf_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_burndown.days }} days
 [Burn Down]({% link releases/process.md %}#burn-down) (others) | {{ site.data.releases.next_nightly.other_burndown.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_burndown.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_burndown.days }} days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops) | {{ site.data.releases.next_nightly.cudf_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_codefreeze.days }} days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.releases.next_nightly.cudf_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.cudf_codefreeze.days }} days
 [Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) [^1] | {{ site.data.releases.next_nightly.other_codefreeze.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_codefreeze.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.other_codefreeze.days }} days
 [Release]({% link releases/process.md %}#releasing) | {{ site.data.releases.next_nightly.release.start | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.release.end | date: "%a, %b %e" }} | {{ site.data.releases.next_nightly.release.days }} days
 


### PR DESCRIPTION
The core RAPIDS packages that build wheels (rmm, cudf, raft, cuml, cugraph, cuopt, ucx-py) are now also building wheels with CUDA 12 support. We plan to release these packages in 23.06.