### PR TITLE
Allow TensorFlow conda packages with CUDA 11.8.

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -788,7 +788,7 @@
                     return;
                 }
                 this.active_additional_packages = [...this.active_additional_packages, package];
-                if (this.active_additional_packages.includes("TensorFlow") && (this.active_cuda_ver !== "11.2" || this.active_cuda_ver !== "11.8")) this.active_cuda_ver = "11.8";
+                if (this.active_additional_packages.includes("TensorFlow") && (this.active_cuda_ver !== "11.2" && this.active_cuda_ver !== "11.8")) this.active_cuda_ver = "11.8";
             },
             copyToClipboard() {
                 let range = document.createRange();

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -677,7 +677,7 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "11.2" || cuda_version !== "11.8")) isDisabled = true;
+                if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "11.2" && cuda_version !== "11.8")) isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -617,8 +617,7 @@
                     } else {
                         var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     }
-                    notes = [...notes, "The CUDA " + this.active_cuda_ver +
-                        " <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
+                    notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
                 }
 
                 if (this.active_additional_packages.length) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -625,7 +625,7 @@
                     notes = [...notes, "Third-party packages are not tested."];
 
                     if (this.active_additional_packages.includes("TensorFlow")) {
-                        notes = [...notes, "TensorFlow requires CUDA 11.2."];
+                        notes = [...notes, "TensorFlow requires CUDA 11."];
                     }
                 }
 
@@ -677,7 +677,7 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
+                if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "11.2" || cuda_version !== "11.8")) isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -788,7 +788,7 @@
                     return;
                 }
                 this.active_additional_packages = [...this.active_additional_packages, package];
-                if (this.active_additional_packages.includes("TensorFlow") && this.active_cuda_ver !== "11.2") this.active_cuda_ver = "11.2";
+                if (this.active_additional_packages.includes("TensorFlow") && (this.active_cuda_ver !== "11.2" || this.active_cuda_ver !== "11.8")) this.active_cuda_ver = "11.8";
             },
             copyToClipboard() {
                 let range = document.createRange();


### PR DESCRIPTION
Currently the release selector only allows TensorFlow with CUDA 11.2, but conda-forge has package builds for CUDA 11.8. We should allow CUDA 11.2 or 11.8 when TensorFlow is selected.

Resolves an issue reported on the GoAI Slack.