### PR TITLE
Add years to release schedule

### DIFF
--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,6 @@
-{
-  "2306": {
+[
+  {
+    "version": "23.06",
     "cudf_dev": {
       "start": "Mar 23 2023",
       "end": "May 17 2023",
@@ -35,5 +36,776 @@
       "end": "Jun 8 2023",
       "days": 2
     }
+  },
+  {
+    "version": "23.04",
+    "cudf_dev": {
+      "start": "Jan 19 2023",
+      "end": "Mar 22 2023",
+      "days": 42
+    },
+    "other_dev": {
+      "start": "Jan 26 2023",
+      "end": "Mar 29 2023",
+      "days": 42
+    },
+    "cudf_burndown": {
+      "start": "Mar 23 2023",
+      "end": "Mar 29 2023",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Mar 30 2023",
+      "end": "Apr 5 2023",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Mar 30 2023",
+      "end": "Apr 4 2023",
+      "days": 4
+    },
+    "other_codefreeze": {
+      "start": "Apr 6 2023",
+      "end": "Apr 11 2023",
+      "days": 4
+    },
+    "release": {
+      "start": "Apr 12 2023",
+      "end": "Apr 13 2023",
+      "days": 2
+    }
+  },
+  {
+    "version": "23.02",
+    "cudf_dev": {
+      "start": "Nov 10 2022",
+      "end": "Jan 18 2023",
+      "days": 42
+    },
+    "other_dev": {
+      "start": "Nov 17 2022",
+      "end": "Jan 25 2023",
+      "days": 43
+    },
+    "cudf_burndown": {
+      "start": "Jan 19 2023",
+      "end": "Jan 25 2023",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Jan 26 2023",
+      "end": "Feb 1 2023",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Jan 26 2023",
+      "end": "Jan 31 2023",
+      "days": 4
+    },
+    "other_codefreeze": {
+      "start": "Feb 2 2023",
+      "end": "Feb 7 2023",
+      "days": 4
+    },
+    "release": {
+      "start": "Feb 8 2023",
+      "end": "Feb 9 2023",
+      "days": 2
+    }
+  },
+  {
+    "version": "22.12",
+    "cudf_dev": {
+      "start": "Sep 22 2022",
+      "end": "Nov 9 2022",
+      "days": 35
+    },
+    "other_dev": {
+      "start": "Sep 29 2022",
+      "end": "Nov 16 2022",
+      "days": 34
+    },
+    "cudf_burndown": {
+      "start": "Nov 10 2022",
+      "end": "Nov 16 2022",
+      "days": 4
+    },
+    "other_burndown": {
+      "start": "Nov 17 2022",
+      "end": "Nov 30 2022",
+      "days": 8
+    },
+    "cudf_codefreeze": {
+      "start": "Nov 17 2022",
+      "end": "Nov 30 2022",
+      "days": 8
+    },
+    "other_codefreeze": {
+      "start": "Dec 1 2022",
+      "end": "Dec 6 2022",
+      "days": 4
+    },
+    "release": {
+      "start": "Dec 7 2022",
+      "end": "Dec 8 2022",
+      "days": 2
+    }
+  },
+  {
+    "version": "22.10",
+    "cudf_dev": {
+      "start": "Jul 21 2022",
+      "end": "Sep 21 2022",
+      "days": 42
+    },
+    "other_dev": {
+      "start": "Jul 28 2022",
+      "end": "Sep 28 2022",
+      "days": 42
+    },
+    "cudf_burndown": {
+      "start": "Sep 22 2022",
+      "end": "Sep 28 2022",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Sep 29 2022",
+      "end": "Oct 5 2022",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Sep 29 2022",
+      "end": "Oct 5 2022",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Oct 6 2022",
+      "end": "Oct 11 2022",
+      "days": 4
+    },
+    "release": {
+      "start": "Oct 12 2022",
+      "end": "Oct 13 2022",
+      "days": 2
+    }
+  },
+  {
+    "version": "22.08",
+    "cudf_dev": {
+      "start": "May 18 2022",
+      "end": "Jul 20 2022",
+      "days": 41
+    },
+    "other_dev": {
+      "start": "May 25 2022",
+      "end": "Jul 27 2022",
+      "days": 41
+    },
+    "cudf_burndown": {
+      "start": "Jul 21 2022",
+      "end": "Jul 27 2022",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Jul 28 2022",
+      "end": "Aug 3 2022",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Jul 28 2022",
+      "end": "Aug 3 2022",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Aug 4 2022",
+      "end": "Aug 10 2022",
+      "days": 5
+    },
+    "release": {
+      "start": "Aug 11 2022",
+      "end": "Aug 17 2022",
+      "days": 5
+    }
+  },
+  {
+    "version": "22.06",
+    "cudf_dev": {
+      "start": "Mar 17 2022",
+      "end": "May 17 2022",
+      "days": 44
+    },
+    "other_dev": {
+      "start": "Mar 24 2022",
+      "end": "May 24 2022",
+      "days": 44
+    },
+    "cudf_burndown": {
+      "start": "May 18 2022",
+      "end": "May 24 2022",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "May 25 2022",
+      "end": "Jun 1 2022",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "May 25 2022",
+      "end": "May 31 2022",
+      "days": 4
+    },
+    "other_codefreeze": {
+      "start": "Jun 2 2022",
+      "end": "Jun 6 2022",
+      "days": 3
+    },
+    "release": {
+      "start": "Jun 7 2022",
+      "end": "Jun 8 2022",
+      "days": 2
+    }
+  },
+  {
+    "version": "22.04",
+    "cudf_dev": {
+      "start": "Jan 12 2022",
+      "end": "Mar 16 2022",
+      "days": 44
+    },
+    "other_dev": {
+      "start": "Jan 20 2022",
+      "end": "Mar 23 2022",
+      "days": 44
+    },
+    "cudf_burndown": {
+      "start": "Mar 17 2022",
+      "end": "Mar 23 2022",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Mar 24 2022",
+      "end": "Mar 30 2022",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Mar 24 2022",
+      "end": "Mar 30 2022",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Mar 31 2022",
+      "end": "Apr 5 2022",
+      "days": 4
+    },
+    "release": {
+      "start": "Apr 6 2022",
+      "end": "Apr 7 2022",
+      "days": 2
+    }
+  },
+  {
+    "version": "22.02",
+    "cudf_dev": {
+      "start": "Nov 4 2021",
+      "end": "Jan 11 2022",
+      "days": 43
+    },
+    "other_dev": {
+      "start": "Nov 11 2021",
+      "end": "Jan 19 2022",
+      "days": 43
+    },
+    "cudf_burndown": {
+      "start": "Jan 12 2022",
+      "end": "Jan 19 2022",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Jan 20 2022",
+      "end": "Jan 26 2022",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Jan 20 2022",
+      "end": "Jan 26 2022",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Jan 27 2022",
+      "end": "Feb 1 2022",
+      "days": 4
+    },
+    "release": {
+      "start": "Feb 2 2022",
+      "end": "Feb 3 2022",
+      "days": 2
+    }
+  },
+  {
+    "version": "21.12",
+    "cudf_dev": {
+      "start": "Sep 16 2021",
+      "end": "Nov 3 2021",
+      "days": 35
+    },
+    "other_dev": {
+      "start": "Sep 23 2021",
+      "end": "Nov 10 2021",
+      "days": 35
+    },
+    "cudf_burndown": {
+      "start": "Nov 4 2021",
+      "end": "Nov 10 2021",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Nov 11 2021",
+      "end": "Nov 17 2021",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Nov 11 2021",
+      "end": "Nov 17 2021",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Nov 18 2021",
+      "end": "Nov 30 2021",
+      "days": 7
+    },
+    "release": {
+      "start": "Dec 8 2021",
+      "end": "Dec 9 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "21.10",
+    "cudf_dev": {
+      "start": "Jul 14 2021",
+      "end": "Sep 15 2021",
+      "days": 45
+    },
+    "other_dev": {
+      "start": "Jul 21 2021",
+      "end": "Sep 22 2021",
+      "days": 45
+    },
+    "cudf_burndown": {
+      "start": "Sep 16 2021",
+      "end": "Sep 22 2021",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Sep 23 2021",
+      "end": "Sep 28 2021",
+      "days": 4
+    },
+    "cudf_codefreeze": {
+      "start": "Sep 23 2021",
+      "end": "Sep 28 2021",
+      "days": 4
+    },
+    "other_codefreeze": {
+      "start": "Sep 29 2021",
+      "end": "Oct 5 2021",
+      "days": 5
+    },
+    "release": {
+      "start": "Oct 6 2021",
+      "end": "Oct 7 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "21.08",
+    "cudf_dev": {
+      "start": "May 19 2021",
+      "end": "Jul 14 2021",
+      "days": 39
+    },
+    "other_dev": {
+      "start": "May 26 2021",
+      "end": "Jul 21 2021",
+      "days": 39
+    },
+    "cudf_burndown": {
+      "start": "Jul 15 2021",
+      "end": "Jul 21 2021",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Jul 22 2021",
+      "end": "Jul 28 2021",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Jul 22 2021",
+      "end": "Jul 28 2021",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Jul 29 2021",
+      "end": "Aug 3 2021",
+      "days": 4
+    },
+    "release": {
+      "start": "Aug 4 2021",
+      "end": "Aug 5 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "21.06",
+    "cudf_dev": {
+      "start": "Mar 25 2021",
+      "end": "May 18 2021",
+      "days": 39
+    },
+    "other_dev": {
+      "start": "Apr 1 2021",
+      "end": "May 25 2021",
+      "days": 39
+    },
+    "cudf_burndown": {
+      "start": "May 19 2021",
+      "end": "May 25 2021",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "May 26 2021",
+      "end": "Jun 2 2021",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "May 26 2021",
+      "end": "Jun 2 2021",
+      "days": 4
+    },
+    "other_codefreeze": {
+      "start": "Jun 3 2021",
+      "end": "Jun 8 2021",
+      "days": 4
+    },
+    "release": {
+      "start": "Jun 9 2021",
+      "end": "Jun 10 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "0.19",
+    "cudf_dev": {
+      "start": "Jan 27 2021",
+      "end": "Mar 24 2021",
+      "days": 40
+    },
+    "other_dev": {
+      "start": "Feb 3 2021",
+      "end": "Mar 31 2021",
+      "days": 40
+    },
+    "cudf_burndown": {
+      "start": "Mar 25 2021",
+      "end": "Mar 31 2021",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Apr 1 2021",
+      "end": "Apr 7 2021",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Apr 1 2021",
+      "end": "Apr 7 2021",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Apr 8 2021",
+      "end": "Apr 20 2021",
+      "days": 9
+    },
+    "release": {
+      "start": "Apr 21 2021",
+      "end": "Apr 22 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "0.18",
+    "cudf_dev": {
+      "start": "Nov 24 2020",
+      "end": "Jan 26 2021",
+      "days": 34
+    },
+    "other_dev": {
+      "start": "Nov 24 2020",
+      "end": "Feb 2 2021",
+      "days": 39
+    },
+    "cudf_burndown": {
+      "start": "Jan 27 2021",
+      "end": "Feb 16 2021",
+      "days": 14
+    },
+    "other_burndown": {
+      "start": "Feb 3 2021",
+      "end": "Feb 16 2021",
+      "days": 9
+    },
+    "cudf_codefreeze": {
+      "start": "Feb 17 2021",
+      "end": "Feb 23 2021",
+      "days": 5
+    },
+    "other_codefreeze": {
+      "start": "Feb 17 2021",
+      "end": "Feb 23 2021",
+      "days": 5
+    },
+    "release": {
+      "start": "Feb 24 2021",
+      "end": "Feb 25 2021",
+      "days": 2
+    }
+  },
+  {
+    "version": "0.17",
+    "dev": {
+      "start": "Oct 1 2020",
+      "end": "Nov 23 2020",
+      "days": 38
+    },
+    "burndown": {
+      "start": "Nov 24 2020",
+      "end": "Dec 3 2020",
+      "days": 6
+    },
+    "codefreeze": {
+      "start": "Dec 4 2020",
+      "end": "Dec 9 2020",
+      "days": 4
+    },
+    "release": {
+      "start": "Dec 10 2020",
+      "end": "Dec 10 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.16",
+    "dev": {
+      "start": "Aug 6 2020",
+      "end": "Sep 30 2020",
+      "days": 39
+    },
+    "burndown": {
+      "start": "Oct 1 2020",
+      "end": "Oct 14 2020",
+      "days": 10
+    },
+    "codefreeze": {
+      "start": "Oct 15 2020",
+      "end": "Oct 20 2020",
+      "days": 4
+    },
+    "release": {
+      "start": "Oct 21 2020",
+      "end": "Oct 21 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.15",
+    "dev": {
+      "start": "May 19 2020",
+      "end": "Aug 5 2020",
+      "days": 56
+    },
+    "burndown": {
+      "start": "Aug 6 2020",
+      "end": "Aug 19 2020",
+      "days": 10
+    },
+    "codefreeze": {
+      "start": "Aug 20 2020",
+      "end": "Aug 25 2020",
+      "days": 4
+    },
+    "release": {
+      "start": "Aug 26 2020",
+      "end": "Aug 26 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.14",
+    "dev": {
+      "start": "Mar 9 2020",
+      "end": "May 18 2020",
+      "days": 51
+    },
+    "burndown": {
+      "start": "May 19 2020",
+      "end": "May 27 2020",
+      "days": 6
+    },
+    "codefreeze": {
+      "start": "May 28 2020",
+      "end": "Jun 2 2020",
+      "days": 4
+    },
+    "release": {
+      "start": "Jun 3 2020",
+      "end": "Jun 3 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.13",
+    "dev": {
+      "start": "Jan 16 2020",
+      "end": "Mar 6 2020",
+      "days": 35
+    },
+    "burndown": {
+      "start": "Mar 9 2020",
+      "end": "Mar 26 2020",
+      "days": 14
+    },
+    "codefreeze": {
+      "start": "Mar 27 2020",
+      "end": "Mar 30 2020",
+      "days": 2
+    },
+    "release": {
+      "start": "Mar 31 2020",
+      "end": "Mar 31 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.12",
+    "dev": {
+      "start": "Nov 21 2019",
+      "end": "Jan 15 2020",
+      "days": 36
+    },
+    "burndown": {
+      "start": "Jan 16 2020",
+      "end": "Jan 23 2020",
+      "days": 5
+    },
+    "codefreeze": {
+      "start": "Jan 24 2020",
+      "end": "Feb 3 2020",
+      "days": 9
+    },
+    "release": {
+      "start": "Feb 4 2020",
+      "end": "Feb 4 2020",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.11",
+    "dev": {
+      "start": "Sep 26 2019",
+      "end": "Nov 20 2019",
+      "days": 40
+    },
+    "burndown": {
+      "start": "Nov 21 2019",
+      "end": "Dec 4 2019",
+      "days": 8
+    },
+    "codefreeze": {
+      "start": "Dec 5 2019",
+      "end": "Dec 10 2019",
+      "days": 4
+    },
+    "release": {
+      "start": "Dec 11 2019",
+      "end": "Dec 11 2019",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.10",
+    "dev": {
+      "start": "Aug 14 2019",
+      "end": "Sep 25 2019",
+      "days": 30
+    },
+    "burndown": {
+      "start": "Sep 26 2019",
+      "end": "Oct 2 2019",
+      "days": 5
+    },
+    "codefreeze": {
+      "start": "Oct 10 2019",
+      "end": "Oct 16 2019",
+      "days": 5
+    },
+    "release": {
+      "start": "Oct 17 2019",
+      "end": "Oct 17 2019",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.9",
+    "dev": {
+      "start": "Jun 24 2019",
+      "end": "Aug 6 2019",
+      "days": 30
+    },
+    "burndown": {
+      "start": "Aug 7 2019",
+      "end": "Aug 13 2019",
+      "days": 5
+    },
+    "codefreeze": {
+      "start": "Aug 14 2019",
+      "end": "Aug 20 2019",
+      "days": 5
+    },
+    "release": {
+      "start": "Aug 21 2019",
+      "end": "Aug 21 2019",
+      "days": 1
+    }
+  },
+  {
+    "version": "0.8",
+    "release": "Jun 27 2019"
+  },
+  {
+    "version": "0.7",
+    "release": "May 10 2019"
+  },
+  {
+    "version": "0.6",
+    "release": "Mar 22 2019"
+  },
+  {
+    "version": "0.5",
+    "release": "Jan 31 2019"
+  },
+  {
+    "version": "0.4",
+    "release": "Dec 10 2018"
+  },
+  {
+    "version": "0.3",
+    "release": "Nov 29 2018"
+  },
+  {
+    "version": "0.2",
+    "release": "Nov 14 2018"
+  },
+  {
+    "version": "0.1",
+    "release": "Oct 28 2018"
   }
-}
+]

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -778,34 +778,34 @@
   },
   {
     "version": "0.8",
-    "release": "Jun 27 2019"
+    "date": "Jun 27 2019"
   },
   {
     "version": "0.7",
-    "release": "May 10 2019"
+    "date": "May 10 2019"
   },
   {
     "version": "0.6",
-    "release": "Mar 22 2019"
+    "date": "Mar 22 2019"
   },
   {
     "version": "0.5",
-    "release": "Jan 31 2019"
+    "date": "Jan 31 2019"
   },
   {
     "version": "0.4",
-    "release": "Dec 10 2018"
+    "date": "Dec 10 2018"
   },
   {
     "version": "0.3",
-    "release": "Nov 29 2018"
+    "date": "Nov 29 2018"
   },
   {
     "version": "0.2",
-    "release": "Nov 14 2018"
+    "date": "Nov 14 2018"
   },
   {
     "version": "0.1",
-    "release": "Oct 28 2018"
+    "date": "Oct 28 2018"
   }
 ]

--- a/releases/schedule.md
+++ b/releases/schedule.md
@@ -32,263 +32,32 @@ The current release schedule is posted on the [RAPIDS Maintainers Docs]({% link 
 
 Historical list of completed releases
 
-### Release v23.06 Schedule
+{% for release in site.data.previous_releases %}
+### Release v{{ release.version }} Schedule
 
+{% if release.dev %}
 Phase | Start | End | Duration
 -- | -- | -- | --
-Development (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.previous_releases.2306.cudf_dev.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_dev.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_dev.days }} days
-Development (others) | {{ site.data.previous_releases.2306.other_dev.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_dev.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_dev.days }} days
-[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.previous_releases.2306.cudf_burndown.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_burndown.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_burndown.days }} days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | {{ site.data.previous_releases.2306.other_burndown.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_burndown.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_burndown.days }} days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ site.data.previous_releases.2306.cudf_codefreeze.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_codefreeze.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.cudf_codefreeze.days }} days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | {{ site.data.previous_releases.2306.other_codefreeze.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_codefreeze.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.other_codefreeze.days }} days
-[Release]({% link releases/process.md %}#releasing) | {{ site.data.previous_releases.2306.release.start | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.release.end | date: "%a, %b %e, %Y" }} | {{ site.data.previous_releases.2306.release.days }} days
+Development | {{ release.dev.start | date: "%a, %b %e, %Y" }} | {{ release.dev.end | date: "%a, %b %e, %Y" }} | {{ release.dev.days }} days
+Burn Down | {{ release.burndown.start | date: "%a, %b %e, %Y" }} | {{ release.burndown.end | date: "%a, %b %e, %Y" }} | {{ release.burndown.days }} days
+Code Freeze/Testing | {{ release.codefreeze.start | date: "%a, %b %e, %Y" }} | {{ release.codefreeze.end | date: "%a, %b %e, %Y" }} | {{ release.codefreeze.days }} days
+Release | {{ release.release.start | date: "%a, %b %e, %Y" }} | {{ release.release.end | date: "%a, %b %e, %Y" }} | {{ release.release.days }} days
 
-### Release v23.04 Schedule
-
+{% else %}
+{% if release.version < '0.9' %}
+Phase | Date
+-- | --
+Release | {{ release.release | date: "%a, %b %e, %Y" }}
+{% else %}
 Phase | Start | End | Duration
 -- | -- | -- | --
-Development (cuDF/RMM) | Thu, Jan 19, 2023 | Wed, Mar 22, 2023 | 42 days
-Development (others) | Thu, Jan 26, 2023 | Wed, Mar 29, 2023 | 42 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Mar 23, 2023 | Wed, Mar 29, 2023 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Mar 30, 2023 | Wed, Apr 5, 2023 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Mar 30, 2023 | Tue, Apr 4, 2023 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 6, 2023 | Tue, Apr 11, 2023 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Apr 12, 2023 | Thu, Apr 13, 2023 | 2 days
-
-### Release v23.02 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Nov 10 | Wed, Jan 18 | 42 days
-Development (others) | Thu, Nov 17 | Wed, Jan 25 | 43 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Jan 19 | Wed, Jan 25 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Jan 26 | Wed, Feb 1 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Jan 26 | Tue, Jan 31 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Feb 2 | Tue, Feb 7 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Feb 8 | Thu, Feb 9 | 2 days
-
-### Release v22.12 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Sep 22 | Wed, Nov 9 | 35 days
-Development (others) | Thu, Sep 29 | Wed, Nov 16 | 34 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Nov 10 | Wed, Nov 16 | 4 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Nov 17 | Wed, Nov 30 | 8 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Nov 17 | Wed, Nov 30 | 8 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Dec 1 | Tue, Dec 6 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Dec 7 | Thu, Dec 8 | 2 days
-
-### Release v22.10 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Jul 21 | Wed, Sep 21 | 42 days
-Development (others) | Thu, Jul 28 | Wed, Sep 28 | 42 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Sep 22 | Wed, Sep 28 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Sep 29 | Wed, Oct 5 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Sep 29 | Wed, Oct 5 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Oct 6 | Tue, Oct 11 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Oct 12 | Thu, Oct 13 | 2 days
-
-### Release v22.08 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Wed, May 18 | Wed, Jul 20 | 41 days
-Development (others) | Wed, May 25 | Wed, Jul 27 | 41 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Jul 21 | Wed, Jul 27 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Jul 28 | Wed, Aug 3 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Jul 28 | Wed, Aug 3 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Aug 4 | Wed, Aug 10 | 5 days
-[Release]({% link releases/process.md %}#releasing) | Thu, Aug 11 | Wed, Aug 17 | 5 days
-
-### Release v22.06 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Mar 17 | Tue, May 17 | 44 days
-Development (others) | Thu, Mar 24 | Tue, May 24 | 44 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Wed, May 18 | Tue, May 24 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Wed, May 25 | Wed, Jun 1 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Wed, May 25 | Tue, May 31 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Jun 2 | Mon, Jun 6 | 3 days
-[Release]({% link releases/process.md %}#releasing) | Tue, Jun 7 | Wed, Jun 8 | 2 days
-
-### Release v22.04 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Wed, Jan 12 | Wed, Mar 16 | 44 days
-Development (others) | Thu, Jan 20 | Wed, Mar 23 | 44 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Mar 17 | Wed, Mar 23 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Mar 24 | Wed, Mar 30 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Mar 24 | Wed, Mar 30 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Mar 31 | Tue, Apr 5 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Apr 6 | Thu, Apr 7 | 2 days
-
-### Release v22.02 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Nov 4 | Tue, Jan 11 | 43 days
-Development (others) | Thu, Nov 11 | Wed, Jan 19 | 43 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Wed, Jan 12 | Wed, Jan 19 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Jan 20 | Wed, Jan 26 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Jan 20 | Wed, Jan 26 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Jan 27 | Tue, Feb 1 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Feb 2 | Thu, Feb 3 | 2 days
-
-### Release v21.12 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Sep 16 | Wed, Nov 3 | 35 days
-Development (others) | Thu, Sep 23 | Wed, Nov 10 | 35 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Nov 4 | Wed, Nov 10 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Nov 11 | Wed, Nov 17 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Nov 11 | Wed, Nov 17 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Nov 18 | Tue, Nov 30 | 7 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Dec 8 | Thu, Dec 9 | 2 days
-
-### Release v21.10 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Wed, Jul 14 | Wed, Sep 15 | 45 days
-Development (others) | Wed, Jul 21 | Wed, Sep 22 | 45 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Sep 16 | Wed, Sep 22 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Sep 23 | Tue, Sep 28 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Sep 23 | Tue, Sep 28 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Wed, Sep 29 | Tue, Oct 5 | 5 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Oct 6 | Thu, Oct 7 | 2 days
-
-### Release v21.08 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Wed, May 19 | Wed, Jul 14 | 39 days
-Development (others) | Wed, May 26 | Wed, Jul 21 | 39 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Jul 15 | Wed, Jul 21 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Jul 22 | Wed, Jul 28 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Jul 22 | Wed, Jul 28 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Jul 29 | Tue, Aug 3 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Aug 4 | Thu, Aug 5 | 2 days
-
-### Release v21.06 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Thu, Mar 25 | Tue, May 18 | 39 days
-Development (others) | Thu, Apr 1 | Tue, May 25 | 39 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Wed, May 19 | Tue, May 25 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Wed, May 26 | Wed, Jun 2 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Wed, May 26 | Wed, Jun 2 | 4 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Jun 3 | Tue, Jun 8 | 4 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Jun 9 | Thu, Jun 10 | 2 days
-
-### Release v0.19 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Wed, Jan 27 | Wed, Mar 24 | 40 days
-Development (others) | Wed, Feb 3 | Wed, Mar 31 | 40 days
-[Burn Down]({% link releases/process.md %}#burn-down) (cuDF/RMM) | Thu, Mar 25 | Wed, Mar 31 | 5 days
-[Burn Down]({% link releases/process.md %}#burn-down) (others) | Thu, Apr 1 | Wed, Apr 7 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM) | Thu, Apr 1 | Wed, Apr 7 | 5 days
-[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | Thu, Apr 8 | Tue, Apr 20 | 9 days
-[Release]({% link releases/process.md %}#releasing) | Wed, Apr 21 | Thu, Apr 22 | 2 days
-
-### Release v0.18 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development (cuDF/RMM) | Tue, Nov 24 | Tue, Jan 26 | 34 days
-Development (others) | Tue, Nov 24 | Tue, Feb 2 | 39 days
-Burn Down (cuDF/RMM) | Wed, Jan 27 | Tue, Feb 16 | 14 days
-Burn Down (others) | Wed, Feb 3 | Tue, Feb 16 | 9 days
-Code Freeze/Testing (cuDF/RMM) | Wed, Feb 17 | Tue, Feb 23 | 5 days
-Code Freeze/Testing (others) | Wed, Feb 17 | Tue, Feb 23 | 5 days
-Release | Wed, Feb 24 | Thu, Feb 25 | 2 days
-
-### Release v0.17 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Thu, Oct 1st | Mon, Nov 23rd | 38 days
-Burn Down | Tue, Nov 24th | Thu, Dec 3rd | 6 days
-Code Freeze/Testing | Fri, Dec 4th | Wed, Dec 9th | 4 days
-Release | Thu, Dec 10th | Thu, Dec 10th | 1 day
-
-### Release v0.16 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Thu, Aug 6th | Wed, Sept 30th | 39 days
-Burn Down | Thu, Oct 1st | Wed, Oct 14th | 10 days
-Code Freeze/Testing | Thu, Oct 15th | Tue, Oct 20th | 4 days
-Release | Wed, Oct 21st | Wed, Oct 21st | 1 day
-
-### Release v0.15 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Tue, May 19th | Wed, Aug 5th | 56 days
-Burn Down | Thu, Aug 6th | Wed, Aug 19th | 10 days
-Code Freeze/Testing | Thu, Aug 20th | Tue, Aug 25th | 4 days
-Release | Wed, Aug 26th | Wed, Aug 26th | 1 day
-
-### Release v0.14 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Mon, Mar 9th | Mon, May 18th | 51 days
-Burn Down | Tue, May 19th | Wed, May 27th | 6 days
-Code Freeze/Testing | Thu, May 28th | Tue, June 2nd | 4 days
-Release | Wed, June 3rd | Wed, June 3rd | 1 day
-
-### Release v0.13 Schedule
-
-Phase | Start | End | Duration
--- | -- | -- | --
-Development | Thu, Jan 16th | Fri, Mar 6th | 35 days
-Burn Down | Mon, Mar 9th | Thu, Mar 26th | 14 days
-Code Freeze/Testing | Fri, Mar 27th | Mon, Mar 30th | 2 days
-Release | Tue, Mar 31st | Tue, Mar 31st | 1 day
-
-### Release v0.12 Schedule
-
-| Phase | Start | End | Duration |
-|:------|:------|:----|:---------|
-| New Development | Thu, Nov 21st | Wed, Jan 15th | 36 days |
-| Burn Down | Thu, Jan 16th | Thu, Jan 23rd | 5 days |
-| Code Freeze/Testing | Fri, Jan 24th | Mon, Feb 3rd | 9 days |
-| Release | Tue, Feb 4th | Tue, Feb 4th | 1 day |
-
-### Release v0.11 Schedule
-
-| Phase | Start | End | Duration |
-|:------|:------|:----|:---------|
-| New Development | Thu, Sep 26th | Wed, Nov 20th | 40 days |
-| Burn Down | Thu, Nov 21st | Wed, Dec 4th | 8 days |
-| Code Freeze/Testing | Thu, Dec 5th | Tue, Dec 10th | 4 days |
-| Release | Wed, Dec 11th | Wed, Dec 11th | 1 day |
-
-### Release v0.10 Schedule
-
-| Phase | Start | End | Duration |
-|:------|:------|:----|:---------|
-| New Development | Wed, Aug 14th | Wed, Sep 25th | 30 days |
-| Burn Down | Thu, Sep 26th | Wed, Oct 2nd | 5 days |
-| Code Freeze/Testing | Thu, Oct 10th | Wed, Oct 16th | 5 days |
-| Release | Thu, Oct 17th | Thu, Oct 17th | 1 day |
-
-### Release v0.9 Schedule
-
-| Phase | Start | End | Duration |
-|:------|:------|:----|:---------|
-| New Development | Mon, Jun 24th | Tue, Aug 6th | 30 days |
-| Burn Down | Wed, Aug 7th | Tue, Aug 13th | 5 days |
-| Code Freeze/Testing | Wed, Aug 14th | Tue, Aug 20th | 5 days |
-| Release | Wed, Aug 21st | Wed, Aug 21st | 1 day |
+Development (cuDF/RMM{% if release.version >= '23.06' %}/rapids-cmake/cugraph-ops/raft{% endif %}) | {{ release.cudf_dev.start | date: "%a, %b %e, %Y" }} | {{ release.cudf_dev.end | date: "%a, %b %e, %Y" }} | {{ release.cudf_dev.days }} days
+Development (others) | {{ release.other_dev.start | date: "%a, %b %e, %Y" }} | {{ release.other_dev.end | date: "%a, %b %e, %Y" }} | {{ release.other_dev.days }} days
+[Burn Down]({% link releases/process.md %}#burn-down)(cuDF/RMM{% if release.version >= '23.06' %}/rapids-cmake/cugraph-ops/raft{% endif %}) | {{ release.cudf_burndown.start | date: "%a, %b %e, %Y" }} | {{ release.cudf_burndown.end | date: "%a, %b %e, %Y" }} | {{ release.cudf_burndown.days }} days
+[Burn Down]({% link releases/process.md %}#burn-down) (others) | {{ release.other_burndown.start | date: "%a, %b %e, %Y" }} | {{ release.other_burndown.end | date: "%a, %b %e, %Y" }} | {{ release.other_burndown.days }} days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (cuDF/RMM/rapids-cmake/cugraph-ops/raft) | {{ release.cudf_codefreeze.start | date: "%a, %b %e, %Y" }} | {{ release.cudf_codefreeze.end | date: "%a, %b %e, %Y" }} | {{ release.cudf_codefreeze.days }} days
+[Code Freeze/Testing]({% link releases/process.md %}#code-freeze) (others) | {{ release.other_codefreeze.start | date: "%a, %b %e, %Y" }} | {{ release.other_codefreeze.end | date: "%a, %b %e, %Y" }} | {{ release.other_codefreeze.days }} days
+[Release]({% link releases/process.md %}#releasing) | {{ release.release.start | date: "%a, %b %e, %Y" }} | {{ release.release.end | date: "%a, %b %e, %Y" }} | {{ release.release.days }} days
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/releases/schedule.md
+++ b/releases/schedule.md
@@ -44,10 +44,10 @@ Code Freeze/Testing | {{ release.codefreeze.start | date: "%a, %b %e, %Y" }} | {
 Release | {{ release.release.start | date: "%a, %b %e, %Y" }} | {{ release.release.end | date: "%a, %b %e, %Y" }} | {{ release.release.days }} days
 
 {% else %}
-{% if release.version < '0.9' %}
+{% if release.date %}
 Phase | Date
 -- | --
-Release | {{ release.release | date: "%a, %b %e, %Y" }}
+Release | {{ release.date | date: "%a, %b %e, %Y" }}
 {% else %}
 Phase | Start | End | Duration
 -- | -- | -- | --


### PR DESCRIPTION
This PR does a few things to the previous releases schedule:
1. Refactors the schedule page to use `previous_releases.json` as source of truth for all versions
2. Adds the missing years for releases prior to `23.04`
3. Adds release dates for versions prior to `0.9` (derived from `cudf` Anaconda releases)

The years were calculated using this script: https://gist.github.com/raydouglass/8a0a13d06a26aca756b7d5011d7a3118