### PR TITLE
Fix dark theme to not have dark text color that is same as background

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -182,7 +182,7 @@ body {
     roboto, noto, "segoe ui", arial, sans-serif;
   font-size: inherit;
   line-height: 1.4;
-  color: #5c5962;
+  color: var(--pst-color-text-base);
 }
 
 h1,
@@ -546,7 +546,7 @@ table.io-supported-types-table thead{
 }
 
 :root {
-
+  --pst-heading-color: var(--pst-color-primary);
   --pst-color-active-navigation: 114, 83, 237;
   --pst-color-navbar-link: 77, 77, 77;
   --pst-color-navbar-link-hover: var(--pst-color-active-navigation);


### PR DESCRIPTION
Fixes: https://github.com/rapidsai/cudf/issues/14463

This PR fixes dark theme text color to not pick the background color and also fixes span tags text color to not pick general body color.

Previously:

<img width="1414" alt="Screenshot 2023-11-21 at 8 02 40 PM" src="https://github.com/rapidsai/docs/assets/11664259/c30842a6-59b9-42d2-a8ba-a419073d635a">


Now:
<img width="886" alt="Screenshot 2023-11-21 at 7 56 59 PM" src="https://github.com/rapidsai/docs/assets/11664259/f243e7d1-90fe-47ab-b897-e313c9a2ca10">

