### PR TITLE
add cuXfilter to PyPI packages

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -636,7 +636,7 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
+                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, and <code>cuXfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
                          'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -400,7 +400,7 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["core", "standard"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
+            pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "PyCaret", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",

--- a/install/install.md
+++ b/install/install.md
@@ -239,7 +239,7 @@ bash /rapids/utils/stop-jupyter.sh
 <div id="pip"></div>
 
 ## **pip**
-RAPIDS 23.06 pip packages of cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
+RAPIDS pip packages are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
 
 ### **pip Additional Prerequisites**
 <i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>


### PR DESCRIPTION
This PR adds cuXfilter to the list of PyPI packages, since it [builds wheels](https://github.com/rapidsai/cuxfilter/pull/497) now.

I'll keep this open as a draft until the stable version of cuXfilter is released on `pypi.nvidia.com`