### PR TITLE
Release Selector 23.06 Updates

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -525,11 +525,6 @@
                 if (pkgs === "cucim") {
                     index_url = "";
                 }
-
-                // This should be unnecessary and removed after 23.06
-                // if (isArm) {
-                //     cupy_inst = "\npip install cupy-cuda11x -f https://pip.cupy.dev/aarch64";
-                // }
                 
                 return pip_install + pkgs + index_url + cupy_inst;
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -692,7 +692,7 @@
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
                 if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
-                if (this.active_method === 'Conda' && cuda_version === '12.0') isDisabled = true;
+                if (this.active_method !== 'pip' && cuda_version === '12.0') isDisabled = true;
 
                 return isDisabled;
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -516,7 +516,7 @@
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;
-                    return pkg + cuda_suffix
+                    return pkg + cuda_suffix;
                 }
                 var pkgs = this.active_packages.map(libraryToPkg).join(" ");
                 var isArm = this.active_arch === "arm";
@@ -765,7 +765,7 @@
                     this.active_additional_packages = [];
                 }
                 if (method === 'Conda') {
-                    this.active_packages = ['Standard']
+                    this.active_packages = ['Standard'];
                 }
                 if (method === "pip") {
                     this.active_pip_cuda_ver = '12.0';

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -252,6 +252,15 @@
                         </div>
                     </template>
                 </div>
+                <div class="options-section">
+                    <div class="option-label">Method</div>
+                    <template x-for="method in methods">
+                        <div x-on:click="(e) => methodClickHandler(e, method)"
+                            x-bind:class="{'active': method === active_method}" class="option"
+                            x-html="getMethodHTML(method)">
+                        </div>
+                    </template>
+                </div>
                 <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">CUDA</div>
                     <template x-for="version in cuda_vers">
@@ -266,15 +275,6 @@
                         <div x-on:click="(e) => pipCUDAClickHandler(e, version)"
                             x-bind:class="{'active': version === active_pip_cuda_ver}"
                             class="option" x-text="'CUDA ' + version"></div>
-                    </template>
-                </div>
-                <div class="options-section">
-                    <div class="option-label">Method</div>
-                    <template x-for="method in methods">
-                        <div x-on:click="(e) => methodClickHandler(e, method)"
-                            x-bind:class="{'active': method === active_method}" class="option"
-                            x-html="getMethodHTML(method)">
-                        </div>
                     </template>
                 </div>
                 <div class="options-section" x-show="active_method !== 'pip'">

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -256,13 +256,13 @@
                     <div class="option-label">Method</div>
                     <template x-for="method in methods">
                         <div x-on:click="(e) => methodClickHandler(e, method)"
-                            x-bind:class="{'active': method === active_method}" class="option"
+                            x-bind:class="{'active': method === active_method, 'disabled': disableUnsupportedMethod(method)}" class="option"
                             x-html="getMethodHTML(method)">
                         </div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip'">
-                    <div class="option-label">CUDA</div>
+                <div class="options-section" x-show="active_method !== 'pip' && active_method !== 'Source'">
+                    <div class="option-label">ENV. CUDA</div>
                     <template x-for="version in cuda_vers">
                         <div x-on:click="(e) => cudaClickHandler(e, version)"
                             x-bind:class="{'active': version === active_cuda_ver, 'disabled': disableUnsupportedCuda(version)}"
@@ -270,14 +270,14 @@
                     </template>
                 </div>
                 <div class="options-section" x-show="active_method === 'pip'">
-                    <div class="option-label">CUDA</div>
+                    <div class="option-label">System CUDA</div>
                     <template x-for="version in pip_cuda_vers">
                         <div x-on:click="(e) => pipCUDAClickHandler(e, version)"
                             x-bind:class="{'active': version === active_pip_cuda_ver}"
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip'">
+                <div class="options-section" x-show="active_method !== 'pip' && active_method !== 'Source'">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
@@ -721,12 +721,20 @@
                 var isDisabled = false;
                 return isDisabled;
             },
