### PR TITLE
Enable cudf-java for 23.12

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
cudf javadocs are now available on S3, so re-enable stable for `cudf-java`.