### PR TITLE
23.06 Install Page Update

### DIFF
--- a/install/install.md
+++ b/install/install.md
@@ -123,7 +123,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 525.60.13 or newer **for pip installations only**
+- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive){: target="_blank"} with Driver 525.60.13 or newer **for pip installations only**
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
  
@@ -246,7 +246,7 @@ bash /rapids/utils/stop-jupyter.sh
 Beginning with the release of 23.06: cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT CUDA 11 and CUDA 12 pip packages are available on the NVIDIA Index.
 
 ### **pip Additional Prerequisites**
-<i class="fas fa-info-circle"></i> The CUDA version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
+<i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
 <i class="fas fa-info-circle"></i> **glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
 <i class="fas fa-info-circle"></i> **glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.31 (only ARM Server Base System Architecture is supported).
 

--- a/install/install.md
+++ b/install/install.md
@@ -59,6 +59,11 @@ If the server has not started or needs to be restarted / stop, use the included 
 <br/>
 
 ### **pip Issues**
+<i class="fas fa-info-circle"></i> The CUDA version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). If you're unsure of your system CUDA version, the code below automatically determines it:<br/>
+```
+CUDA_MAJOR_VERSION="$(nvidia-smi | head -n3 | tail -n1 | tr -d '[:space:]' | cut -d':' -f3 | cut -d '.' -f1)"
+pip install --extra-index-url=https://pypi.nvidia.com cudf-cu${CUDA_MAJOR_VERSION}
+```
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
 <i class="fas fa-info-circle"></i> These packages are not compatible with Tensorflow pip packages. Please use the [NGC containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow){: target="_blank"} or conda packages instead. <br/>
 <i class="fas fa-info-circle"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install `cupy-cuda11x`. For example:
@@ -118,7 +123,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 525.60.13 or newer for pip installations only
+- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 525.60.13 or newer **for pip installations only**
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
  
@@ -241,6 +246,7 @@ bash /rapids/utils/stop-jupyter.sh
 Beginning with the release of 23.06: cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT CUDA 11 and CUDA 12 pip packages are available on the NVIDIA Index.
 
 ### **pip Additional Prerequisites**
+<i class="fas fa-info-circle"></i> The CUDA version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
 <i class="fas fa-info-circle"></i> **glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
 <i class="fas fa-info-circle"></i> **glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.31 (only ARM Server Base System Architecture is supported).
 
@@ -312,7 +318,8 @@ Windows users can now tap into GPU accelerated data science on their local machi
 1. Install WSL2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
