### PR TITLE
Enable `23.08` docs for `cudf-java`

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
I've just uploaded the `23.08` docs for `cudf-java` to S3.

Therefore, they can now be enabled on the docs site.