### PR TITLE
Disable cudf-java docs for 23.08.

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
Fixes CI failures in deployment: https://github.com/rapidsai/docs/actions/runs/5860715491/job/15889357066

cudf-java docs are not yet available for 23.08.