-4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then [install the CUDA Toolkit without drivers](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} into the WSL2 instance. It's important to execute `sudo apt-get -y install cuda-toolkit` instead of `sudo apt-get -y install cuda` to avoid installing a GPU driver into WSL2. The Windows host system provides the driver to WSL2.
+4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then install the WSL-specific [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} or [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} Toolkit without drivers into the WSL2 instance.
+	- The CUDA version you install must match the pip CUDA version you select for pip (`-cu11` or `-cu12`)
 5. Install RAPIDS pip packages on the WSL2 Linux Instance using the [release selector](#selector) commands.
 6. Run this code to check that the RAPIDS installation is working:
 	```

--- a/install/install.md
+++ b/install/install.md
@@ -59,11 +59,7 @@ If the server has not started or needs to be restarted / stop, use the included 
 <br/>
 
 ### **pip Issues**
-<i class="fas fa-info-circle"></i> The CUDA version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). If you're unsure of your system CUDA version, the code below automatically determines it:<br/>
-```
-CUDA_MAJOR_VERSION="$(nvidia-smi | head -n3 | tail -n1 | tr -d '[:space:]' | cut -d':' -f3 | cut -d '.' -f1)"
-pip install --extra-index-url=https://pypi.nvidia.com cudf-cu${CUDA_MAJOR_VERSION}
-```
+<i class="fas fa-info-circle"></i> The CUDA toolkit major version on your system must match the pip CUDA version you install (CUDA Toolkit 11 -> `-cu11` wheels and CUDA Toolkit 12 -> `-cu12` wheels). <br/>
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
 <i class="fas fa-info-circle"></i> These packages are not compatible with Tensorflow pip packages. Please use the [NGC containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow){: target="_blank"} or conda packages instead. <br/>
 <i class="fas fa-info-circle"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install `cupy-cuda11x`. For example:
@@ -127,7 +123,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
  
- **Note**: Docker and Conda CUDA 11.x installations function as expected on a CUDA 12.x machine. pip installations require using the matching wheel to the system's installed CUDA. For CUDA 11.x machines, install the <code>-cu11</code> wheels, and for CUDA 12.x machines install the <code>-cu12</code> wheels.
+ **Note**: RAPIDS Docker and Conda CUDA 11 environments function as expected on a system with a CUDA 12 driver and they include their own toolkit. pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 tookits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>

--- a/install/install.md
+++ b/install/install.md
@@ -74,7 +74,7 @@ ERROR: No matching distribution found for cudf-cu11
 ```
 Check the suggestions below for possible resolutions:
 - The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
-- Only Python versions 3.8, 3.9, or 3.10 are supported
+- Only Python versions 3.9 and 3.10 are supported
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip`
 
 <br/>
@@ -112,8 +112,11 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
+- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 525.60.13 or newer for pip installations only
 
- **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details.
+ **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
+ 
+ **Note**: Docker and Conda CUDA 11.x installations function as expected on a CUDA 12.x machine. pip installations require using the matching wheel to the system's installed CUDA. For CUDA 11.x machines, install the <code>-cu11</code> wheels, and for CUDA 12.x machines install the <code>-cu12</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>
@@ -229,7 +232,7 @@ bash /rapids/utils/stop-jupyter.sh
 <div id="pip"></div>
 
 ## **pip**
-Beginning with the release of 23.04: cuDF, dask-cuDF, cuML, cuGraph, RMM, and RAFT CUDA 11 pip packages are available on the NVIDIA Index.
+Beginning with the release of 23.06: cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT CUDA 11 and CUDA 12 pip packages are available on the NVIDIA Index.
 
 ### **pip Additional Prerequisites**
 <i class="fas fa-info-circle"></i> **glibc version:** x86_64 wheels require glibc >= 2.17. <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -59,7 +59,7 @@ If the server has not started or needs to be restarted / stop, use the included 
 <br/>
 
 ### **pip Issues**
-<i class="fas fa-info-circle"></i> The CUDA toolkit major version on your system must match the pip CUDA version you install (CUDA Toolkit 11 -> `-cu11` wheels and CUDA Toolkit 12 -> `-cu12` wheels). <br/>
+<i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system’s installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 tookits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
 <i class="fas fa-info-circle"></i> These packages are not compatible with Tensorflow pip packages. Please use the [NGC containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow){: target="_blank"} or conda packages instead. <br/>
 <i class="fas fa-info-circle"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install `cupy-cuda11x`. For example:

--- a/install/install.md
+++ b/install/install.md
@@ -59,7 +59,7 @@ If the server has not started or needs to be restarted / stop, use the included 
 <br/>
 
 ### **pip Issues**
-<i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system’s installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 tookits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>
+<i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 tookits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
 <i class="fas fa-info-circle"></i> These packages are not compatible with Tensorflow pip packages. Please use the [NGC containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow){: target="_blank"} or conda packages instead. <br/>
 <i class="fas fa-info-circle"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install `cupy-cuda11x`. For example:
@@ -123,7 +123,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
  
- **Note**: RAPIDS Docker and Conda CUDA 11 environments function as expected on a system with a CUDA 12 driver and they include their own toolkit. pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 tookits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
+ **Note**: RAPIDS Docker images and conda packages for CUDA 11 can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit. pip installations require using a wheel matching the system's installed CUDA toolkit. For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>
@@ -239,7 +239,7 @@ bash /rapids/utils/stop-jupyter.sh
 <div id="pip"></div>
 
 ## **pip**
-Beginning with the release of 23.06: cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT CUDA 11 and CUDA 12 pip packages are available on the NVIDIA Index.
+RAPIDS 23.06 pip packages of cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
 
 ### **pip Additional Prerequisites**
 <i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
@@ -315,7 +315,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
 4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then install the WSL-specific [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} or [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} Toolkit without drivers into the WSL2 instance.
-	- The CUDA version you install must match the pip CUDA version you select for pip (`-cu11` or `-cu12`)
+	- The installed CUDA Toolkit version must match the pip wheel version (`-cu11` or `-cu12`)
 5. Install RAPIDS pip packages on the WSL2 Linux Instance using the [release selector](#selector) commands.
 6. Run this code to check that the RAPIDS installation is working:
 	```

--- a/install/install.md
+++ b/install/install.md
@@ -85,6 +85,12 @@ Check the suggestions below for possible resolutions:
     jupyter-client 7.4.2 requires tornado>=6.2, but you have tornado 6.1 which is incompatible.
 ```
 
+<i class="fas fa-info-circle"></i> cuSpatial installation may yield the error below:<br/>
+```
+    ERROR: GDAL >= 3.2 is required for fiona. Please upgrade GDAL.
+```
+To resolve, either <code>GDAL</code> needs to be updated, or <code>fiona</code> needs to be pinned to specific versions depending on the installation OS. please see the [cuSpatial README](https://github.com/rapidsai/cuspatial/tree/branch-23.06#install-with-pip){: target="_blank"} to resolve this error.
+
 <br/>
 
 ### **WSL2 Issues**


### PR DESCRIPTION
This turned out smaller than expected, probably could have been part of #394 but I like smaller PRs anyway. 

- Removed the mention of `Python 3.8` support in pip installation guide
- Added CUDA 12.0 as a supported CUDA
- Added a note that the Docker/Conda CUDA 11 installations work fine on CUDA 12 machines, but that pip needs to match

Contributes to #386 