+            disableUnsupportedMethod(method) {
+                var isDisabled = false;
+                if (this.active_release === "Nightly" && method === "pip") isDisabled = true;
+                return isDisabled;
+            },
             isDisabled(e) {
                 return e.classList.contains("disabled");
             },
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
+                if (release === 'Stable') {
+                        this.active_img_loc = 'NGC';
+                    }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;
@@ -768,7 +776,9 @@
                     this.active_packages = ['cuDF']
                 }
                 if (method === "Docker") {
-                    this.active_release = "Stable"
+                    if (this.active_release === 'Nightly') {
+                        this.active_img_loc = 'Dockerhub';
+                    }
                     if (this.active_os_ver === 'Ubuntu 22.04') {
                         this.active_cuda_ver = '11.8';
                     }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -677,7 +677,8 @@
                 return "Not implemented yet!";
             },
             getNewestCudaVer() {
-                return this.cuda_vers[this.cuda_vers.length - 1];
+                // TODO: When we support CUDA 12 on developer images, revert to this.cuda_vers.length - 1
+                return this.cuda_vers[this.cuda_vers.length - 2];
             },
             disableUnsupportedRelease(release) {
                 var isDisabled = false;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -400,7 +400,7 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["core", "standard"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            pip_packages: ["cuDF", "dask-cudf", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
+            pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "PyCaret", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -260,12 +260,12 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip'">
-                    <div class="option-label">Python</div>
-                    <template x-for="version in python_vers">
-                        <div x-on:click="(e) => pythonClickHandler(e, version)"
-                            x-bind:class="{'active': version === active_python_ver, 'disabled': disableUnsupportedPython(version)}"
-                            class="option" x-text="'Python ' + version"></div>
+                <div class="options-section" x-show="active_method === 'pip'">
+                    <div class="option-label">CUDA</div>
+                    <template x-for="version in pip_cuda_vers">
+                        <div x-on:click="(e) => pipCUDAClickHandler(e, version)"
+                            x-bind:class="{'active': version === active_pip_cuda_ver}"
+                            class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
                 <div class="options-section">
@@ -275,6 +275,14 @@
                             x-bind:class="{'active': method === active_method}" class="option"
                             x-html="getMethodHTML(method)">
                         </div>
+                    </template>
+                </div>
+                <div class="options-section" x-show="active_method !== 'pip'">
+                    <div class="option-label">Python</div>
+                    <template x-for="version in python_vers">
+                        <div x-on:click="(e) => pythonClickHandler(e, version)"
+                            x-bind:class="{'active': version === active_python_ver, 'disabled': disableUnsupportedPython(version)}"
+                            class="option" x-text="'Python ' + version"></div>
                     </template>
                 </div>
                 <div class="conda-options-container" x-show="active_method === 'Conda'">
@@ -370,6 +378,7 @@
             // default values
             active_python_ver: "3.10",
             active_cuda_ver: "11.8",
+            active_pip_cuda_ver: "12.0",
             active_os_ver: "Ubuntu 22.04",
             active_method: "Conda",
             active_release: "Stable",
@@ -381,16 +390,17 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.8", "3.10"],
-            cuda_vers: ["11.2", "11.4", "11.5", "11.8"],
+            python_vers: ["3.9", "3.10"],
+            cuda_vers: ["11.2", "11.4", "11.5", "11.8", "12.0"],
+            pip_cuda_vers: ["11.2 - 11.8", "12.0"],
             os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
             methods: ["Conda", "pip", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
-            img_types: ["core", "standard", "clx"],
+            img_types: ["core", "standard"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            pip_packages: ["cuDF", "cuML", "cuGraph", "cuCIM"],
+            pip_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "PyCaret", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
@@ -498,10 +508,15 @@
             getpipCmdHtml() {
                 var pip_install = "pip install ";
                 var index_url = " --extra-index-url=https://pypi.nvidia.com";
+                var cuda_suffix = "-cu12";
+                
+                if (this.active_pip_cuda_ver === "11.2 - 11.8") {
+                    cuda_suffix = "-cu11";
+                }
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;
-                    return pkg + "-cu11"
+                    return pkg + cuda_suffix
                 }
                 var pkgs = this.active_packages.map(libraryToPkg).join(" ");
                 var isArm = this.active_arch === "arm";
@@ -512,9 +527,9 @@
                 }
 
                 // This should be unnecessary and removed after 23.06
-                if (isArm) {
-                    cupy_inst = "\npip install cupy-cuda11x -f https://pip.cupy.dev/aarch64";
-                }
+                // if (isArm) {
+                //     cupy_inst = "\npip install cupy-cuda11x -f https://pip.cupy.dev/aarch64";
+                // }
                 
                 return pip_install + pkgs + index_url + cupy_inst;
             },
@@ -527,7 +542,6 @@
                 if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/"
                 var imgVariant = "";
                 if (this.active_img_type === "core") imgVariant = "core";
-                if (this.active_img_type === "clx") imgVariant = "clx";
                 var imgType = "base";
                 if (hasNotebooks) imgType = "runtime";
                 if (isDevel) imgType = "devel";
@@ -586,7 +600,6 @@
             getImgTypeText(type) {
                 if (type === "core") return "Basic"
                 if (type === "standard") return "Basic w/ Dask-SQL"
-                if (type === "clx") return "Basic w/ CLX"
                 return type;
             },
             getImgOptionText(option) {
@@ -604,9 +617,6 @@
 
                 if (this.active_img_type === "standard") {
                     core_pkgs = [...core_pkgs, "dask-sql"];
-                }
-                if (this.active_img_type === "clx") {
-                    core_pkgs = [...core_pkgs, "clx"];
                 }
                 var pkgs_html = core_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                 return [this.note_prefix + " The selected image contains the following packages:<br>" + pkgs_html];
@@ -631,9 +641,8 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, and <code>cuGraph</code> pip packages are hosted on the NVIDIA Index<br>",
-                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code><br>',
-                         'pip installation supports CUDA <code>11.2</code> - <code>11.8</code>'];
+                notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Index<br>",
+                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
@@ -688,7 +697,7 @@
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
                 if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
-                if (this.active_method === 'pip' && cuda_version !== '11.8') isDisabled = true;
+                if (this.active_method === 'Conda' && cuda_version === '12.0') isDisabled = true;
 
                 return isDisabled;
             },
@@ -738,6 +747,10 @@
                 if (this.isDisabled(e.target)) return;
                 this.active_cuda_ver = version;
             },
+            pipCUDAClickHandler(e, version) {
+                if (this.isDisabled(e.target)) return;
+                this.active_pip_cuda_ver = version;
+            },
             pythonClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
                 this.active_python_ver = version;
@@ -751,8 +764,11 @@
                 if (method !== "Conda") {
                     this.active_additional_packages = [];
                 }
+                if (method === 'Conda') {
+                    this.active_packages = ['Standard']
+                }
                 if (method === "pip") {
-                    this.active_cuda_ver = '11.8';
+                    this.active_pip_cuda_ver = '12.0';
                     this.active_release = 'Stable';
                     this.active_packages = ['cuDF']
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -637,7 +637,7 @@
             getpipNotes() {
                 var notes = [];
                 notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Index<br>",
-                         'pip installation supports Python <code>3.8</code>, <code>3.9</code>, and <code>3.10</code><br>'];
+                         'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -400,7 +400,7 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["core", "standard"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            pip_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
+            pip_packages: ["cuDF", "dask-cudf", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "PyCaret", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
@@ -636,7 +636,7 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Index<br>",
+                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
                          'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
@@ -705,6 +705,7 @@
                 var isDisabled = false;
                 if (this.active_arch === "arm" && os === "CentOS 7") isDisabled = true;
                 if (this.active_cuda_ver !== '11.8' && os === 'Ubuntu 22.04' && this.active_method === 'Docker') isDisabled = true;
+                if (this.active_arch === "arm" && os === 'Ubuntu 20.04' && this.active_method === 'Docker') isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {


### PR DESCRIPTION
This PR updates the release selector for 23.06:
- Python `3.8` has been replaced with `3.9`
- CUDA 12 has been added for pip!
   - In Conda/Docker it shows as a disabled button
   - I've added a new CUDA options row for pip - doing this let us get rid of the note and make it clear the CUDA version supported directly through the selector
- Moves `Method` above `Python` since it's more thematically appropriate IMO
   - ~I could see doing this for CUDA also, but didn't want to change _tooooo_ much all at once~
   - Made the change - I did this because `Method` changes the results of `CUDA`, feels wrong for something downstream to be above physically
- Adds cuSpatial for pip (Paul's working hard here 🙏 )
- Removes all `CLX` options as it has been removed/archived from RAPIDS

Some thoughts/comments:
- I don't clear the conda/pip cuda versions when they aren't being used - I figured it's a better experience for it to be saved if the user goes back and forth (and seemed like wasted cycles)
- I think we might be opening ourselves to questions about CUDA version compatibility, not 100% on the best path forward, but I can imagine a thought process like:
   1. I have a CUDA 12 machine
   2. I want RAPIDS
   3. Huh...only pip supports CUDA 12. I guess that means I can't use cuXFilter since it doesn't have a pip release 
   - Not sure if it makes sense to have a note that says Conda/Docker CUDA 11 installations work great on CUDA 12 machines

Contributes to #386 