### PR TITLE
Disable cudf-java for 23.12

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
We don't have the `cudf-java` v23.12 docs yet, so disable it for now.

Fixes https://github.com/rapidsai/docs/actions/runs/7186808980