### PR TITLE
Enable stable/23.10 cudf-java docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
I've uploaded the [`cudf-java` `23.10` docs](https://repo1.maven.org/maven2/ai/rapids/cudf/23.10.0/cudf-23.10.0-javadoc.jar) to the S3 bucket, so this PR just enables them.
