### PR TITLE
Add cuProj to docs.yml

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -78,7 +78,7 @@ apis:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
       stable: 1
-      nightly: 1
+      nightly: 0
   cusignal:
     name: cusignal
     path: cusignal
@@ -204,7 +204,7 @@ libs:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
       stable: 1
-      nightly: 1
+      nightly: 0
   libcuml:
     name: libcuml
     path: libcuml

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -78,7 +78,7 @@ apis:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
       stable: 1
-      nightly: 0
+      nightly: 1
   cusignal:
     name: cusignal
     path: cusignal
@@ -204,7 +204,7 @@ libs:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
       stable: 1
-      nightly: 0
+      nightly: 1
   libcuml:
     name: libcuml
     path: libcuml

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -58,7 +58,7 @@ apis:
       stable: 1
       nightly: 1
   cuspatial:
-    name: cuspatial
+    name: cuSpatial
     path: cuspatial
     desc: 'cuSpatial is a GPU-accelerated vector GIS library including binary predicates (DE-9IM), point-in-polygon, spatial join, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -60,12 +60,23 @@ apis:
   cuspatial:
     name: cuspatial
     path: cuspatial
-    desc: 'cuSpatial is a GPU accelerated C++/Python library for accelerating GIS workflows including point-in-polygon, spatial join, coordinate systems, shape primitives, distances, and trajectory analysis.'
+    desc: 'cuSpatial is a GPU-accelerated vector GIS library including binary predicates (DE-9IM), point-in-polygon, spatial join, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
+      stable: 1
+      nightly: 1
+  cuproj:
+    name: cuProj
+    path: cuProj
+    desc: 'cuProj is a GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), compatible with PyProj.'
+    ghlink: https://github.com/rapidsai/cuspatial/python/cuproj
+    cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # cuProj is housed within cuSpatial so updates remain in the cuSpatial changelog
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
       stable: 1
       nightly: 1
   cusignal:
@@ -175,12 +186,23 @@ libs:
   libcuspatial:
     name: libcuspatial
     path: libcuspatial
-    desc: 'libcuspatial is a GPU-accelerated C++ library for spatial data analysis including distance and trajectory computations, spatial data indexing and spatial join operations.'
+    desc: 'libcuspatial is a GPU-accelerated header-only C++ vector GIS library including binary predicates (DE-9IM), point-in-polygon, spatial join, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
+      stable: 1
+      nightly: 1
+  libcuproj:
+    name: libcuproj
+    path: libcuproj
+    desc: 'libcuproj is a C++ header-only library for GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), similar to PROJ.'
+    ghlink: https://github.com/rapidsai/cuspatial/cpp/cuproj
+    cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # Shares a changelog with cuSpatial
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
       stable: 1
       nightly: 1
   libcuml:

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -72,7 +72,7 @@ apis:
     name: cuProj
     path: cuProj
     desc: 'cuProj is a GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), compatible with PyProj.'
-    ghlink: https://github.com/rapidsai/cuspatial/python/cuproj
+    ghlink: https://github.com/rapidsai/cuspatial/tree/main/python/cuproj
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # cuProj is housed within cuSpatial so updates remain in the cuSpatial changelog
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
@@ -198,7 +198,7 @@ libs:
     name: libcuproj
     path: libcuproj
     desc: 'libcuproj is a C++ header-only library for GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), similar to PROJ.'
-    ghlink: https://github.com/rapidsai/cuspatial/cpp/cuproj
+    ghlink: https://github.com/rapidsai/cuspatial/tree/main/cpp/cuproj
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # Shares a changelog with cuSpatial
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled


### PR DESCRIPTION
This PR adds cuProj to the docs.yml supporting its docs builds. It also updates the description of cuSpatial to a more up-to-date description.

Question: I set the legacy flag to `0` for cuProj, I wasn't sure if that was necessary but figured it was since there's no `23.06` version.