### PR TITLE
Disable librmm and libcudf docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -164,7 +164,7 @@ libs:
   libcudf:
     name: libcudf
     path: libcudf
-    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations. Note that as of RAPIDS 24.02 libcudf docs are integrated into the Sphinx documentation alongside the cudf Python docs.'
+    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations.\n Note that as of RAPIDS 24.02 libcudf docs are integrated into the Sphinx documentation alongside the cuDF Python docs.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
     versions:
@@ -208,7 +208,7 @@ libs:
   librmm:
     name: librmm
     path: librmm
-    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous. Note that as of RAPIDS 23.12 librmm docs are integrated into the Sphinx documentation alongside the rmm Python docs.'
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.\n Note that as of RAPIDS 23.12 librmm docs are integrated into the Sphinx documentation alongside the RMM Python docs.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
     versions:

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -171,7 +171,7 @@ libs:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
-      nightly: 1
+      nightly: 0
   libcuspatial:
     name: libcuspatial
     path: libcuspatial
@@ -214,8 +214,8 @@ libs:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
-      nightly: 1
+      stable: 0
+      nightly: 0
   libkvikio:
     name: libkvikio
     path: libkvikio

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -164,7 +164,7 @@ libs:
   libcudf:
     name: libcudf
     path: libcudf
-    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations.'
+    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations. Note that as of RAPIDS 24.02 libcudf docs are integrated into the Sphinx documentation alongside the cudf Python docs.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
     versions:
@@ -208,7 +208,7 @@ libs:
   librmm:
     name: librmm
     path: librmm
-    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous. Note that as of RAPIDS 23.12 librmm docs are integrated into the Sphinx documentation alongside the rmm Python docs.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
     versions:

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -164,7 +164,7 @@ libs:
   libcudf:
     name: libcudf
     path: libcudf
-    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations.\n Note that as of RAPIDS 24.02 libcudf docs are integrated into the Sphinx documentation alongside the cuDF Python docs.'
+    desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations. Note that as of RAPIDS 24.02 libcudf docs are integrated into the Sphinx documentation alongside the cuDF Python docs.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
     versions:
@@ -208,7 +208,7 @@ libs:
   librmm:
     name: librmm
     path: librmm
-    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.\n Note that as of RAPIDS 23.12 librmm docs are integrated into the Sphinx documentation alongside the RMM Python docs.'
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous. Note that as of RAPIDS 23.12 librmm docs are integrated into the Sphinx documentation alongside the RMM Python docs.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
     versions:


### PR DESCRIPTION
These doxygen doc builds are both now incorporated into the Sphinx builds and need not be published separately. The rmm docs were published as part of the 23.12 release, so they can also be removed from the stable pages, but libcudf is only being merged this release so only the nightly can be removed. This PR should be merged after rapidsai/cudf#13846.