### PR TITLE
Selector updates: pip, RAFT and pytorch

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -460,6 +460,12 @@
                     pkgs.push("cuSpatial");
                     pkgs.push("cuProj");
                 }
+                if (pkgs.includes("RAFT")) {
+                    pkgs = pkgs.filter(pkg => pkg !== "RAFT");
+                    pkgs.push("pylibraft");
+                    pkgs.push("raft-dask");
+                }
+
 
                 var pkgs_vers = pkgs.filter(pkg => pkg !== "Choose Specific Packages").map(pkg => this.highlightPkgOrImg(pkg) + "=" + rapids_version + " ").join("").toLowerCase();
                 var all_pkgs = pkgs_vers + py_cuda_pkgs;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -505,7 +505,7 @@
                 }
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<{{ site.data.releases.nightly.version }}\"";
+                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<={{ site.data.releases.nightly.version }}\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -359,7 +359,7 @@
         Alpine.data('rapids_selector', () => ({
             // default values
             active_python_ver: "3.10",
-            active_cuda_ver: "11.8",
+            active_cuda_ver: "12.0",
             active_pip_cuda_ver: "12.0",
             active_method: "Conda",
             active_release: "Stable",
@@ -377,11 +377,11 @@
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
             packages: ["Standard", "Choose Specific Packages"],
-            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM"],
-            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuSignal", "cuCIM"],
-            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial"],
+            additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM", "RAFT"],
+            additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM", "RAFT"],
+            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial", "Pytorch"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
-            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuSignal", "cuCIM"],
+            rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuCIM", "RAFT"],
             getStableVersion() {
                 return "{{ site.data.releases.stable.version }}";
             },
@@ -481,7 +481,12 @@
             },
             getpipCmdHtml() {
                 var pip_install = `${this.highlightCmd("pip")} install`;
-                var index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
+                if (this.active_release === "Stable") {
+                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
+                }
+                else {
+                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
+                }
                 var cuda_suffix = "-cu12";
                 var indentation = "    ";
 
@@ -491,7 +496,7 @@
 
                 var libraryToPkg = (pkg) => {
                     pkg = pkg.toLowerCase();
-                    if (pkg === "cucim") return pkg;
+                    if (pkg === "cucim" && this.active_release === "Stable") return pkg; // Remove this line in 23.12 when stable cucim out on our index
                     if (pkg == "cuspatial/cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
                     return pkg + cuda_suffix;
                 }
@@ -501,7 +506,6 @@
                     var pkgs = this.additional_pip_packages.map(libraryToPkg);
                 } else {
                     var pkgs = this.active_packages
-                        .filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "cuSignal")
                         .map(libraryToPkg);
                 }
 
@@ -551,7 +555,7 @@
             getDockerNotes() {
                 var notes = [];
                 if (this.active_cuda_ver.startsWith("12") && this.active_release === "Stable") {
-                    var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
+                    var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     var cuda12 = "Only nightly RAPIDS Docker images for CUDA 12 currently support ARM architectures<br>";
                     notes = [...notes, cuda12]
                 } else {
@@ -568,7 +572,7 @@
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     if (this.active_cuda_ver.startsWith("12") && this.active_release === "Stable") {
                         notes = [...notes, "Only nightly RAPIDS conda packages for CUDA 12 currently support ARM architectures"];
-                        var pkgs_html = this.rapids_meta_pkgs.filter(pkg => pkg !== "cuSignal").map(pkg => "<code>" + pkg + "</code>").join(", ");
+                        var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
@@ -622,7 +626,6 @@
             disableUnsupportedRelease(release) {
                 var isDisabled = false;
                 if (this.active_img_loc === "NGC" && this.active_method === "Docker" && release === "Nightly") isDisabled = true;
-                if (this.active_method === "pip" && release === "Nightly") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedCuda(cuda_version) {
@@ -645,12 +648,10 @@
             },
             disableUnsupportedMethod(method) {
                 var isDisabled = false;
-                if (this.active_release === "Nightly" && method === "pip") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
-                if (package === "cuSignal" && ((this.active_cuda_ver.startsWith("12") && this.active_method === "Conda") || this.active_release === "Nightly")) isDisabled = true;
                 return isDisabled;
             },
             isDisabled(e) {
@@ -666,9 +667,6 @@
             },
             cudaClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
-                if (version === "12.0") {
-                    this.active_packages = this.active_packages.filter(pkg => pkg !== "cuSignal");
-                }
                 this.active_cuda_ver = version;
             },
             pipCUDAClickHandler(e, version) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -508,7 +508,7 @@
                     cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix + " " + "cuproj" + cuda_suffix];
                         return ["\"" + pkg + cuda_suffix];
                     }
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -512,7 +512,7 @@
                 }
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<{{ site.data.releases.nightly.version }}.0a9999\"";
+                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<={{ site.data.releases.nightly.version }}\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -492,7 +492,7 @@
                 }
 
                 // Change index depending on stable vs nightly for pip
-                // Also add versioning commands for nightly installs to prevent --pre usage
+                // Also add versioning commands for nightly installs so that --pre is unnecessary
                 // This has duplicate code, but makes for easier edits in the future
                 if (this.active_release === "Stable") {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -499,7 +499,8 @@
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cucim") return pkg; // Remove this line in 23.12 when stable cucim is out on our index
-                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        if (pkg === "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        if (pkg === "raft") return ["pylibraft" + cuda_suffix, "raft-dask" + cuda_suffix];
                         return [pkg + cuda_suffix];
                     }
                 }
@@ -508,7 +509,8 @@
                     cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<={{ site.data.releases.nightly.version }}\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
+                        if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
+                        if (pkg === "raft") return ["pylibraft" + cuda_suffix, "raft-dask" + cuda_suffix];
                         return ["\"" + pkg + cuda_suffix];
                     }
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -508,7 +508,7 @@
                     cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix + " " + "cuproj" + cuda_suffix];
