### PR TITLE
Enable `legacy` docs for `dask-cudf`

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -21,7 +21,7 @@ apis:
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 0
+      legacy: 1
       stable: 1
       nightly: 1
   cuml:


### PR DESCRIPTION
`dask-cudf` has `23.04`, `23.06`, and `23.08` docs available.

Therefore, we can enable this `legacy` flag for `dask-cudf`.