### PR TITLE
Update CUDA 12 nightly availability

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -550,9 +550,9 @@
             },
             getDockerNotes() {
                 var notes = [];
-                if (this.active_cuda_ver.startsWith("12")) {
+                if (this.active_cuda_ver.startsWith("12") && this.active_release === "Stable") {
                     var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    var cuda12 = "RAPIDS Docker images for CUDA 12 do not currently support ARM architectures<br>";
+                    var cuda12 = "Only nightly RAPIDS Docker images for CUDA 12 currently support ARM architectures<br>";
                     notes = [...notes, cuda12]
                 } else {
                     var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
@@ -566,8 +566,8 @@
                 var notes = [];
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
-                    if (this.active_cuda_ver.startsWith("12")) {
-                        notes = [...notes, "RAPIDS conda packages for CUDA 12 do not currently support ARM architectures"];
+                    if (this.active_cuda_ver.startsWith("12") && this.active_release === "Stable") {
+                        notes = [...notes, "Only nightly RAPIDS Conda packages for CUDA 12 currently support ARM architectures"];
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -567,7 +567,7 @@
                 notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     if (this.active_cuda_ver.startsWith("12") && this.active_release === "Stable") {
-                        notes = [...notes, "Only nightly RAPIDS Conda packages for CUDA 12 currently support ARM architectures"];
+                        notes = [...notes, "Only nightly RAPIDS conda packages for CUDA 12 currently support ARM architectures"];
                         var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");

--- a/install/install.md
+++ b/install/install.md
@@ -60,7 +60,7 @@ To resolve this error please follow one of these steps:
 - Use the classic solver by removing `--solver=libmamba` from the `conda create` command provided by the selector
 
 <i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
-Conda-forge does not yet support the minimum required glibc (2.32) for CUDA 12 on ARM. For ARM support, please use CUDA 11.
+Nightly packages are now available for CUDA 12.0 on ARM! Stable support is coming in 23.12
 
 <i class="fas fa-info-circle"></i> At the time of writing, there is no stable CUDA 12 release of PyTorch: <br/>
 PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
@@ -78,7 +78,7 @@ To learn more about these changes, please see the [RAPIDS Container README](http
    - CUDA 11.2 images are Ubuntu `20.04`
    - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
-   - CUDA 12 is not yet supported when using Docker images on ARM architecture
+   - CUDA 12 support is available on the nightly versions when using Docker images on ARM architecture
 - The `Base` image starts in an ipython shell
    - To run bash commands inside the ipython shell prefix the command with `!`
    - To run the image without the ipython shell add `/bin/bash` to the end of the `docker run` command
@@ -156,7 +156,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 - <i class="fas fa-info-circle"></i> CUDA 12 conda packages and Docker images currently support CUDA 12.0
 - <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
-- <i class="fas fa-info-circle"></i> ARM is not currently supported by CUDA 12 conda packages or Docker images, use CUDA 11 or pip packages for ARM support
+- <i class="fas fa-info-circle"></i> ARM is currently supported by nightly CUDA 12 Conda packages or Docker images, use CUDA 11 or pip packages for stable version ARM support
  
 ### **pip**
 

--- a/install/install.md
+++ b/install/install.md
@@ -156,7 +156,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 - <i class="fas fa-info-circle"></i> CUDA 12 conda packages and Docker images currently support CUDA 12.0
 - <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
-- <i class="fas fa-info-circle"></i> ARM is currently supported by nightly CUDA 12 Conda packages or Docker images, use CUDA 11 or pip packages for stable version ARM support
+- <i class="fas fa-info-circle"></i> ARM is currently supported by nightly CUDA 12 conda packages or Docker images, use CUDA 11 or pip packages for stable version ARM support
  
 ### **pip**
 


### PR DESCRIPTION
Closes #431 

We have CUDA 12.0 packages available now on the nightly channels for ARM. I've updated the install page/selector to reflect this.

I'll file a followup issue to update during the 23.12 release since then it will be in both stable and nightly and not require a callout at all.