+                        if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix + "\""];
                         return ["\"" + pkg + cuda_suffix];
                     }
                 }
@@ -516,7 +516,7 @@
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 } else if (this.active_packages[0] === 'Standard') {
-                    var pkgs = this.additional_pip_packages.map(libraryToPkg);
+                    var pkgs = this.additional_pip_packages.flatMap(libraryToPkg);
                 } else {
                     // sort active_packages to appear in the same order as the additional_pip_packages list
                     this.active_packages.sort((a, b) => this.additional_pip_packages.indexOf(a) - this.additional_pip_packages.indexOf(b));

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -614,7 +614,13 @@
             },
             getpipNotes() {
                 var notes = [];
-                notes = [...notes, "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, <code>cuProj</code>, and <code>cuxfilter</code> pip packages are hosted on the NVIDIA Python Package Index<br>",
+                if (this.active_release === "Stable") {
+                    var install_location_notes = "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, <code>cuProj</code>, <code>cuxfilter</code>, and <code>RAFT</code> stable pip packages are hosted on the NVIDIA Python Package Index<br>"
+                }
+                else {
+                    var install_location_notes = "<code>cuDF</code>, <code>dask-cuDF</code>, <code>cuML</code>, <code>cuGraph</code>, <code>cuSpatial</code>, <code>cuProj</code>, <code>cuxfilter</code>, <code>cuCIM</code>, and <code>RAFT</code> nightly pip packages are hosted on the RAPIDS Python Package Index<br>"
+                }
+                notes = [...notes, install_location_notes,
                     'pip installation supports Python <code>3.9</code> and <code>3.10</code><br>'];
 
                 return notes.map(note => this.note_prefix + " " + note);

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -437,12 +437,15 @@
                 var dask_prefix = this.active_release === "Nightly" ? "dask/label/dev::" : "";
                 var python_version = this.active_python_ver;
                 var cuda_version = this.active_cuda_ver;
-                var pkgs = this.active_packages;
                 var py_cuda_pkgs = [this.highlightPkgOrImg("python") + "=" + python_version, this.highlightPkgOrImg("cuda-version") + "=" + cuda_version].join(" ");
                 var conda_channels = [rapids_channel, "conda-forge", "nvidia"]
                     .map(ch => "-" + this.highlightFlag("c") + " " + ch + " ")
                     .join("");
                 var indentation = "    ";
+
+                // sort active_packages to appear in the same order as the additional_rapids_packages list
+                this.active_packages.sort((a, b) => this.additional_rapids_packages.indexOf(a) - this.additional_rapids_packages.indexOf(b));
+                var pkgs = this.active_packages;
 
                 if (this.active_packages.length + this.active_additional_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
@@ -496,8 +499,8 @@
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cucim") return pkg; // Remove this line in 23.12 when stable cucim is out on our index
-                        if (pkg == "cuspatial/cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
-                        return pkg + cuda_suffix;
+                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        return [pkg + cuda_suffix];
                     }
                 }
                 else {
@@ -505,8 +508,8 @@
                     cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg == "cuspatial/cuproj") return '"cuspatial' + cuda_suffix + ' "cuproj' + cuda_suffix;
-                        return "\"" + pkg + cuda_suffix;
+                        if (pkg == "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        return ["\"" + pkg + cuda_suffix];
                     }
                 }
 
