### PR TITLE
Simplify releases page text.

### DIFF
--- a/releases/releases.md
+++ b/releases/releases.md
@@ -10,9 +10,4 @@ permalink: releases
 # Releases
 {:.no_toc}
 
-Releases are planned and merged in a defined process to ensure the community is not impacted by new feature development and a minor release is a stable as possible. The following pages outline our approach for releases.
-{: .fs-6 .fw-300 }
-
-## Release cadence
-
-RAPIDS aims for a new release every `~6 weeks`. This cadence will change as we approach `v1.0` and be documented on the pages below.
+Releases are planned using the processes and schedules outlined below.


### PR DESCRIPTION
I revamped the page text of https://docs.rapids.ai/releases. It discusses a 6-week release cadence and a march towards release 1.0 -- which is no longer accurate. I also removed some of the verbiage like "to ensure the community is not impacted by new feature development." Hopefully the community is _positively_ impacted by feature development. 😄