### PR TITLE
23.08 Release Selector and Install Page Updates

### DIFF
--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,43 @@
 [
   {
+    "version": "23.08",
+    "cudf_dev": {
+      "start": "May 18 2023",
+      "end": "Jul 19 2023",
+      "days": 40
+    },
+    "other_dev": {
+      "start": "May 25 2023",
+      "end": "Jul 26 2023",
+      "days": 40
+    },
+    "cudf_burndown": {
+      "start": "Jul 20 2023",
+      "end": "Jul 26 2023",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Jul 27 2023",
+      "end": "Aug 2 2023",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Jul 27 2023",
+      "end": "Aug 8 2023",
+      "days": 9
+    },
+    "other_codefreeze": {
+      "start": "Aug 3 2023",
+      "end": "Aug 8 2023",
+      "days": 4
+    },
+    "release": {
+      "start": "Aug 9 2023",
+      "end": "Aug 10 2023",
+      "days": 2
+    }
+  },
+  {
     "version": "23.06",
     "cudf_dev": {
       "start": "Mar 23 2023",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,51 +1,13 @@
 {
   "legacy": {
-    "version": "23.04",
-    "date": "Apr 13 2023"
-  },
-  "stable": {
     "version": "23.06",
     "date": "Jun 8 2023"
   },
-  "nightly": {
+  "stable": {
     "version": "23.08",
-    "cudf_dev": {
-      "start": "May 18 2023",
-      "end": "Jul 19 2023",
-      "days": 40
-    },
-    "other_dev": {
-      "start": "May 25 2023",
-      "end": "Jul 26 2023",
-      "days": 40
-    },
-    "cudf_burndown": {
-      "start": "Jul 20 2023",
-      "end": "Jul 26 2023",
-      "days": 5
-    },
-    "other_burndown": {
-      "start": "Jul 27 2023",
-      "end": "Aug 2 2023",
-      "days": 5
-    },
-    "cudf_codefreeze": {
-      "start": "Jul 27 2023",
-      "end": "Aug 8 2023",
-      "days": 9
-    },
-    "other_codefreeze": {
-      "start": "Aug 3 2023",
-      "end": "Aug 8 2023",
-      "days": 4
-    },
-    "release": {
-      "start": "Aug 9 2023",
-      "end": "Aug 10 2023",
-      "days": 2
-    }
+    "date": "Aug 10 2023"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "23.10",
     "cudf_dev": {
       "start": "Jul 20 2023",
@@ -54,7 +16,7 @@
     },
     "other_dev": {
       "start": "Jul 27 2023",
-      "end": "Sep 20 2023",
+      "end": "Sep 27 2023",
       "days": 42
     },
     "cudf_burndown": {
@@ -80,6 +42,44 @@
     "release": {
       "start": "Oct 11 2023",
       "end": "Oct 12 2023",
+      "days": 2
+    }
+  },
+  "next_nightly": {
+    "version": "23.12",
+    "cudf_dev": {
+      "start": "Sep 21 2023",
+      "end": "Nov 16 2023",
+      "days": 38
+    },
+    "other_dev": {
+      "start": "Sep 28 2023",
+      "end": "Nov 23 2023",
+      "days": 38
+    },
+    "cudf_burndown": {
+      "start": "Nov 17 2023",
+      "end": "Nov 22 2023",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Nov 23 2023",
+      "end": "Nov 29 2023",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Nov 30 2023",
+      "end": "Dec 12 2023",
+      "days": 9
+    },
+    "other_codefreeze": {
+      "start": "Dec 7 2023",
+      "end": "Dec 12 2023",
+      "days": 4
+    },
+    "release": {
+      "start": "Dec 13 2023",
+      "end": "Dec 14 2023",
       "days": 2
     }
   }

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -49,22 +49,22 @@
     "version": "23.12",
     "cudf_dev": {
       "start": "Sep 21 2023",
-      "end": "Nov 16 2023",
-      "days": 38
+      "end": "Nov 22 2023",
+      "days": 42
     },
     "other_dev": {
       "start": "Sep 28 2023",
-      "end": "Nov 23 2023",
-      "days": 38
+      "end": "Nov 29 2023",
+      "days": 42
     },
     "cudf_burndown": {
-      "start": "Nov 17 2023",
-      "end": "Nov 22 2023",
+      "start": "Nov 23 2023",
+      "end": "Nov 29 2023",
       "days": 5
     },
     "other_burndown": {
-      "start": "Nov 23 2023",
-      "end": "Nov 29 2023",
+      "start": "Nov 30 2023",
+      "end": "Dec 6 2023",
       "days": 5
     },
     "cudf_codefreeze": {

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -49,37 +49,37 @@
     "version": "23.12",
     "cudf_dev": {
       "start": "Sep 21 2023",
-      "end": "Nov 22 2023",
-      "days": 42
+      "end": "Nov 8 2023",
+      "days": 35
     },
     "other_dev": {
       "start": "Sep 28 2023",
-      "end": "Nov 29 2023",
-      "days": 42
+      "end": "Nov 15 2023",
+      "days": 34
     },
     "cudf_burndown": {
-      "start": "Nov 23 2023",
-      "end": "Nov 29 2023",
-      "days": 5
+      "start": "Nov 9 2023",
+      "end": "Nov 15 2023",
+      "days": 4
     },
     "other_burndown": {
-      "start": "Nov 30 2023",
-      "end": "Dec 6 2023",
-      "days": 5
+      "start": "Nov 16 2023",
+      "end": "Nov 29 2023",
+      "days": 8
     },
     "cudf_codefreeze": {
-      "start": "Nov 30 2023",
-      "end": "Dec 12 2023",
-      "days": 9
+      "start": "Nov 16 2023",
+      "end": "Dec 5 2023",
+      "days": 12
     },
     "other_codefreeze": {
-      "start": "Dec 7 2023",
-      "end": "Dec 12 2023",
+      "start": "Nov 30 2023",
+      "end": "Dec 5 2023",
       "days": 4
     },
     "release": {
-      "start": "Dec 13 2023",
-      "end": "Dec 14 2023",
+      "start": "Dec 6 2023",
+      "end": "Dec 7 2023",
       "days": 2
     }
   }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -333,6 +333,7 @@
                                 class="option" x-text="type"></div>
                         </template>
                     </div>
+                </div>
                 <div class="note" x-show="getNoteHtml()">
                     <div class="option-label"></div>
                     <div class="option-blank">

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -536,7 +536,6 @@
 
                 var imgRepo = [
                     imgLoc + "rapidsai/" + imgVariant,
-                    (isNightly ? "nightly" : ""),
                 ].filter(Boolean).join("-");
 
                 var imgTag = [

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -247,15 +247,6 @@
                         </div>
                     </template>
                 </div>
-                <!-- <div class="options-section">
-                    <div class="option-label">Arch</div>
-                    <template x-for="arch in arches">
-                        <div x-on:click="(e) => archClickHandler(e, arch)"
-                            x-bind:class="{'active': arch === active_arch, 'disabled': disableUnsupportedArch(arch)}" class="option" x-text="arch"
-                            x-text="getArchText(arch)">
-                        </div>
-                    </template>
-                </div> -->
                 <div class="options-section">
                     <div class="option-label">Method</div>
                     <template x-for="method in methods">
@@ -384,7 +375,6 @@
             active_pip_cuda_ver: "12.0",
             active_method: "Conda",
             active_release: "Stable",
-            // active_arch: "amd",
             active_img_type: "Base",
             active_img_loc: "NGC",
             active_packages: ["Standard"],
@@ -396,7 +386,6 @@
             pip_cuda_vers: ["11.2 - 11.8", "12.0"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
-            // arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
@@ -414,7 +403,6 @@
             getMethodHTML(method) {
                 var icon_class = "box-open fas";
                 if (method.includes("Docker")) icon_class = "regular fa-container-storage";
-                // if (method.includes("Source")) icon_class = "cogs fas";
                 return method + "&nbsp;<i class='fa-" + icon_class + "'></i>";
             },
             getPackageHTML(pkg) {
@@ -430,12 +418,6 @@
                 if (release.includes("Nightly")) version = this.getNightlyVersion() + "a";
                 return release + " " + "(" + version + ")";
             },
-            // getArchText(arch) {
-            //     var text = "Arch not implemented yet!"
-            //     if (arch === "amd") text = "x86-64";
-            //     if (arch === "arm") text = "Arm Server (SBSA)";
-            //     return text;
-            // },
             highlightCmd(str) {
                 return "<span class='nb'>" + str + "</span>"
             },
@@ -520,7 +502,6 @@
                         .filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "cuSignal")
                         .map(libraryToPkg)
                         .join(" ");                }
-                // var isArm = this.active_arch === "arm";
 
                 if (pkgs === "cucim") {
                     index_url = "";
@@ -559,29 +540,6 @@
                     indent + fullImg;
                 return cmd;
             },
-            // getSourceCmdHtml() {
-            //     var isStable = this.active_release === "Stable";
-            //     var version = isStable ? this.getStableVersion() : this.getNightlyVersion();
-            //     var links = [
-            //         "https://github.com/rapidsai/cudf/blob/branch-" + version + "/CONTRIBUTING.md",
-            //         "https://github.com/rapidsai/cuml/blob/branch-" + version + "/README.md",
-            //         "https://github.com/rapidsai/cugraph/blob/branch-" + version + "/readme_pages/CONTRIBUTING.md",
-            //         "https://github.com/rapidsai/cuspatial/blob/branch-" + version + "/README.md",
-            //         "https://github.com/rapidsai/cuxfilter/blob/branch-" + version + "/CONTRIBUTING.md",
-            //         "https://github.com/rapidsai/cusignal#source-linux-os",
-            //         "https://github.com/rapidsai/cucim/blob/branch-" + version + "/CONTRIBUTING.md#building-and-testing-cucim-from-source"
-            //     ];
-            //     var cmd = "<p class='selector__source-cmd'>For source build instructions, please view the links below:</p>";
-            //     cmd += "<ul class='selector__source-cmd__list'>";
-            //     for (var i = 0; i < links.length; i++) {
-            //         var link = links[i];
-            //         cmd += "<li class='selector__source-cmd__list-item'>";
-            //         cmd += "<a class='selector__source-cmd__link' target='_blank' href='" + link + "'>" + link + "</a>";
-            //         cmd += "</li>";
-            //     }
-            //     cmd += "</ul>";
-            //     return cmd;
-            // },
             getImgLoc(loc) {
                 if (loc === "NGC") return 'NGC (Stable Only) <i class="fa-regular fa-share-nodes"></i>';
                 if (loc === "Dockerhub") return 'Docker Hub (Stable and Nightly) <i class="fa-docker fab"></i>';
@@ -628,15 +586,8 @@
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
-            // getArmNotes() {
-            //     return [this.note_prefix + " ARM support does not currently include Jetson products."];
-            // },
             getNoteHtml() {
                 var notes = [];
-
-                // if (this.active_arch === "arm") {
-                //     notes.push(...this.getArmNotes());
-                // }
 
                 if (this.active_method === "Docker") {
                     notes.push(...this.getDockerNotes());
@@ -659,8 +610,6 @@
                     return this.getCondaCmdHtml();
                 if (this.active_method === "pip")
                     return this.getpipCmdHtml();
-                // if (this.active_method === "Source")
-                //     return this.getSourceCmdHtml();
                 return "Not implemented yet!";
             },
             disableUnsupportedRelease(release) {
@@ -672,8 +621,6 @@
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
-                // if (this.active_arch === "arm" && cuda_version === "12.0") isDisabled = true;
-
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -693,11 +640,6 @@
                 if (this.active_release === "Nightly" && method === "pip") isDisabled = true;
                 return isDisabled;
             },
-            // disableUnsupportedArch(arch) {
-            //     var isDisabled = false;
-            //     if (["Conda", "Docker"].includes(this.active_method) && this.active_cuda_ver.startsWith("12") && arch === "arm") isDisabled = true;
-            //     return isDisabled;
-            // },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
                 if (this.active_cuda_ver.startsWith("12") && this.active_method === "Conda" && package === "cuSignal") isDisabled = true;
@@ -717,10 +659,6 @@
                 if (this.isDisabled(e.target)) return;
                 this.active_img_type = type;
             },
-            // archClickHandler(e, arch) {
-            //     if (this.isDisabled(e.target)) return;
-            //     this.active_arch = arch;
-            // },
             cudaClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
                 this.active_cuda_ver = version;
@@ -748,7 +686,6 @@
                 if (method === "pip") {
                     this.active_pip_cuda_ver = '12.0';
                     this.active_release = 'Stable';
-                    // this.active_packages = ['cuDF']
                 }
                 if (method === "Docker") {
                     if (this.active_release === 'Nightly') {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -377,8 +377,8 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
-            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial + cuProj", "cuxfilter", "cuCIM"],
-            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial + cuProj", "cuxfilter", "cuSignal", "cuCIM"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM"],
+            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
@@ -452,8 +452,8 @@
                     pkgs = ["rapids"];
                 }
 
-                if (pkgs.includes("cuSpatial + cuProj")) {
-                    pkgs = pkgs.filter(pkg => pkg !== "cuSpatial + cuProj");
+                if (pkgs.includes("cuSpatial/cuProj")) {
+                    pkgs = pkgs.filter(pkg => pkg !== "cuSpatial/cuProj");
                     pkgs.push("cuSpatial");
                     pkgs.push("cuProj");
                 }
@@ -492,7 +492,7 @@
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;
-                    if (pkg == "cuspatial + cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
+                    if (pkg == "cuspatial/cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
                     return pkg + cuda_suffix;
                 }
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -18,6 +18,14 @@
         flex-wrap: nowrap;
     }
 
+    .selector .options-section-specific {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        width: 97%;
+        margin: 0 auto;
+    }
+
     .selector .options .option-label {
         color: white;
         width: 6em;
@@ -290,8 +298,8 @@
                             </div>
                         </template>
                     </div>
-                    <div class="options-section" x-show="active_packages != 'Standard'">
-                        <div class="option-label">RAPIDS Packages</div>
+                    <div class="options-section-specific" x-show="active_packages != 'Standard'">
+                        <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_rapids_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
                                 x-bind:class="{'active': active_packages.includes(package)}" class="option"
@@ -317,7 +325,7 @@
                             </div>
                         </template>
                     </div>
-                    <div class="options-section" x-show="active_packages != 'Standard'">
+                    <div class="options-section-specific" x-show="active_packages != 'Standard'">
                         <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_pip_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
@@ -709,6 +717,15 @@
                 if (package === "Standard") {
                     this.active_packages = [package];
                     return;
+                }
+
+                if (package === "Choose Specific Packages") {
+                    if (this.active_packages[0] === "Standard" && this.active_packages.length === 1) {
+                        this.active_packages = [package, "cuDF"];
+                        return;
+                    } else {
+                        return;
+                    }
                 }
 
                 this.active_packages = this.active_packages.filter(el => el !== "Standard");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -560,6 +560,7 @@
             },
             getDockerNotes() {
                 var cuda12 = ""
+                var notes = [];
                 if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                         cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
@@ -567,7 +568,10 @@
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
 
-                return [this.note_prefix + cuda12 + " The selected image contains the following packages:<br>" + pkgs_html];
+                // return [this.note_prefix + cuda12 + " The selected image contains the following packages:<br>" + pkgs_html];
+                notes = [cuda12, "The selected image contains the following packages:<br>", pkgs_html]
+                return notes.map(note => this.note_prefix + " " + note);
+
             },
             getCondaNotes() {
                 var notes = [];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -326,31 +326,13 @@
                         </template>
                     </div>
                     <div class="options-section">
-                        <div class="option-label">Image OS</div>
-                        <template x-for="version in os_vers">
-                            <div x-on:click="(e) => imgOSClickHandler(e, version)"
-                                x-bind:class="{'active': version === active_os_ver, 'disabled': disableUnsupportedImgOS(version)}"
-                                class="option" x-html="getOSHTML(version)">
-                            </div>
-                        </template>
-                    </div>
-                    <div class="options-section">
                         <div class="option-label">Image Type</div>
                         <template x-for="type in img_types">
                             <div x-on:click="(e) => imgTypeClickHandler(e, type)"
                                 x-bind:class="{'active': type === active_img_type, 'disabled': disableUnsupportedImgType(type)}"
-                                class="option" x-text="getImgTypeText(type)"></div>
+                                class="option" x-text="type"></div>
                         </template>
                     </div>
-                    <div class="options-section">
-                        <div class="option-label">Image Options</div>
-                        <template x-for="option in img_options">
-                            <div x-on:click="(e) => imgOptionClickHandler(e, option)"
-                                x-bind:class="{'active': active_img_options.includes(option), 'disabled': disableUnsupportedImgOption(option)}"
-                                class="option" x-text="getImgOptionText(option)"></div>
-                        </template>
-                    </div>
-                </div>
                 <div class="note" x-show="getNoteHtml()">
                     <div class="option-label"></div>
                     <div class="option-blank">
@@ -379,30 +361,26 @@
             active_python_ver: "3.10",
             active_cuda_ver: "11.8",
             active_pip_cuda_ver: "12.0",
-            active_os_ver: "Ubuntu 22.04",
             active_method: "Conda",
             active_release: "Stable",
             active_arch: "amd",
-            active_img_type: "core",
+            active_img_type: "Base",
             active_img_loc: "NGC",
             active_packages: ["Standard"],
-            active_img_options: ["notebooks"],
             active_additional_packages: [],
 
             // all possible values
             python_vers: ["3.9", "3.10"],
             cuda_vers: ["11.2", "11.4", "11.5", "11.8", "12.0"],
             pip_cuda_vers: ["11.2 - 11.8", "12.0"],
-            os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
             methods: ["Conda", "pip", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
-            img_types: ["core", "standard"],
+            img_types: ["Base", "Notebook"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
-            img_options: ["notebooks", "development"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             getStableVersion() {
@@ -410,12 +388,6 @@
             },
             getNightlyVersion() {
                 return "{{ site.data.releases.nightly.version }}";
-            },
-            getOSHTML(os_ver) {
-                var icon_class = "ubuntu"
-                if (os_ver.includes("CentOS")) icon_class = "centos";
-                if (os_ver.includes("Rocky Linux")) icon_class = "linux";
-                return os_ver + "&nbsp;<i class='fab fa-" + icon_class + "'></i>";
             },
             getMethodHTML(method) {
                 var icon_class = "box-open fas";
@@ -529,33 +501,24 @@
                 return pip_install + pkgs + index_url + cupy_inst;
             },
             getDockerCmdHtml() {
-                var hasNotebooks = this.active_img_options.includes("notebooks");
-                var isDevel = this.active_img_options.includes("development");
+                var hasNotebooks = this.active_img_type === "Notebook";
                 var isNightly = this.active_release === "Nightly";
-                var isArm = this.active_arch === "arm";
                 var imgLoc = "";
-                if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/"
-                var imgVariant = "";
-                if (this.active_img_type === "core") imgVariant = "core";
-                var imgType = "base";
-                if (hasNotebooks) imgType = "runtime";
-                if (isDevel) imgType = "devel";
+                if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/";
+                var imgVariant = this.active_img_type;
+
                 var portOptions = (hasNotebooks ? ["8888:8888", "8787:8787", "8786:8786"] : [])
                     .map(opt => this.highlightFlag("-p") + " " + opt + " ").join("");
 
                 var imgRepo = [
                     imgLoc + "rapidsai/rapidsai",
                     imgVariant,
-                    (isDevel ? "dev" : ""),
                     (isNightly ? "nightly" : ""),
-                    (isArm ? "arm64" : ""),
                 ].filter(Boolean).join("-");
 
                 var imgTag = [
                     (isNightly ? this.getNightlyVersion() : this.getStableVersion()),
                     "cuda" + this.active_cuda_ver,
-                    imgType,
-                    this.active_os_ver.replaceAll(" ", ""),
                     "py" + this.active_python_ver
                 ].join("-");
 
@@ -591,16 +554,6 @@
                 }
                 cmd += "</ul>";
                 return cmd;
-            },
-            getImgTypeText(type) {
-                if (type === "core") return "Basic"
-                if (type === "standard") return "Basic w/ Dask-SQL"
-                return type;
-            },
-            getImgOptionText(option) {
-                if (option === "notebooks") return "Include Jupyter Notebooks";
-                if (option === "development") return "Development Image (only on Docker Hub)";
-                return option;
             },
             getImgLoc(loc) {
                 if (loc === "NGC") return 'NGC (Stable Only) <i class="fa-regular fa-share-nodes"></i>';
@@ -694,11 +647,7 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                if (this.active_img_options.includes("development") && cuda_version !== this.getNewestCudaVer()) {
-                    isDisabled = true;
-                }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
-                if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
                 if (this.active_arch === "arm" && cuda_version === "12.0") isDisabled = true;
 
                 return isDisabled;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -372,7 +372,7 @@
 
             // all possible values
             python_vers: ["3.9", "3.10"],
-            cuda_vers: ["11.2", "11.4", "11.5", "11.8", "12.0"],
+            cuda_vers: ["11.2", "11.8", "12.0"],
             pip_cuda_vers: ["11.2 - 11.8", "12.0"],
             methods: ["Conda", "pip", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
@@ -506,15 +506,14 @@
                 var isNightly = this.active_release === "Nightly";
                 var imgLoc = "";
                 if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/";
-                var imgVariant = "";
+                var imgVariant = "Base";
                 if (this.active_img_type === "Notebooks") imgVariant = this.active_img_type;
 
                 var portOptions = (hasNotebooks ? ["8888:8888", "8787:8787", "8786:8786"] : [])
                     .map(opt => this.highlightFlag("-p") + " " + opt + " ").join("");
 
                 var imgRepo = [
-                    imgLoc + "rapidsai/rapidsai",
-                    imgVariant,
+                    imgLoc + "rapidsai/" + imgVariant,
                     (isNightly ? "nightly" : ""),
                 ].filter(Boolean).join("-");
 

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -582,7 +582,7 @@
             getpipNotes() {
                 var notes = [];
                 notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, and <code>cuXfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
-                    'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
+                    'pip installation supports Python <code>3.9</code> and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -9,6 +9,7 @@
     .selector-bg {
         background-color: #9943ff;
         padding: 1rem;
+        border-radius: 5px;
     }
 
     .selector .options-section {
@@ -36,6 +37,7 @@
         cursor: pointer;
         line-height: 1.5em;
         box-shadow: 2px 2px 2px rgba(10, 10, 10, 0.4);
+        border-radius: 2px;
     }
 
     .selector .options .option:hover,
@@ -61,6 +63,7 @@
         background: #e3e3e3;
         color: #000000;
         padding: 0.1em 0.1em 0.15em;
+        border-radius: 2px;
     }
 
     .selector .options .option-blank {
@@ -512,9 +515,10 @@
                 if (this.active_packages[0] === 'Standard') {
                     var pkgs = this.additional_pip_packages.map(libraryToPkg).join(" ");
                 } else {
-                    var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
-                }
-                // var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
+                    var pkgs = this.active_packages
+                        .filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "cuSignal")
+                        .map(libraryToPkg)
+                        .join(" ");                }
                 // var isArm = this.active_arch === "arm";
 
                 if (pkgs === "cucim") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -563,10 +563,9 @@
                 return loc;
             },
             getDockerNotes() {
-                if (this.active_cuda_ver === "12.0") {
+                if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    }
-                else {
+                } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
 
@@ -576,10 +575,9 @@
                 var notes = [];
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
-                    if (this.active_cuda_ver === "12.0") {
+                    if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    }
-                    else {
+                    } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
                     notes = [...notes, "The CUDA " + this.active_cuda_ver + 
@@ -671,13 +669,12 @@
             },
             disableUnsupportedArch(arch) {
                 var isDisabled = false;
-                if (this.active_method === "Conda" && this.active_cuda_ver === "12.0" && arch === "arm") isDisabled = true;
-                if (this.active_method === "Docker" && this.active_cuda_ver === "12.0" && arch === "arm") isDisabled = true;
+                if (["Conda", "Docker"].includes(this.active_method) && this.active_cuda_ver.startsWith("12") && arch === "arm") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
-                if (this.active_cuda_ver === "12.0" && this.active_method === "Conda" && package === "cuSignal") isDisabled = true;
+                if (this.active_cuda_ver.startsWith("12") && this.active_method === "Conda" && package === "cuSignal") isDisabled = true;
                 return isDisabled;
             },
             isDisabled(e) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -261,7 +261,7 @@
                         </div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip' && active_method !== 'Source'">
+                <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">ENV. CUDA</div>
                     <template x-for="version in cuda_vers">
                         <div x-on:click="(e) => cudaClickHandler(e, version)"
@@ -277,7 +277,7 @@
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip' && active_method !== 'Source'">
+                <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">Python</div>
                     <template x-for="version in python_vers">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
@@ -380,7 +380,7 @@
             active_pip_cuda_ver: "12.0",
             active_method: "Conda",
             active_release: "Stable",
-            active_arch: "amd",
+            // active_arch: "amd",
             active_img_type: "Base",
             active_img_loc: "NGC",
             active_packages: ["Standard"],
@@ -392,7 +392,7 @@
             pip_cuda_vers: ["11.2 - 11.8", "12.0"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
-            arches: ["amd", "arm"],
+            // arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
@@ -410,7 +410,7 @@
             getMethodHTML(method) {
                 var icon_class = "box-open fas";
                 if (method.includes("Docker")) icon_class = "regular fa-container-storage";
-                if (method.includes("Source")) icon_class = "cogs fas";
+                // if (method.includes("Source")) icon_class = "cogs fas";
                 return method + "&nbsp;<i class='fa-" + icon_class + "'></i>";
             },
             getPackageHTML(pkg) {
@@ -426,12 +426,12 @@
                 if (release.includes("Nightly")) version = this.getNightlyVersion() + "a";
                 return release + " " + "(" + version + ")";
             },
-            getArchText(arch) {
-                var text = "Arch not implemented yet!"
-                if (arch === "amd") text = "x86-64";
-                if (arch === "arm") text = "Arm Server (SBSA)";
-                return text;
-            },
+            // getArchText(arch) {
+            //     var text = "Arch not implemented yet!"
+            //     if (arch === "amd") text = "x86-64";
+            //     if (arch === "arm") text = "Arm Server (SBSA)";
+            //     return text;
+            // },
             highlightCmd(str) {
                 return "<span class='nb'>" + str + "</span>"
             },
@@ -515,14 +515,13 @@
                     var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
                 }
                 // var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
-                var isArm = this.active_arch === "arm";
-                var cupy_inst = "";
+                // var isArm = this.active_arch === "arm";
 
                 if (pkgs === "cucim") {
                     index_url = "";
                 }
 
-                return pip_install + pkgs + index_url + cupy_inst;
+                return pip_install + pkgs + index_url;
             },
             getDockerCmdHtml() {
                 var hasNotebooks = this.active_img_type === "Notebook";
@@ -549,36 +548,35 @@
                 var fullImg = (this.highlightPkgOrImg(imgRepo) + ":" + imgTag).toLowerCase();
 
                 var indent = "    ";
-                var cmd = this.highlightCmd("docker") + " pull " + fullImg + "\n" +
-                    this.highlightCmd("docker") + " run --" + this.highlightFlag("gpus") + " all --" + this.highlightFlag("rm") + " -" + this.highlightFlag("it") + " \\\n" +
+                var cmd = this.highlightCmd("docker") + " run --" + this.highlightFlag("gpus") + " all --pull always --" + this.highlightFlag("rm") + " -" + this.highlightFlag("it") + " \\\n" +
                     indent + "--" + this.highlightFlag("shm-size") + "=1g --" + this.highlightFlag("ulimit") + " memlock=-1 --" + this.highlightFlag("ulimit") + " stack=67108864" + " \\\n" +
                     (portOptions ? indent + portOptions + "\\\n" : "") +
                     indent + fullImg;
                 return cmd;
             },
-            getSourceCmdHtml() {
-                var isStable = this.active_release === "Stable";
-                var version = isStable ? this.getStableVersion() : this.getNightlyVersion();
-                var links = [
-                    "https://github.com/rapidsai/cudf/blob/branch-" + version + "/CONTRIBUTING.md",
-                    "https://github.com/rapidsai/cuml/blob/branch-" + version + "/README.md",
-                    "https://github.com/rapidsai/cugraph/blob/branch-" + version + "/readme_pages/CONTRIBUTING.md",
-                    "https://github.com/rapidsai/cuspatial/blob/branch-" + version + "/README.md",
-                    "https://github.com/rapidsai/cuxfilter/blob/branch-" + version + "/CONTRIBUTING.md",
-                    "https://github.com/rapidsai/cusignal#source-linux-os",
-                    "https://github.com/rapidsai/cucim/blob/branch-" + version + "/CONTRIBUTING.md#building-and-testing-cucim-from-source"
-                ];
-                var cmd = "<p class='selector__source-cmd'>For source build instructions, please view the links below:</p>";
-                cmd += "<ul class='selector__source-cmd__list'>";
-                for (var i = 0; i < links.length; i++) {
-                    var link = links[i];
-                    cmd += "<li class='selector__source-cmd__list-item'>";
-                    cmd += "<a class='selector__source-cmd__link' target='_blank' href='" + link + "'>" + link + "</a>";
-                    cmd += "</li>";
-                }
-                cmd += "</ul>";
-                return cmd;
-            },
+            // getSourceCmdHtml() {
+            //     var isStable = this.active_release === "Stable";
+            //     var version = isStable ? this.getStableVersion() : this.getNightlyVersion();
+            //     var links = [
+            //         "https://github.com/rapidsai/cudf/blob/branch-" + version + "/CONTRIBUTING.md",
+            //         "https://github.com/rapidsai/cuml/blob/branch-" + version + "/README.md",
+            //         "https://github.com/rapidsai/cugraph/blob/branch-" + version + "/readme_pages/CONTRIBUTING.md",
+            //         "https://github.com/rapidsai/cuspatial/blob/branch-" + version + "/README.md",
+            //         "https://github.com/rapidsai/cuxfilter/blob/branch-" + version + "/CONTRIBUTING.md",
+            //         "https://github.com/rapidsai/cusignal#source-linux-os",
+            //         "https://github.com/rapidsai/cucim/blob/branch-" + version + "/CONTRIBUTING.md#building-and-testing-cucim-from-source"
+            //     ];
+            //     var cmd = "<p class='selector__source-cmd'>For source build instructions, please view the links below:</p>";
+            //     cmd += "<ul class='selector__source-cmd__list'>";
+            //     for (var i = 0; i < links.length; i++) {
+            //         var link = links[i];
+            //         cmd += "<li class='selector__source-cmd__list-item'>";
+            //         cmd += "<a class='selector__source-cmd__link' target='_blank' href='" + link + "'>" + link + "</a>";
+            //         cmd += "</li>";
+            //     }
+            //     cmd += "</ul>";
+            //     return cmd;
+            // },
             getImgLoc(loc) {
                 if (loc === "NGC") return 'NGC (Stable Only) <i class="fa-regular fa-share-nodes"></i>';
                 if (loc === "Dockerhub") return 'Docker Hub (Stable and Nightly) <i class="fa-docker fab"></i>';
@@ -623,15 +621,15 @@
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
-            getArmNotes() {
-                return [this.note_prefix + " ARM support does not currently include Jetson products."];
-            },
+            // getArmNotes() {
+            //     return [this.note_prefix + " ARM support does not currently include Jetson products."];
+            // },
             getNoteHtml() {
                 var notes = [];
 
-                if (this.active_arch === "arm") {
-                    notes.push(...this.getArmNotes());
-                }
+                // if (this.active_arch === "arm") {
+                //     notes.push(...this.getArmNotes());
+                // }
 
                 if (this.active_method === "Docker") {
                     notes.push(...this.getDockerNotes());
@@ -654,8 +652,8 @@
                     return this.getCondaCmdHtml();
                 if (this.active_method === "pip")
                     return this.getpipCmdHtml();
-                if (this.active_method === "Source")
-                    return this.getSourceCmdHtml();
+                // if (this.active_method === "Source")
+                //     return this.getSourceCmdHtml();
                 return "Not implemented yet!";
             },
             disableUnsupportedRelease(release) {
@@ -667,7 +665,7 @@
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
-                if (this.active_arch === "arm" && cuda_version === "12.0") isDisabled = true;
+                // if (this.active_arch === "arm" && cuda_version === "12.0") isDisabled = true;
 
                 return isDisabled;
             },
@@ -688,11 +686,11 @@
                 if (this.active_release === "Nightly" && method === "pip") isDisabled = true;
                 return isDisabled;
             },
-            disableUnsupportedArch(arch) {
-                var isDisabled = false;
-                if (["Conda", "Docker"].includes(this.active_method) && this.active_cuda_ver.startsWith("12") && arch === "arm") isDisabled = true;
-                return isDisabled;
-            },
+            // disableUnsupportedArch(arch) {
+            //     var isDisabled = false;
+            //     if (["Conda", "Docker"].includes(this.active_method) && this.active_cuda_ver.startsWith("12") && arch === "arm") isDisabled = true;
+            //     return isDisabled;
+            // },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
                 if (this.active_cuda_ver.startsWith("12") && this.active_method === "Conda" && package === "cuSignal") isDisabled = true;
@@ -712,10 +710,10 @@
                 if (this.isDisabled(e.target)) return;
                 this.active_img_type = type;
             },
-            archClickHandler(e, arch) {
-                if (this.isDisabled(e.target)) return;
-                this.active_arch = arch;
-            },
+            // archClickHandler(e, arch) {
+            //     if (this.isDisabled(e.target)) return;
+            //     this.active_arch = arch;
+            // },
             cudaClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
                 this.active_cuda_ver = version;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -476,7 +476,7 @@
                     add_pkgs_ln
                 ].filter(Boolean).join(" \\\n");
 
-                return lines;
+                return lines + " --solver=libmamba";
             },
             getpipCmdHtml() {
                 var pip_install = "pip install ";

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -568,7 +568,7 @@
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
 
-                notes = [...notes, "The selected image contains the following packages:<br>", pkgs_html];
+                notes = [...notes, "The selected image contains the following packages:<br>" + pkgs_html];
                 return notes.map(note => this.note_prefix + " " + note);
 
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -676,6 +676,9 @@
             },
             cudaClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
+                if (version === "12.0") {
+                    this.active_packages = this.active_packages.filter(pkg => pkg !== "cuSignal");
+                }
                 this.active_cuda_ver = version;
             },
             pipCUDAClickHandler(e, version) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -381,7 +381,7 @@
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
-            additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
+            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             getStableVersion() {
@@ -436,7 +436,7 @@
                 var dask_prefix = this.active_release === "Nightly" ? "dask/label/dev::" : "";
                 var pkg_names = {
                     "Plotly Dash": "dash",
-                    "Dask SQL": dask_prefix + "dask-sql"
+                    "Dask-SQL": dask_prefix + "dask-sql"
                 }
                 return (pkg_names[pkg] || pkg).toLowerCase();
             },
@@ -508,7 +508,7 @@
                 if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/";
                 var imgVariant = "";
                 if (this.active_img_type === "Notebooks") imgVariant = this.active_img_type;
-                
+
                 var portOptions = (hasNotebooks ? ["8888:8888", "8787:8787", "8786:8786"] : [])
                     .map(opt => this.highlightFlag("-p") + " " + opt + " ").join("");
 
@@ -655,7 +655,6 @@
             },
             disableUnsupportedImgType(type) {
                 var isDisabled = false;
-                if (this.active_arch === "arm" && type !== "core") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgLoc(loc) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -464,6 +464,10 @@
                     .join("");
                 var indentation = "    ";
 
+                if (this.active_packages.length + this.active_additional_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
+                    return "Select at least one package.";
+                }
+                
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     pkgs = ["rapids"];
                 }
@@ -503,7 +507,7 @@
                     if (pkg === "cucim") return pkg;
                     return pkg + cuda_suffix;
                 }
-                if (this.active_packages.length === 0) {
+                if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 } else if (this.active_packages[0] === 'Standard') {
                     var pkgs = this.additional_pip_packages.map(libraryToPkg).join(" ");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -377,11 +377,11 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
-            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuCIM"],
-            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuCIM"],
+            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
-            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
+            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuxfilter", "cuSignal", "cuCIM"],
             getStableVersion() {
                 return "{{ site.data.releases.stable.version }}";
             },
@@ -581,7 +581,7 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, and <code>cuXfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
+                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, <code>cuProj</code>, and <code>cuxfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
                     'pip installation supports Python <code>3.9</code> and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -506,8 +506,9 @@
                 var isNightly = this.active_release === "Nightly";
                 var imgLoc = "";
                 if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/";
-                var imgVariant = this.active_img_type;
-
+                var imgVariant = "";
+                if (this.active_img_type === "Notebooks") imgVariant = this.active_img_type;
+                
                 var portOptions = (hasNotebooks ? ["8888:8888", "8787:8787", "8786:8786"] : [])
                     .map(opt => this.highlightFlag("-p") + " " + opt + " ").join("");
 
@@ -636,10 +637,6 @@
                 if (this.active_method === "Source")
                     return this.getSourceCmdHtml();
                 return "Not implemented yet!";
-            },
-            getNewestCudaVer() {
-                // TODO: When we support CUDA 12 on developer images, revert to this.cuda_vers.length - 1
-                return this.cuda_vers[this.cuda_vers.length - 2];
             },
             disableUnsupportedRelease(release) {
                 var isDisabled = false;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -650,6 +650,7 @@
             },
             disableUnsupportedImgLoc(loc) {
                 var isDisabled = false;
+                if (this.active_release === "Nightly" && loc === "NGC") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedMethod(method) {
@@ -668,9 +669,6 @@
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
-                if (release === 'Stable') {
-                        this.active_img_loc = 'NGC';
-                    }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;
@@ -691,7 +689,6 @@
             methodClickHandler(e, method) {
                 if (this.isDisabled(e.target)) return;
                 if (method !== "Docker") {
-                    this.active_img_options = ["notebooks"];
                     this.active_img_type = "Base";
                 }
                 if (method !== "Conda") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -171,8 +171,9 @@
         width: 6em;
         text-transform: uppercase;
         font-weight: 600;
-        margin-top: 2em;
-        margin-right:0.6em;
+        margin-top: 1rem;
+        margin-right: 0.6em;
+        vertical-align: top;
     }
 
     .cmd-box {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -514,7 +514,7 @@
                     .join(" \\\n" + indentation);
             },
             getDockerCmdHtml() {
-                var hasNotebooks = this.active_img_type === "Notebook";
+                var hasNotebooks = this.active_img_type === "Notebooks";
                 var isNightly = this.active_release === "Nightly";
                 var imgLoc = "";
                 if (this.active_img_loc === "NGC") imgLoc = "nvcr.io/nvidia/";

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -141,25 +141,6 @@
         cursor: not-allowed;
     }
 
-    p.selector__source-cmd {
-        color: #3c3c3c;
-        margin-bottom: 0.4em;
-    }
-
-    .selector__source-cmd__link {
-        text-decoration: underline;
-        color: #080013;
-    }
-
-    .selector__source-cmd__list,
-    p.selector__source-cmd {
-        font-size: 1em;
-    }
-
-    .selector__source-cmd__list-item {
-        margin-bottom: 0.2em;
-    }
-
     .cmd {
         display: flex;
         margin-top: 2rem;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -590,6 +590,7 @@
             getDockerNotes() {
                 if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
+                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"];
                 } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
@@ -601,7 +602,7 @@
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     if (this.active_cuda_ver.startsWith("12")) {
-                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"]
+                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"];
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -377,8 +377,8 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
-            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuCIM"],
-            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial + cuProj", "cuxfilter", "cuCIM"],
+            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial + cuProj", "cuxfilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
@@ -452,6 +452,12 @@
                     pkgs = ["rapids"];
                 }
 
+                if (pkgs.includes("cuSpatial + cuProj")) {
+                    pkgs = pkgs.filter(pkg => pkg !== "cuSpatial + cuProj");
+                    pkgs.push("cuSpatial");
+                    pkgs.push("cuProj");
+                }
+
                 var pkgs_vers = pkgs.filter(pkg => pkg !== "Choose Specific Packages").map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
                 var all_pkgs = pkgs_vers + py_cuda_pkgs;
 
@@ -486,6 +492,7 @@
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;
+                    if (pkg == "cuspatial + cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
                     return pkg + cuda_suffix;
                 }
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -401,7 +401,7 @@
             packages: ["Standard", "Choose Specific Packages"],
             additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuCIM"],
             additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
+            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             getStableVersion() {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -62,8 +62,8 @@
     .selector .options .note code {
         background: #e3e3e3;
         color: #000000;
-        padding: 0.1em 0.1em 0.15em;
-        border-radius: 2px;
+        padding: 0.08em 0.15em;
+        border-radius: 4px;
     }
 
     .selector .options .option-blank {
@@ -171,6 +171,7 @@
         cursor: text;
         overflow: auto;
         width: calc(100% - 6em);
+        border-radius: 4px;
     }
 
     .cmd-button {
@@ -600,6 +601,7 @@
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     if (this.active_cuda_ver.startsWith("12")) {
+                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"]
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -559,17 +559,16 @@
                 return loc;
             },
             getDockerNotes() {
-                var cuda12 = ""
                 var notes = [];
                 if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                        cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
+                        var cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
+                        notes = [...notes, cuda12]
                 } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
 
-                // return [this.note_prefix + cuda12 + " The selected image contains the following packages:<br>" + pkgs_html];
-                notes = [cuda12, "The selected image contains the following packages:<br>", pkgs_html]
+                notes = [...notes, "The selected image contains the following packages:<br>", pkgs_html];
                 return notes.map(note => this.note_prefix + " " + note);
 
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -318,7 +318,7 @@
                         </template>
                     </div>
                     <div class="options-section" x-show="active_packages != 'Standard'">
-                        <div class="option-label">Packages</div>
+                        <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_pip_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
                                 x-bind:class="{'active': active_packages.includes(package)}" class="option"
@@ -389,7 +389,7 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
-            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuXFilter", "cuSpatial", "cuCIM"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuCIM"],
             additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
@@ -548,7 +548,7 @@
             getDockerNotes() {
                 if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"];
+                        notes = [...notes, "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures"];
                 } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
@@ -560,7 +560,7 @@
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     if (this.active_cuda_ver.startsWith("12")) {
-                        notes = [...notes, "RAPIDS CUDA 12.0 packages do not support ARM architectures"];
+                        notes = [...notes, "RAPIDS conda packages for CUDA 12 do not currently support ARM architectures"];
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
@@ -642,7 +642,7 @@
             },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
-                if (this.active_cuda_ver.startsWith("12") && this.active_method === "Conda" && package === "cuSignal") isDisabled = true;
+                if (package === "cuSignal" && ((this.active_cuda_ver.startsWith("12") && this.active_method === "Conda") || this.active_release === "Nightly")) isDisabled = true;
                 return isDisabled;
             },
             isDisabled(e) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -518,7 +518,7 @@
                 ].filter(Boolean).join("-");
 
                 var imgTag = [
-                    (isNightly ? this.getNightlyVersion() : this.getStableVersion()),
+                    (isNightly ? this.getNightlyVersion() + "a" : this.getStableVersion()),
                     "cuda" + this.active_cuda_ver,
                     "py" + this.active_python_ver
                 ].join("-");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -378,7 +378,7 @@
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
-            img_types: ["Base", "Notebook"],
+            img_types: ["Base", "Notebooks"],
             packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
             additional_packages: ["Dask SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
@@ -562,12 +562,13 @@
                 return loc;
             },
             getDockerNotes() {
-                var core_pkgs = this.rapids_meta_pkgs;
+                if (this.active_cuda_ver === "12.0") {
+                        var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
+                    }
+                else {
+                        var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
+                    }
 
-                if (this.active_img_type === "standard") {
-                    core_pkgs = [...core_pkgs, "dask-sql"];
-                }
-                var pkgs_html = core_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                 return [this.note_prefix + " The selected image contains the following packages:<br>" + pkgs_html];
             },
             getCondaNotes() {
@@ -657,22 +658,9 @@
                 var isDisabled = false;
                 return isDisabled;
             },
-            disableUnsupportedImgOS(os) {
-                var isDisabled = false;
-                if (this.active_arch === "arm" && os === "CentOS 7") isDisabled = true;
-                if (this.active_cuda_ver !== '11.8' && os === 'Ubuntu 22.04' && this.active_method === 'Docker') isDisabled = true;
-                if (this.active_arch === "arm" && os === 'Ubuntu 20.04' && this.active_method === 'Docker') isDisabled = true;
-                return isDisabled;
-            },
             disableUnsupportedImgType(type) {
                 var isDisabled = false;
                 if (this.active_arch === "arm" && type !== "core") isDisabled = true;
-                return isDisabled;
-            },
-            disableUnsupportedImgOption(option) {
-                var isDisabled = false;
-                var isNGC = this.active_img_loc === "NGC"
-                if (isNGC && option === "development") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgLoc(loc) {
@@ -687,6 +675,7 @@
             disableUnsupportedArch(arch) {
                 var isDisabled = false;
                 if (this.active_method === "Conda" && this.active_cuda_ver === "12.0" && arch === "arm") isDisabled = true;
+                if (this.active_method === "Docker" && this.active_cuda_ver === "12.0" && arch === "arm") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPackage(package) {
@@ -753,46 +742,12 @@
                 }
                 this.active_method = method;
             },
-            imgOSClickHandler(e, version) {
-                if (this.isDisabled(e.target)) return;
-                this.active_os_ver = version;
-            },
             imgLocClickHandler(e, loc) {
                 if (this.isDisabled(e.target)) return;
 
                 if (loc === "NGC" && this.active_release !== "Stable") this.active_release = "Stable";
 
-                // Disable development option when clicking NGC
-                if (loc === "NGC" && this.active_img_options.includes("development")) {
-                    this.active_img_options = this.active_img_options.filter(el => el !== "development")
-                }
-
                 this.active_img_loc = loc;
-            },
-            imgOptionClickHandler(e, option) {
-                if (this.isDisabled(e.target)) return;
-
-                // development images have notebooks
-                if (option === "development" && this.active_img_options.length === 0) {
-                    this.active_img_options = ["notebooks", "development"];
-                    this.active_cuda_ver = this.getNewestCudaVer();
-                    return;
-                }
-
-                if (option === "notebooks" && this.active_img_options.length === 2) {
-                    this.active_img_options = [];
-                    return;
-                }
-
-                if (this.active_img_options.includes(option)) {
-                    this.active_img_options = this.active_img_options.filter(el => el !== option);
-                    return;
-                }
-
-                this.active_img_options = [...this.active_img_options, option];
-                if (this.active_img_options.includes("development")) {
-                    this.active_cuda_ver = this.getNewestCudaVer();
-                }
             },
             /**
             * Determines which packages are selected. "Standard" can only be

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -503,7 +503,9 @@
                     if (pkg === "cucim") return pkg;
                     return pkg + cuda_suffix;
                 }
-                if (this.active_packages[0] === 'Standard') {
+                if (this.active_packages.length === 0) {
+                    return "Select at least one package.";
+                } else if (this.active_packages[0] === 'Standard') {
                     var pkgs = this.additional_pip_packages.map(libraryToPkg).join(" ");
                 } else {
                     var pkgs = this.active_packages

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -243,7 +243,7 @@
                         </div>
                     </template>
                 </div>
-                <div class="options-section">
+                <!-- <div class="options-section">
                     <div class="option-label">Arch</div>
                     <template x-for="arch in arches">
                         <div x-on:click="(e) => archClickHandler(e, arch)"
@@ -251,7 +251,7 @@
                             x-text="getArchText(arch)">
                         </div>
                     </template>
-                </div>
+                </div> -->
                 <div class="options-section">
                     <div class="option-label">Method</div>
                     <template x-for="method in methods">
@@ -287,12 +287,20 @@
                 </div>
                 <div class="conda-options-container" x-show="active_method === 'Conda'">
                     <div class="options-section">
-                        <div class="option-label">Packages</div>
+                        <div class="option-label">RAPIDS Packages</div>
                         <template x-for="package in packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
                                 x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}" class="option"
                                 x-html="getPackageHTML(package)">
                             </div>
+                        </template>
+                    </div>
+                    <div class="options-section" x-show="active_packages != 'Standard'">
+                        <div class="option-label">RAPIDS Packages</div>
+                        <template x-for="package in additional_rapids_packages">
+                            <div x-on:click="(e) => packagesClickHandler(e, package)"
+                                x-bind:class="{'active': active_packages.includes(package)}" class="option"
+                                x-text="package"></div>
                         </template>
                     </div>
                     <div class="options-section">
@@ -307,13 +315,20 @@
                 <div class="pip-options-container" x-show="active_method === 'pip'">
                     <div class="options-section">
                         <div class="option-label">Packages</div>
-                        <template x-for="package in pip_packages">
+                        <template x-for="package in packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
                                 x-bind:class="{'active': active_packages.includes(package)}" class="option"
                                 x-html="getPackageHTML(package)">
                             </div>
                         </template>
                     </div>
+                    <div class="options-section" x-show="active_packages != 'Standard'">
+                        <div class="option-label">Packages</div>
+                        <template x-for="package in additional_pip_packages">
+                            <div x-on:click="(e) => packagesClickHandler(e, package)"
+                                x-bind:class="{'active': active_packages.includes(package)}" class="option"
+                                x-text="package"></div>
+                        </template>
                 </div>
                 <div class="docker-options-container" x-show="active_method === 'Docker'">
                     <div class="options-section">
@@ -374,13 +389,14 @@
             python_vers: ["3.9", "3.10"],
             cuda_vers: ["11.2", "11.8", "12.0"],
             pip_cuda_vers: ["11.2 - 11.8", "12.0"],
-            methods: ["Conda", "pip", "Docker", "Source"],
+            methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
-            packages: ["Standard", "cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
-            pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial", "cuCIM"],
+            packages: ["Standard", "Choose Specific Packages"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuXFilter", "cuSpatial", "cuCIM"],
+            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"], // , "RTXpy" will return later
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuXFilter", "cuSignal", "cuCIM"],
@@ -457,7 +473,7 @@
                     pkgs = ["rapids"];
                 }
 
-                var pkgs_vers = pkgs.map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
+                var pkgs_vers = pkgs.filter(pkg => pkg !== "Choose Specific Packages").map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
                 var all_pkgs = pkgs_vers + py_cuda_pkgs;
 
                 var conda_create_ln = this.highlightCmd('conda') + " create " + this.highlightFlag("-n") + " rapids-" + rapids_version + " " + conda_channels;
@@ -486,12 +502,18 @@
                 if (this.active_pip_cuda_ver === "11.2 - 11.8") {
                     cuda_suffix = "-cu11";
                 }
+
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
                     if (pkg === "cucim") return pkg;
                     return pkg + cuda_suffix;
                 }
-                var pkgs = this.active_packages.map(libraryToPkg).join(" ");
+                if (this.active_packages[0] === 'Standard') {
+                    var pkgs = this.additional_pip_packages.map(libraryToPkg).join(" ");
+                } else {
+                    var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
+                }
+                // var pkgs = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages").map(libraryToPkg).join(" ");
                 var isArm = this.active_arch === "arm";
                 var cupy_inst = "";
 
@@ -720,7 +742,7 @@
                 if (method === "pip") {
                     this.active_pip_cuda_ver = '12.0';
                     this.active_release = 'Stable';
-                    this.active_packages = ['cuDF']
+                    // this.active_packages = ['cuDF']
                 }
                 if (method === "Docker") {
                     if (this.active_release === 'Nightly') {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -50,8 +50,7 @@
 
     .selector .options .option:hover,
     .selector .options .option.active:hover,
-    .cmd-button:hover
-    {
+    .cmd-button:hover {
         background: #ffb500;
         box-shadow: 1px 1px 0px rgba(10, 10, 10, 0.7);
         -webkit-transition: background-color 0.3s ease-in-out;
@@ -238,8 +237,6 @@
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
     }
-
-
 </style>
 
 <script defer src="https://unpkg.com/alpinejs@3.10.2/dist/cdn.min.js"></script>
@@ -261,8 +258,8 @@
                     <div class="option-label">Method</div>
                     <template x-for="method in methods">
                         <div x-on:click="(e) => methodClickHandler(e, method)"
-                            x-bind:class="{'active': method === active_method, 'disabled': disableUnsupportedMethod(method)}" class="option"
-                            x-html="getMethodHTML(method)">
+                            x-bind:class="{'active': method === active_method, 'disabled': disableUnsupportedMethod(method)}"
+                            class="option" x-html="getMethodHTML(method)">
                         </div>
                     </template>
                 </div>
@@ -278,8 +275,8 @@
                     <div class="option-label">System CUDA</div>
                     <template x-for="version in pip_cuda_vers">
                         <div x-on:click="(e) => pipCUDAClickHandler(e, version)"
-                            x-bind:class="{'active': version === active_pip_cuda_ver}"
-                            class="option" x-text="'CUDA ' + version"></div>
+                            x-bind:class="{'active': version === active_pip_cuda_ver}" class="option"
+                            x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
                 <div class="options-section" x-show="active_method !== 'pip'">
@@ -295,8 +292,8 @@
                         <div class="option-label">RAPIDS Packages</div>
                         <template x-for="package in packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
-                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}" class="option"
-                                x-html="getPackageHTML(package)">
+                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}"
+                                class="option" x-html="getPackageHTML(package)">
                             </div>
                         </template>
                     </div>
@@ -304,8 +301,8 @@
                         <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_rapids_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
-                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}" class="option"
-                                x-text="package"></div>
+                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}"
+                                class="option" x-text="package"></div>
                         </template>
                     </div>
                     <div class="options-section">
@@ -469,7 +466,7 @@
                 if (this.active_packages.length + this.active_additional_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 }
-                
+
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     pkgs = ["rapids"];
                 }
@@ -517,7 +514,8 @@
                     var pkgs = this.active_packages
                         .filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "cuSignal")
                         .map(libraryToPkg)
-                        .join(" ");                }
+                        .join(" ");
+                }
 
                 if (pkgs === "cucim") {
                     index_url = "";
@@ -563,12 +561,12 @@
             getDockerNotes() {
                 var notes = [];
                 if (this.active_cuda_ver.startsWith("12")) {
-                        var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                        var cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
-                        notes = [...notes, cuda12]
+                    var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
+                    var cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
+                    notes = [...notes, cuda12]
                 } else {
-                        var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    }
+                    var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
+                }
 
                 notes = [...notes, "The selected image contains the following packages:<br>" + pkgs_html];
                 return notes.map(note => this.note_prefix + " " + note);
@@ -584,8 +582,8 @@
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
-                    notes = [...notes, "The CUDA " + this.active_cuda_ver + 
-                             " <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
+                    notes = [...notes, "The CUDA " + this.active_cuda_ver +
+                        " <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
                 }
 
                 if (this.active_additional_packages.length) {
@@ -601,7 +599,7 @@
             getpipNotes() {
                 var notes = [];
                 notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, and <code>cuXfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
-                         'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
+                    'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -554,14 +554,15 @@
                 return loc;
             },
             getDockerNotes() {
+                var cuda12 = ""
                 if (this.active_cuda_ver.startsWith("12")) {
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                        notes = [...notes, "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures"];
+                        cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
                 } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
 
-                return [this.note_prefix + " The selected image contains the following packages:<br>" + pkgs_html];
+                return [this.note_prefix + cuda12 + " The selected image contains the following packages:<br>" + pkgs_html];
             },
             getCondaNotes() {
                 var notes = [];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -440,7 +440,7 @@
                 var pkgs = this.active_packages;
                 var py_cuda_pkgs = [this.highlightPkgOrImg("python") + "=" + python_version, this.highlightPkgOrImg("cuda-version") + "=" + cuda_version].join(" ");
                 var conda_channels = [rapids_channel, "conda-forge", "nvidia"]
-                    .map(ch => this.highlightFlag("-c") + " " + ch + " ")
+                    .map(ch => "-" + this.highlightFlag("c") + " " + ch + " ")
                     .join("");
                 var indentation = "    ";
 
@@ -455,7 +455,7 @@
                 var pkgs_vers = pkgs.filter(pkg => pkg !== "Choose Specific Packages").map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
                 var all_pkgs = pkgs_vers + py_cuda_pkgs;
 
-                var conda_create_ln = this.highlightCmd('conda') + " create --solver=libmamba " + this.highlightFlag("-n") + " rapids-" + rapids_version + " " + conda_channels;
+                var conda_create_ln = this.highlightCmd('conda') + " create --" + this.highlightFlag("solver") + "=libmamba " + this.highlightFlag("-n") + " rapids-" + rapids_version + " " + conda_channels;
                 var pkgs_ln = indentation + all_pkgs;
                 var add_pkgs_ln = "";
 
@@ -474,9 +474,10 @@
                 return lines;
             },
             getpipCmdHtml() {
-                var pip_install = "pip install ";
-                var index_url = " --extra-index-url=https://pypi.nvidia.com";
+                var pip_install = `${this.highlightCmd("pip")} install`;
+                var index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
                 var cuda_suffix = "-cu12";
+                var indentation = "    ";
 
                 if (this.active_pip_cuda_ver === "11.2 - 11.8") {
                     cuda_suffix = "-cu11";
@@ -490,19 +491,20 @@
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 } else if (this.active_packages[0] === 'Standard') {
-                    var pkgs = this.additional_pip_packages.map(libraryToPkg).join(" ");
+                    var pkgs = this.additional_pip_packages.map(libraryToPkg);
                 } else {
                     var pkgs = this.active_packages
                         .filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "cuSignal")
-                        .map(libraryToPkg)
-                        .join(" ");
+                        .map(libraryToPkg);
                 }
 
-                if (pkgs === "cucim") {
+                if (pkgs.length === 1 && pkgs[0] === "cucim") {
                     index_url = "";
                 }
 
-                return pip_install + pkgs + index_url;
+                return [pip_install, index_url, pkgs.map(pkg => this.highlightPkgOrImg(pkg)).join(" ")]
+                    .filter(Boolean)
+                    .join(" \\\n" + indentation);
             },
             getDockerCmdHtml() {
                 var hasNotebooks = this.active_img_type === "Notebook";
@@ -528,7 +530,7 @@
                 var fullImg = (this.highlightPkgOrImg(imgRepo) + ":" + imgTag).toLowerCase();
 
                 var indent = "    ";
-                var cmd = this.highlightCmd("docker") + " run --" + this.highlightFlag("gpus") + " all --pull always --" + this.highlightFlag("rm") + " -" + this.highlightFlag("it") + " \\\n" +
+                var cmd = this.highlightCmd("docker") + " run --" + this.highlightFlag("gpus") + " all --" + this.highlightFlag("pull") + " always --" + this.highlightFlag("rm") + " -" + this.highlightFlag("it") + " \\\n" +
                     indent + "--" + this.highlightFlag("shm-size") + "=1g --" + this.highlightFlag("ulimit") + " memlock=-1 --" + this.highlightFlag("ulimit") + " stack=67108864" + " \\\n" +
                     (portOptions ? indent + portOptions + "\\\n" : "") +
                     indent + fullImg;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -381,7 +381,7 @@
             additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
             additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
-            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuxfilter", "cuSignal", "cuCIM"],
+            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
             getStableVersion() {
                 return "{{ site.data.releases.stable.version }}";
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -475,7 +475,7 @@
                 var pkgs_vers = pkgs.filter(pkg => pkg !== "Choose Specific Packages").map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
                 var all_pkgs = pkgs_vers + py_cuda_pkgs;
 
-                var conda_create_ln = this.highlightCmd('conda') + " create " + this.highlightFlag("-n") + " rapids-" + rapids_version + " " + conda_channels;
+                var conda_create_ln = this.highlightCmd('conda') + " create --solver=libmamba " + this.highlightFlag("-n") + " rapids-" + rapids_version + " " + conda_channels;
                 var pkgs_ln = indentation + all_pkgs;
                 var add_pkgs_ln = "";
 
@@ -491,7 +491,7 @@
                     add_pkgs_ln
                 ].filter(Boolean).join(" \\\n");
 
-                return lines + " --solver=libmamba";
+                return lines;
             },
             getpipCmdHtml() {
                 var pip_install = "pip install ";

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -174,6 +174,7 @@
         margin-top: 1rem;
         margin-right: 0.6em;
         vertical-align: top;
+        text-align: right
     }
 
     .cmd-box {
@@ -721,6 +722,7 @@
             * selected individually. All other packages can be selected together.
             **/
             packagesClickHandler(e, package) {
+                if (this.isDisabled(e.target)) return;
                 if (package === "Standard") {
                     this.active_packages = [package];
                     return;
@@ -745,6 +747,7 @@
                 this.active_packages = [...this.active_packages, package];
             },
             additionalPackagesClickHandler(e, package) {
+                if (this.isDisabled(e.target)) return;
                 if (this.active_additional_packages.includes(package)) {
                     this.active_additional_packages = this.active_additional_packages.filter(el => el !== package);
                     return;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -616,7 +616,7 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, and <code>cuSpatial</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
+                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, and <code>cuXfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
                          'pip installation supports Python <code>3.9</code>, and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -302,7 +302,7 @@
                         <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_rapids_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
-                                x-bind:class="{'active': active_packages.includes(package)}" class="option"
+                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}" class="option"
                                 x-text="package"></div>
                         </template>
                     </div>

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -692,8 +692,6 @@
             },
             archClickHandler(e, arch) {
                 if (this.isDisabled(e.target)) return;
-                if (arch === "arm") this.active_img_type = "core";
-                if (arch === "arm" && this.active_os_ver === "CentOS 7") this.active_os_ver = "Ubuntu 22.04";
                 this.active_arch = arch;
             },
             cudaClickHandler(e, version) {
@@ -712,7 +710,7 @@
                 if (this.isDisabled(e.target)) return;
                 if (method !== "Docker") {
                     this.active_img_options = ["notebooks"];
-                    this.active_img_type = "core";
+                    this.active_img_type = "Base";
                 }
                 if (method !== "Conda") {
                     this.active_additional_packages = [];
@@ -728,9 +726,6 @@
                 if (method === "Docker") {
                     if (this.active_release === 'Nightly') {
                         this.active_img_loc = 'Dockerhub';
-                    }
-                    if (this.active_os_ver === 'Ubuntu 22.04') {
-                        this.active_cuda_ver = '11.8';
                     }
                 }
                 this.active_method = method;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -329,6 +329,7 @@
                                 x-bind:class="{'active': active_packages.includes(package)}" class="option"
                                 x-text="package"></div>
                         </template>
+                    </div>
                 </div>
                 <div class="docker-options-container" x-show="active_method === 'Docker'">
                     <div class="options-section">

--- a/install/install.md
+++ b/install/install.md
@@ -83,7 +83,7 @@ pip uninstall cupy-cuda115; pip install cupy-cuda11x
 
 <i class="fas fa-info-circle"></i> The following error message indicates a problem with your environment:
 ```
-ERROR: Could not find a version that satisfies the requirement cudf-cu11 (from versions: 0.0.1, 22.10.0)
+ERROR: Could not find a version that satisfies the requirement cudf-cu11 (from versions: 0.0.1, {{ site.data.releases.stable.version }})
 ERROR: No matching distribution found for cudf-cu11
 ```
 Check the suggestions below for possible resolutions:

--- a/install/install.md
+++ b/install/install.md
@@ -71,12 +71,6 @@ mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forg
 
 <br/>
 
-### **Docker Issues**
-<i class="fas fa-info-circle"></i> Jupyter Lab is not accessible:<br/>
-If the server has not started or needs to be restarted / stop, use the included [start/stop script](#docker-startstop). Note this may change in the near future releases.
-
-<br/>
-
 ### **pip Issues**
 <i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 tookits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
@@ -134,7 +128,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 <i class="fas fa-download text-purple"></i> **CUDA & NVIDIA Drivers:** One of the following supported versions:
 {: .no-tb-margins }
 
-- <i class="fas fa-check-circle"></i> [CUDA 11.2](https://developer.nvidia.com/cuda-11.2.0-download-archive){: target="_blank"} with Driver 460.27.03 or newer
+- <i class="fas fa-check-circle"></i> [CUDA 11.2](https://developer.nvidia.com/cuda-11.2.0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
@@ -251,16 +245,6 @@ docker run -t -d --gpus all --shm-size=1g --ulimit memlock=-1 --ulimit stack= 67
 
 The standard docker command may be sufficient, but the additional arguments ensures more stability.  See the [NCCL docs](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting.html#sharing-data){: target="_blank"} and [UCX docs](https://github.com/openucx/ucx/blob/master/docs/source/running.md#running-in-docker-containers){: target="_blank"} for more details on MNMG usage.
 
-<div id="docker-startstop"></div>
-**Start / Stop Jupyter Lab Notebooks.** Either the standard single GPU or the modified MNMG Docker command above should auto-run a Jupyter Lab Notebook server. If it does not, or a restart is needed, run the following command within the Docker container to launch the notebook server:
-```
-bash /rapids/utils/start-jupyter.sh
-```
-
-If, for whatever reason, you need to shut down the Jupyter Lab server, use:
-```
-bash /rapids/utils/stop-jupyter.sh
-```
 
 **Custom Datasets.** See the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/rapidsai){: target="_blank"} for more information about using custom datasets. [Docker Hub](https://hub.docker.com/r/rapidsai/rapidsai/){: target="_blank"} and [NVIDIA GPU Cloud](https://ngc.nvidia.com/catalog/containers/nvidia:rapidsai:rapidsai){: target="_blank"} host RAPIDS containers with a full list of [available tags](https://hub.docker.com/r/rapidsai/rapidsai/tags){: target="_blank"}.
 

--- a/install/install.md
+++ b/install/install.md
@@ -53,12 +53,11 @@ RAPIDS has switched the default solver recommendation to [libmamba](https://www.
 conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 'classic')
 ```
 
-Please resolve by updating your conda installation to at least `23.5.2` as it include the `libmamba` solver.
-```
-conda update -n base -c defaults conda
-```
-
-Alternatively, either use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"} or use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector.
+To resolve this error please follow one of these steps:
+- If the conda installation is version `22.11` or newer, run: `conda install -n base conda-libmamba-solver`
+- If the conda installtion is older than `22.11` please update your [Conda or Miniconda to the latest version](https://conda.io/projects/conda/en/stable/user-guide/install/index.html){: target="_blank"}
+- Use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"}
+- Use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector.
 
 <i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
 Conda-forge does not yet support the minimum required glibc (2.27) for CUDA 12 on ARM. For ARM support, please use CUDA 11.

--- a/install/install.md
+++ b/install/install.md
@@ -48,7 +48,7 @@ Use the selector tool below to select your preferred method, packages, and envir
 
 ### **Conda Issues**
 <i class="fas fa-info-circle"></i> A `conda create error` occurs:<br/>
-RAPIDS has switched the default solver recommendation to [libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}, a Mamba-powered Conda solver that is [now included with all Conda/Miniconda installations](https://www.anaconda.com/blog/new-release-anaconda-distribution-2023-07-miniconda-23-5-0-and-more){: target="_blank"} to significantly accelerate environment solving. If the error below occurs:
+RAPIDS has switched the default solver recommendation to [libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}, a Mamba-powered Conda solver that is [now included with all Conda/Miniconda installations](https://www.anaconda.com/blog/new-release-anaconda-distribution-2023-07-miniconda-23-5-0-and-more){: target="_blank"} to significantly accelerate environment solving. The error output shows:
 ```
 conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 'classic')
 ```
@@ -150,9 +150,9 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 ### **Docker and Conda**
 
-- <i class="fas fa-info-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
-- <i class="fas fa-info-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
-- <i class="fas fa-info-circle"></i> ARM is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip packages for ARM support
+- <i class="fas fa-info-circle"></i> CUDA 12 conda packages and Docker images currently support CUDA 12.0
+- <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
+- <i class="fas fa-info-circle"></i> ARM is not currently supported by CUDA 12 conda packages or Docker images, use CUDA 11 or pip packages for ARM support
  
 ### **pip**
 

--- a/install/install.md
+++ b/install/install.md
@@ -133,18 +133,18 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
 
- ### **CUDA 12 Compatibility**
+### **CUDA 12 Compatibility**
  
- #### **Docker and Conda**
+#### **Docker and Conda**
 
- - <i class="fas fa-check-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
- - <i class="fas fa-check-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
- - <i class="fas fa-check-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
+- <i class="fas fa-check-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
+- <i class="fas fa-check-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
+- <i class="fas fa-check-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
  
- #### **pip**
+#### **pip**
 
- - <i class="fas fa-check-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
- - <i class="fas fa-check-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
+- <i class="fas fa-check-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
+- <i class="fas fa-check-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>

--- a/install/install.md
+++ b/install/install.md
@@ -72,7 +72,7 @@ mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forg
 ### **Docker Issues**
 <i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes. <br/>
 To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/rapidsai){: target="_blank"}. Some key notes below:
-- `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
+- `Development` images are no longer being published, in the coming releases RAPIDS will roll out [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
    - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
    - CUDA 11.2 images are Ubuntu `20.04`
@@ -246,7 +246,8 @@ docker run --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark
 
 <br/>
 
-### **JupyterLab.** Defaults will run [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/){: target="_blank"} on your host machine at port: `8888`.
+### **JupyterLab.** 
+The command provided from the selector for the `notebooks` Docker image will run [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/){: target="_blank"} on your host machine at port: `8888`.
 
 **Running Multi-Node / Multi-GPU (MNMG) Environment.** To start the container in an MNMG environment:
 ```

--- a/install/install.md
+++ b/install/install.md
@@ -82,6 +82,7 @@ To learn more about these changes, please see the [RAPIDS Container README](http
 - The `Base` image starts in an ipython shell
    - To run bash commands inside the ipython shell prefix the command with `!`
    - To run the image without the ipython shell add `/bin/bash` to the end of the `docker run` command
+- For a full list of changes please see this [RAPIDS Docker Issue](https://github.com/rapidsai/docker/issues/539){: target="_blank"}
 
 
 ### **pip Issues**

--- a/install/install.md
+++ b/install/install.md
@@ -79,6 +79,9 @@ To learn more about these changes, please see the [RAPIDS Container README](http
    - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
    - CUDA 12 is not yet supported when using Docker images on ARM architecture
+- The `Base` image starts in an ipython shell
+   - To run bash commands inside the ipython shell prefix the command with `!`
+   - To run the image without the ipython shell add `/bin/bash` to the end of the `docker run` command
 
 
 ### **pip Issues**

--- a/install/install.md
+++ b/install/install.md
@@ -47,6 +47,19 @@ Use the selector tool below to select your preferred method, packages, and envir
 ## Installation Troubleshooting
 
 ### **Conda Issues**
+<i class="fas fa-info-circle"></i> A `conda create error` occurs:<br/>
+RAPIDS has switched the default solver recommendation to [libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}, a Mamba-powered conda solver that is [now included with all Conda/Miniconda installations](https://www.anaconda.com/blog/new-release-anaconda-distribution-2023-07-miniconda-23-5-0-and-more){: target="_blank"} to significantly accelerate environment solving. If the error below occurs:
+```
+conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 'classic')
+```
+
+Please resolve by updating your conda installation to at least `23.5.2` as it include the `libmamba` solver.
+```
+conda install conda=23.5.2
+```
+
+Alternatively, either use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"} or use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector.
+
 <i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
 Conda-forge does not yet support the minimum required glibc (2.27) for CUDA 12 on ARM. For ARM support, please use CUDA 11.
 
@@ -56,9 +69,6 @@ The installation method below may allow RAPIDS CUDA 12.0 packages to coexist wit
 ```
 mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
 ```
-
-<i class="fas fa-info-circle"></i> The dependency solver takes too long or never resolves: <br/>
-Update conda to use the new [libmamba solver](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="blank"} or use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"}.
 
 <br/>
 

--- a/install/install.md
+++ b/install/install.md
@@ -69,6 +69,17 @@ The installation method below may allow RAPIDS CUDA 12.0 packages to coexist wit
 mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
 ```
 
+### **Docker Issues**
+<i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes
+To learn more about these changes, please see the [RAPIDS Docker README](https://github.com/rapidsai/docker){: target="_blank"}. Some key notes below:
+- `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) for development
+   - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer)
+- All images are Ubuntu-based
+   - CUDA `11.2` images are Ubuntu `20.04`
+   - All other images are Ubuntu `22.04`
+- All images are multiarch (x86_64 and ARM)
+   - CUDA 12 is not yet supported on ARM the Docker images
+
 <br/>
 
 ### **pip Issues**
@@ -313,7 +324,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Install latest Docker Desktop for Windows
 4. Log in to the WSL2 Linux instance.
-5. Generate and run the RAPIDS `docker pull` and `docker run` commands based on your desired configuration using the RAPIDS [Release Selector](#selector).
+5. Generate and run the RAPIDS `docker` command based on your desired configuration using the RAPIDS [Release Selector](#selector).
 6. Inside the Docker instance, run this code to check that the RAPIDS installation is working:
 	```
 	import cudf

--- a/install/install.md
+++ b/install/install.md
@@ -133,15 +133,15 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
 
- ### CUDA 12 Compatibility
+ ### **CUDA 12 Compatibility**
  
- #### Docker and Conda
+ #### **Docker and Conda**
 
  - <i class="fas fa-check-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
  - <i class="fas fa-check-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
  - <i class="fas fa-check-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
  
- #### pip
+ #### **pip**
 
  - <i class="fas fa-check-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
  - <i class="fas fa-check-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.

--- a/install/install.md
+++ b/install/install.md
@@ -66,7 +66,7 @@ Conda-forge does not yet support the minimum required glibc (2.32) for CUDA 12 o
 PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
 The installation method below may allow RAPIDS CUDA 12.0 packages to coexist with PyTorch CUDA 12.1 nightly packages if there is a hard-requirement of CUDA 12 but it is currently unsupported:
 ```
-mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
+conda create --solver=libmamba -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
 ```
 
 ### **Docker Issues**

--- a/install/install.md
+++ b/install/install.md
@@ -47,12 +47,12 @@ Use the selector tool below to select your preferred method, packages, and envir
 ## Installation Troubleshooting
 
 ### **Conda Issues**
-<i class="fas fa-info-circle"></i> CUDA 12.0 arm packages don't exist:<br/>
-Conda-forge doesn't yet support the minimum required glibc (2.27) for CUDA 12 on arm. For arm support, please use an 11.x installation.
+<i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
+Conda-forge does not yet support the minimum required glibc (2.27) for CUDA 12 on ARM. For ARM support, please use CUDA 11.
 
-<i class="fas fa-info-circle"></i> CUDA 12.0 packages don't work with stable PyTorch packages: <br/>
-PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11.x. <br/>
-The installation method below may function if there is a hard-requirement of CUDA 12 but it is currently unsupported:
+<i class="fas fa-info-circle"></i> At the time of writing, there is no stable CUDA 12 release of PyTorch: <br/>
+PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
+The installation method below may allow RAPIDS CUDA 12.0 packages to coexist with PyTorch CUDA 12.1 nightly packages if there is a hard-requirement of CUDA 12 but it is currently unsupported:
 ```
 mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia cuml pytorch pytorch-cuda=12.1 cuda-version=12.0
 ```
@@ -139,7 +139,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 - <i class="fas fa-info-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
 - <i class="fas fa-info-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
-- <i class="fas fa-info-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
+- <i class="fas fa-info-circle"></i> ARM is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip packages for ARM support
  
 ### **pip**
 

--- a/install/install.md
+++ b/install/install.md
@@ -75,7 +75,7 @@ To learn more about these changes, please see the [RAPIDS Container README](http
 - `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
    - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
-   - CUDA `11.2` images are Ubuntu `20.04`
+   - CUDA 11.2 images are Ubuntu `20.04`
    - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
    - CUDA 12 is not yet supported when using Docker images on ARM architecture

--- a/install/install.md
+++ b/install/install.md
@@ -253,7 +253,7 @@ The standard docker command may be sufficient, but the additional arguments ensu
 <div id="pip"></div>
 
 ## **pip**
-RAPIDS 23.06 pip packages of cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and RAFT are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
+RAPIDS pip packages are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
 
 ### **pip Additional Prerequisites**
 <i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -299,7 +299,9 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 ### **Troubleshooting**
 
-<i class="fas fa-info-circle text-white"></i> When installing with conda, if an `http 000 connection error` occurs when accessing the repository data, run `wsl --shutdown` and then [restart the WSL instance](https://stackoverflow.com/questions/67923183/miniconda-on-wsl2-ubuntu-20-04-fails-with-condahttperror-http-000-connection){: target="_blank"}.
+<i class="fas fa-info-circle text-white"></i> When installing with Conda, if an `http 000 connection error` occurs when accessing the repository data, run `wsl --shutdown` and then [restart the WSL instance](https://stackoverflow.com/questions/67923183/miniconda-on-wsl2-ubuntu-20-04-fails-with-condahttperror-http-000-connection){: target="_blank"}.
+
+<i class="fas fa-info-circle text-white"></i> When installing with Conda or pip, if an `WSL2 Jitify fatal error: libcuda.so: cannot open shared object file` error occurs, follow suggestions in [this WSL issue](https://github.com/microsoft/WSL/issues/8587) to resolve.
 
 <i class="fas fa-info-circle text-white"></i> When installing with Docker Desktop, if the container pull command is successful, but the run command hangs indefinitely, [ensure you're on Docker Desktop >= 4.18](https://docs.docker.com/desktop/release-notes/){: target="_blank"}.
 

--- a/install/install.md
+++ b/install/install.md
@@ -133,15 +133,15 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
 
-### **CUDA 12 Compatibility**
+## **CUDA 12 Support**
 
-#### **Docker and Conda**
+### **Docker and Conda**
 
 - <i class="fas fa-info-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
 - <i class="fas fa-info-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
 - <i class="fas fa-info-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
  
-#### **pip**
+### **pip**
 
 - <i class="fas fa-info-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
 - <i class="fas fa-info-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.

--- a/install/install.md
+++ b/install/install.md
@@ -70,15 +70,15 @@ mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forg
 ```
 
 ### **Docker Issues**
-<i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes
-To learn more about these changes, please see the [RAPIDS Docker README](https://github.com/rapidsai/docker){: target="_blank"}. Some key notes below:
-- `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) for development
-   - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer)
+<i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes <br/>
+To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/rapidsai){: target="_blank"}. Some key notes below:
+- `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
+   - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
    - CUDA `11.2` images are Ubuntu `20.04`
    - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
-   - CUDA 12 is not yet supported on ARM the Docker images
+   - CUDA 12 is not yet supported when using Docker Images on ARM architechture
 
 <br/>
 
@@ -245,9 +245,9 @@ docker run --gpus all nvcr.io/nvidia/k8s/cuda-sample:nbody nbody -gpu -benchmark
 **4b. Legacy Docker Users.** Docker CE v18 & [nvidia-docker2](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(version-2.0)){: target="_blank"} users will need to replace the following for compatibility:
 `docker run --gpus all` with `docker run --runtime=nvidia`
 
-<br/><br/>
+<br/>
 
-**JupyterLab.** Defaults will run [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/){: target="_blank"} on your host machine at port: `8888`.
+### **JupyterLab.** Defaults will run [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/){: target="_blank"} on your host machine at port: `8888`.
 
 **Running Multi-Node / Multi-GPU (MNMG) Environment.** To start the container in an MNMG environment:
 ```

--- a/install/install.md
+++ b/install/install.md
@@ -134,17 +134,17 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
 
 ### **CUDA 12 Compatibility**
- 
+
 #### **Docker and Conda**
 
-- <i class="fas fa-check-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
-- <i class="fas fa-check-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
-- <i class="fas fa-check-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
+- <i class="fas fa-info-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
+- <i class="fas fa-info-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
+- <i class="fas fa-info-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
  
 #### **pip**
 
-- <i class="fas fa-check-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
-- <i class="fas fa-check-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
+- <i class="fas fa-info-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
+- <i class="fas fa-info-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>

--- a/install/install.md
+++ b/install/install.md
@@ -129,11 +129,22 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive){: target="_blank"} with Driver 525.60.13 or newer **for pip installations only**
+- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive){: target="_blank"} with Driver 525.60.13 or newer **see CUDA 12 section below for notes on usage**
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details. 
+
+ ### CUDA 12 Compatibility
  
- **Note**: RAPIDS Docker images and conda packages for CUDA 11 can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit. pip installations require using a wheel matching the system's installed CUDA toolkit. For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
+ #### Docker and Conda
+
+ - <i class="fas fa-check-circle"></i> CUDA 12 packages and images currently support CUDA 12.0
+ - <i class="fas fa-check-circle"></i> CUDA 11 packages and images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
+ - <i class="fas fa-check-circle"></i> arm is not currently supported on CUDA 12 packages and images, use CUDA 11 or pip for arm support
+ 
+ #### pip
+
+ - <i class="fas fa-check-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit. 
+ - <i class="fas fa-check-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
 
 <br/>
 <div id="system-recommendations"></div>

--- a/install/install.md
+++ b/install/install.md
@@ -54,7 +54,7 @@ Conda-forge does not yet support the minimum required glibc (2.27) for CUDA 12 o
 PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
 The installation method below may allow RAPIDS CUDA 12.0 packages to coexist with PyTorch CUDA 12.1 nightly packages if there is a hard-requirement of CUDA 12 but it is currently unsupported:
 ```
-mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia cuml pytorch pytorch-cuda=12.1 cuda-version=12.0
+mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
 ```
 
 <i class="fas fa-info-circle"></i> The dependency solver takes too long or never resolves: <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -48,19 +48,19 @@ Use the selector tool below to select your preferred method, packages, and envir
 
 ### **Conda Issues**
 <i class="fas fa-info-circle"></i> A `conda create error` occurs:<br/>
-RAPIDS has switched the default solver recommendation to [libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}, a Mamba-powered conda solver that is [now included with all Conda/Miniconda installations](https://www.anaconda.com/blog/new-release-anaconda-distribution-2023-07-miniconda-23-5-0-and-more){: target="_blank"} to significantly accelerate environment solving. If the error below occurs:
+RAPIDS has switched the default solver recommendation to [libmamba](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}, a Mamba-powered Conda solver that is [now included with all Conda/Miniconda installations](https://www.anaconda.com/blog/new-release-anaconda-distribution-2023-07-miniconda-23-5-0-and-more){: target="_blank"} to significantly accelerate environment solving. If the error below occurs:
 ```
 conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 'classic')
 ```
 
 To resolve this error please follow one of these steps:
-- If the conda installation is version `22.11` or newer, run: `conda install -n base conda-libmamba-solver`
-- If the conda installtion is older than `22.11` please update your [Conda or Miniconda to the latest version](https://conda.io/projects/conda/en/stable/user-guide/install/index.html){: target="_blank"}
+- If the Conda installation is version `22.11` or newer, run: `conda install -n base conda-libmamba-solver`
+- If the Conda installtion is older than `22.11`, please update your [Conda or Miniconda to the latest version](https://conda.io/projects/conda/en/stable/user-guide/install/index.html){: target="_blank"}
 - Use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"}
-- Use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector.
+- Use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector
 
 <i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
-Conda-forge does not yet support the minimum required glibc (2.27) for CUDA 12 on ARM. For ARM support, please use CUDA 11.
+Conda-forge does not yet support the minimum required glibc (2.32) for CUDA 12 on ARM. For ARM support, please use CUDA 11.
 
 <i class="fas fa-info-circle"></i> At the time of writing, there is no stable CUDA 12 release of PyTorch: <br/>
 PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
@@ -274,7 +274,7 @@ RAPIDS 23.06 pip packages of cuDF, dask-cuDF, cuML, cuGraph, cuSpatial, RMM, and
 ### **pip Additional Prerequisites**
 <i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
 <i class="fas fa-info-circle"></i> **glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
-<i class="fas fa-info-circle"></i> **glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.31 (only ARM Server Base System Architecture is supported).
+<i class="fas fa-info-circle"></i> **glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.32 (only ARM Server Base System Architecture is supported).
 
 
 <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -55,7 +55,7 @@ conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 
 
 To resolve this error please follow one of these steps:
 - If the Conda installation is version `22.11` or newer, run: `conda install -n base conda-libmamba-solver`
-- If the Conda installtion is older than `22.11`, please update your [Conda or Miniconda to the latest version](https://conda.io/projects/conda/en/stable/user-guide/install/index.html){: target="_blank"}
+- If the Conda installation is older than `22.11`, please update your [Conda or Miniconda to the latest version](https://conda.io/projects/conda/en/stable/user-guide/install/index.html){: target="_blank"}
 - Use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"}
 - Use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector
 
@@ -70,7 +70,7 @@ mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forg
 ```
 
 ### **Docker Issues**
-<i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes <br/>
+<i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes. <br/>
 To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/rapidsai){: target="_blank"}. Some key notes below:
 - `Development` images are no longer being published, RAPIDS now recommends [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
    - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
@@ -78,9 +78,8 @@ To learn more about these changes, please see the [RAPIDS Container README](http
    - CUDA `11.2` images are Ubuntu `20.04`
    - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
-   - CUDA 12 is not yet supported when using Docker Images on ARM architechture
+   - CUDA 12 is not yet supported when using Docker images on ARM architecture
 
-<br/>
 
 ### **pip Issues**
 <i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 tookits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -55,7 +55,7 @@ conda create: error: argument --solver: invalid choice: 'libmamba' (choose from 
 
 Please resolve by updating your conda installation to at least `23.5.2` as it include the `libmamba` solver.
 ```
-conda install conda=23.5.2
+conda update -n base -c defaults conda
 ```
 
 Alternatively, either use [Mamba directly](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"} or use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector.

--- a/install/install.md
+++ b/install/install.md
@@ -71,7 +71,7 @@ mamba create -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forg
 
 ### **Docker Issues**
 <i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes. <br/>
-To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/rapidsai){: target="_blank"}. Some key notes below:
+To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/base){: target="_blank"}. Some key notes below:
 - `Development` images are no longer being published, in the coming releases RAPIDS will roll out [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
    - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based


### PR DESCRIPTION
closes #413 

This PR contains the updates to the release selector required for the conda-forge CUDA 12.0 work as well as the docker overhaul.

To do:
- [x] CUDA 12 conda-forge updates
- [x] Docker Overhaul updates to the selector
- [x] Docker overhaul updates to the install page
- [x] `23.08` release updates

This PR updates:
- Selector
   - Enables CUDA 12.0 for conda packages
   - Disables CUDA 12.0 for arm conda packages
   - Disables cuSignal from conda CUDA 12.0
   - Removes the note on cuSignal for conda CUDA 12.0
   - Removes `PyCaret` as a conda additional package, it's now only available on pip for the newest versions
      - https://pypi.org/project/pycaret/#history
      - https://anaconda.org/conda-forge/pycaret/files
   - Updated to new docker setup
      - Much simpler, only `base` and `notebooks` 
      - No OS selection
      - Same CUDA 12 restrictions as Conda
 - Install page
    - Adds 2 troubleshooting steps about conda CUDA 12
       - No ARM
       - PyTorch CUDA version compatibilities
    - Expands the CUDA version compatibility section and breaks it up into docker/conda and pip 

I've also merged in #412 to simplify merging at release.