@@ -515,23 +518,26 @@
                 } else if (this.active_packages[0] === 'Standard') {
                     var pkgs = this.additional_pip_packages.map(libraryToPkg);
                 } else {
+                    // sort active_packages to appear in the same order as the additional_pip_packages list
+                    this.active_packages.sort((a, b) => this.additional_pip_packages.indexOf(a) - this.additional_pip_packages.indexOf(b));
                     var pkgs = this.active_packages
                         .filter(pkg => pkg !== "Choose Specific Packages")
-                        .map(libraryToPkg);
+                        .flatMap(libraryToPkg);
                 }
 
                 if (pkgs.length === 1 && pkgs[0] === "cucim") {
                     index_url = "";
                 }
 
-                //for every 3rd package add a new line with a "\" character
-                for (var i = 3; i < pkgs.length; i += 3) {
-                    pkgs.splice(i, 0, "\\\n" + indentation);
-                }                
+                // For every 3rd package add a new line with a "\" character
+                // We need i += 4 since the splice adds a new element to the array
+                for (var i = 3; i < pkgs.length; i += 4) {
+                    pkgs.splice(i, 0, "\\\n" + indentation.slice(0, -1));
+                }
 
-                return [pip_install, index_url, pkgs.map(pkg => this.highlightPkgOrImg(pkg)).join(" ")]
+                return [pip_install, index_url, pkgs.flatMap(pkg => this.highlightPkgOrImg(pkg)).join(" ")]
                     .filter(Boolean)
-                    .join(" \\\n" + indentation);
+                    .join(" \\\n" + indentation)
             },
             getDockerCmdHtml() {
                 var hasNotebooks = this.active_img_type === "Notebooks";

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -505,7 +505,7 @@
                 }
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
+                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<{{ site.data.releases.nightly.version }}\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
@@ -528,10 +528,21 @@
                 if (pkgs.length === 1 && pkgs[0] === "cucim") {
                     index_url = "";
                 }
+                else { // We need to add dask-cuda to nightly pip installs for everything but cucim
+                    if (this.active_release === "Nightly") {
+                        pkgs.push(["\"dask-cuda" + cuda_suffix.slice(5) + "\""])
+                    }
+                }
 
