### PR TITLE
Update `earliest` driver version for GHA Runners

### DIFF
--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -116,7 +116,7 @@ Operating System
 
 ### GPU Labels
 
-{% assign earliest_driver_version = "450" %}
+{% assign earliest_driver_version = "470" %}
 {% assign latest_driver_version = "525" %}
 
 The GPU labeled runners are backed by lab machines and have the GPUs specified in the table below installed.


### PR DESCRIPTION
Our current `earliest` driver version, `450`, is EOL next week ([source](https://docs.nvidia.com/datacenter/tesla/drivers/#cuda-drivers)).

Therefore, we need to update to the next supported minimum driver version which is `470`.

This PR makes adjusts our docs accordingly.