### PR TITLE
Remove 23.10 & 23.12 cusignal docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -88,8 +88,8 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
-      nightly: 1
+      stable: 0
+      nightly: 0
   cudf-java:
     name: 'Java + cuDF'
     path: cudf-java


### PR DESCRIPTION
`23.08` was the final release of `cusignal`, so we should remove the more recent docs.

This will also fix the deploy [here](https://github.com/rapidsai/docs/actions/runs/6511758413/job/17688052514#step:6:40).