-                // For every 3rd package add a new line with a "\" character
-                // We need i += 4 since the splice adds a new element to the array
-                for (var i = 3; i < pkgs.length; i += 4) {
+                // For every n packages add a new line with a "\" character
+                // We need i += n + 1 since the splice adds a new element to the array
+                if (this.active_release === "Stable") {
+                    packages_per_line = 5;
+                }
+                else {
+                    packages_per_line = 2;
+                }
+                for (var i = packages_per_line; i < pkgs.length; i += packages_per_line + 1) {
                     pkgs.splice(i, 0, "\\\n" + indentation.slice(0, -1));
                 }
 

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -510,7 +510,7 @@
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
-                        if (pkg === "raft") return ["pylibraft" + cuda_suffix, "raft-dask" + cuda_suffix];
+                        if (pkg === "raft") return ["\"pylibraft" + cuda_suffix, "\"raft-dask" + cuda_suffix];
                         return ["\"" + pkg + cuda_suffix];
                     }
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -506,7 +506,8 @@
                     var pkgs = this.additional_pip_packages.map(libraryToPkg);
                 } else {
                     var pkgs = this.active_packages
-                        .map(libraryToPkg);
+                    .filter(pkg => pkg !== "Choose Specific Packages")
+                    .map(libraryToPkg);
                 }
 
                 if (pkgs.length === 1 && pkgs[0] === "cucim") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -530,7 +530,7 @@
                 }
                 else { // We need to add dask-cuda to nightly pip installs for everything but cucim
                     if (this.active_release === "Nightly") {
-                        pkgs.push(["\"dask-cuda" + cuda_suffix.slice(5) + "\""])
+                        pkgs.push(["\"dask-cuda" + cuda_suffix.slice(5)])
                     }
                 }
 

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -512,7 +512,7 @@
                 }
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<={{ site.data.releases.nightly.version }}\"";
+                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<{{ site.data.releases.nightly.version }}.0a9999\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -490,7 +490,7 @@
 
                 // Change index depending on stable vs nightly for pip
                 // Also add versioning commands for nightly installs to prevent --pre usage
