### PR TITLE
Updates for the 23.10 release

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,43 @@
 [
   {
+    "version": "23.10",
+    "cudf_dev": {
+      "start": "Jul 20 2023",
+      "end": "Sep 20 2023",
+      "days": 42
+    },
+    "other_dev": {
+      "start": "Jul 27 2023",
+      "end": "Sep 27 2023",
+      "days": 42
+    },
+    "cudf_burndown": {
+      "start": "Sep 21 2023",
+      "end": "Sep 27 2023",
+      "days": 5
+    },
+    "other_burndown": {
+      "start": "Sep 28 2023",
+      "end": "Oct 4 2023",
+      "days": 5
+    },
+    "cudf_codefreeze": {
+      "start": "Sep 28 2023",
+      "end": "Oct 10 2023",
+      "days": 9
+    },
+    "other_codefreeze": {
+      "start": "Oct 5 2023",
+      "end": "Oct 10 2023",
+      "days": 4
+    },
+    "release": {
+      "start": "Oct 11 2023",
+      "end": "Oct 12 2023",
+      "days": 2
+    }
+  },
+  {
     "version": "23.08",
     "cudf_dev": {
       "start": "May 18 2023",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,86 +1,86 @@
 {
   "legacy": {
-    "version": "23.06",
-    "date": "Jun 8 2023"
-  },
-  "stable": {
     "version": "23.08",
     "date": "Aug 10 2023"
   },
-  "nightly": {
+  "stable": {
     "version": "23.10",
-    "cudf_dev": {
-      "start": "Jul 20 2023",
-      "end": "Sep 20 2023",
-      "days": 42
-    },
-    "other_dev": {
-      "start": "Jul 27 2023",
-      "end": "Sep 27 2023",
-      "days": 42
-    },
-    "cudf_burndown": {
-      "start": "Sep 21 2023",
-      "end": "Sep 27 2023",
-      "days": 5
-    },
-    "other_burndown": {
-      "start": "Sep 28 2023",
-      "end": "Oct 4 2023",
-      "days": 5
-    },
-    "cudf_codefreeze": {
-      "start": "Sep 28 2023",
-      "end": "Oct 10 2023",
-      "days": 9
-    },
-    "other_codefreeze": {
-      "start": "Oct 5 2023",
-      "end": "Oct 10 2023",
-      "days": 4
-    },
-    "release": {
-      "start": "Oct 11 2023",
-      "end": "Oct 12 2023",
-      "days": 2
-    }
+    "date": "Oct 12 2023"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "23.12",
     "cudf_dev": {
       "start": "Sep 21 2023",
-      "end": "Nov 8 2023",
-      "days": 35
+      "end": "Wed Nov 8 2023",
+      "days": "35"
     },
     "other_dev": {
       "start": "Sep 28 2023",
-      "end": "Nov 15 2023",
-      "days": 34
+      "end": "Wed Nov 15 2023",
+      "days": "34"
     },
     "cudf_burndown": {
       "start": "Nov 9 2023",
-      "end": "Nov 15 2023",
-      "days": 4
+      "end": "Wed Nov 15 2023",
+      "days": "4"
     },
     "other_burndown": {
       "start": "Nov 16 2023",
-      "end": "Nov 29 2023",
-      "days": 8
+      "end": "Wed Nov 29 2023",
+      "days": "8"
     },
     "cudf_codefreeze": {
       "start": "Nov 16 2023",
-      "end": "Dec 5 2023",
-      "days": 12
+      "end": "Tue Dec 5 2023",
+      "days": "12"
     },
     "other_codefreeze": {
       "start": "Nov 30 2023",
-      "end": "Dec 5 2023",
-      "days": 4
+      "end": "Tue Dec 5 2023",
+      "days": "4"
     },
     "release": {
       "start": "Dec 6 2023",
-      "end": "Dec 7 2023",
-      "days": 2
+      "end": "Thu Dec 7 2023",
+      "days": "2"
+    }
+  },
+  "next_nightly": {
+    "version": "24.02",
+    "cudf_dev": {
+      "start": "Nov 9 2023",
+      "end": "Wed Jan 17 2024",
+      "days": "42"
+    },
+    "other_dev": {
+      "start": "Nov 16 2023",
+      "end": "Wed Jan 24 2024",
+      "days": "43"
+    },
+    "cudf_burndown": {
+      "start": "Jan 18 2024",
+      "end": "Wed Jan 24 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Jan 25 2024",
+      "end": "Wed Jan 31 2024",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Jan 25 2024",
+      "end": "Tue Feb 6 2024",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Feb 1 2024",
+      "end": "Tue Feb 6 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Feb 7 2024",
+      "end": "Thu Feb 8 2024",
+      "days": "2"
     }
   }
 }


### PR DESCRIPTION
1. Cycles the versions in the data files
2. Disables stable (`23.10`) `cudf-java` docs until they are ready