-                // This has dupilicate code, but makes for easier edits in the future
+                // This has duplicate code, but makes for easier edits in the future
                 if (this.active_release === "Stable") {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
                     var libraryToPkg = (pkg) => {
@@ -525,7 +525,7 @@
                 }
 
                 //for every 3rd package add a new line with a "\" character
-                for (var i = 3; i < pkgs.length; i += 4) {
+                for (var i = 3; i < pkgs.length; i += 3) {
                     pkgs.splice(i, 0, "\\\n" + indentation);
                 }                
 

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -508,7 +508,7 @@
                     cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix + "\""];
+                        if (pkg == "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
                         return ["\"" + pkg + cuda_suffix];
                     }
                 }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -691,7 +691,6 @@
                 }
                 if (method === "pip") {
                     this.active_pip_cuda_ver = '12.0';
-                    this.active_release = 'Stable';
                 }
                 if (method === "Docker") {
                     if (this.active_release === 'Nightly') {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -379,7 +379,7 @@
             packages: ["Standard", "Choose Specific Packages"],
             additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM", "RAFT"],
             additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuSpatial/cuProj", "cuxfilter", "cuCIM", "RAFT"],
-            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial", "Pytorch"],
+            additional_packages: ["Dask-SQL", "JupyterLab", "Plotly Dash", "Graphistry", "TensorFlow", "Xarray-Spatial", "PyTorch"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "cuSpatial", "cuProj", "cuxfilter", "cuCIM", "RAFT"],
             getStableVersion() {
@@ -506,8 +506,8 @@
                     var pkgs = this.additional_pip_packages.map(libraryToPkg);
                 } else {
                     var pkgs = this.active_packages
-                    .filter(pkg => pkg !== "Choose Specific Packages")
-                    .map(libraryToPkg);
+                        .filter(pkg => pkg !== "Choose Specific Packages")
+                        .map(libraryToPkg);
                 }
 
                 if (pkgs.length === 1 && pkgs[0] === "cucim") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -481,12 +481,6 @@
             },
             getpipCmdHtml() {
                 var pip_install = `${this.highlightCmd("pip")} install`;
-                if (this.active_release === "Stable") {
-                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
-                }
-                else {
-                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                }
                 var cuda_suffix = "-cu12";
                 var indentation = "    ";
 
@@ -494,12 +488,28 @@
                     cuda_suffix = "-cu11";
                 }
 
-                var libraryToPkg = (pkg) => {
-                    pkg = pkg.toLowerCase();
-                    if (pkg === "cucim" && this.active_release === "Stable") return pkg; // Remove this line in 23.12 when stable cucim out on our index
-                    if (pkg == "cuspatial/cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
-                    return pkg + cuda_suffix;
+                // Change index depending on stable vs nightly for pip
+                // Also add versioning commands for nightly installs to prevent --pre usage
+                // This has dupilicate code, but makes for easier edits in the future
+                if (this.active_release === "Stable") {
+                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
+                    var libraryToPkg = (pkg) => {
+                        pkg = pkg.toLowerCase();
+                        if (pkg === "cucim") return pkg; // Remove this line in 23.12 when stable cucim is out on our index
+                        if (pkg == "cuspatial/cuproj") return "cuspatial" + cuda_suffix + " cuproj" + cuda_suffix;
+                        return pkg + cuda_suffix;
+                    }
                 }
+                else {
+                    index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
+                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0\"";
+                    var libraryToPkg = (pkg) => {
+                        pkg = pkg.toLowerCase();
+                        if (pkg == "cuspatial/cuproj") return '"cuspatial' + cuda_suffix + ' "cuproj' + cuda_suffix;
+                        return "\"" + pkg + cuda_suffix;
+                    }
+                }
+
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 } else if (this.active_packages[0] === 'Standard') {
@@ -513,6 +523,11 @@
                 if (pkgs.length === 1 && pkgs[0] === "cucim") {
                     index_url = "";
                 }
+
+                //for every 3rd package add a new line with a "\" character
+                for (var i = 3; i < pkgs.length; i += 4) {
+                    pkgs.splice(i, 0, "\\\n" + indentation);
+                }                
 
                 return [pip_install, index_url, pkgs.map(pkg => this.highlightPkgOrImg(pkg)).join(" ")]
                     .filter(Boolean)

--- a/install/install.md
+++ b/install/install.md
@@ -62,13 +62,6 @@ To resolve this error please follow one of these steps:
 <i class="fas fa-info-circle"></i> CUDA 12.0 ARM packages are not yet available:<br/>
 Nightly packages are now available for CUDA 12.0 on ARM! Stable support is coming in 23.12
 
-<i class="fas fa-info-circle"></i> At the time of writing, there is no stable CUDA 12 release of PyTorch: <br/>
-PyTorch currently only has nightly builds for CUDA 12.1, stable builds are limited to CUDA 11. <br/>
-The installation method below may allow RAPIDS CUDA 12.0 packages to coexist with PyTorch CUDA 12.1 nightly packages if there is a hard-requirement of CUDA 12 but it is currently unsupported:
-```
-conda create --solver=libmamba -n rapids-pytorch-cu12 -c rapidsai -c pytorch-nightly -c conda-forge -c nvidia rapids={{ site.data.releases.stable.version }} cuda-version=12.0 pytorch pytorch-cuda=12.1
-```
-
 ### **Docker Issues**
 <i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brings significant Docker changes. <br/>
 To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/base){: target="_blank"}. Some key notes below:


### PR DESCRIPTION
This PR does 5 main things:
1. Adds pip nightly versions :tada:
   1. cucim now uses the `-cu11/12` name in line with the rest of RAPIDS
3. Adds RAFT as a selectable RAPIDS package, and notes its inclusion in the meta package
4. Adds pytorch to the selector
5. Changes the default CUDA to `12.0`
6. Removes all mention of cuSignal as `23.08` was the final release prior to cuPy ingesting its functionality