### PR TITLE
add details about git tags to 'Reproducing CI Locally'

### DIFF
--- a/resources/reproducing-ci.md
+++ b/resources/reproducing-ci.md
@@ -170,3 +170,25 @@ sed -ri '/rapids-download-conda-from-s3/ s/_CHANNEL=.*/_CHANNEL=${RAPIDS_CONDA_B
 Currently, [downloads.rapids.ai](https://downloads.rapids.ai) is only available via the NVIDIA VPN.
 
 If you want to run any test jobs locally, you'll need to be connected to the VPN to download CI build artifacts.
+
+### Some Builds Rely on Versioning Information in Git Tags
+
+Some RAPIDS projects rely on versioning information stored in `git` tags.
+
+For example, some use `conda` recipes that rely on the mechanisms described in ["Git environment variables" in the `conda-build` docs](https://docs.conda.io/projects/conda-build/en/stable/user-guide/environment-variables.html#git-environment-variables).
+
+When those tags are unavailable, builds might fail with errors similar to this:
+
+> Error: Failed to render jinja template in /repo/conda/recipes/libcudf/meta.yaml:
+> 'GIT_DESCRIBE_NUMBER' is undefined
+> conda returned exit code: 1
+
+To fix that, pull the latest set of tags from the upstream repo.
+
+For example, for `cudf`:
+
+```sh
+git fetch \
+  git@github.com:rapidsai/cudf.git \
+  --tags
+```


### PR DESCRIPTION
Running through the instructions at https://docs.rapids.ai/resources/reproducing-ci/, I found that building `libcudf` from source on branch `branch-24.02` failed with the following error.

> Attempting to finalize metadata for libcudf
> Error: Failed to render jinja template in /repo/conda/recipes/libcudf/meta.yaml:
> 'GIT_DESCRIBE_NUMBER' is undefined
> `[rapids-conda-retry]` conda returned exit code: 1

It seems that this is caused by the combination of the following:

* the `libcudf` conda recipe uses `{{ GIT_DESCRIBE_NUMBER }}` ([code link](https://github.com/rapidsai/cudf/blob/90cccef3e3070b0f03df75c49aca64517d5a4cfa/conda/recipes/libcudf/meta.yaml#L83-L84))
* the use of `{{ GIT_DESCRIBE_NUMBER }}` in conda recipes requires that you have the relevant recent tags available locally ([conda-build docs](https://docs.conda.io/projects/conda-build/en/stable/user-guide/environment-variables.html#git-environment-variables))
* GitHub forks don't inherit tags by default
    - *(and even if they did at fork time, they're not guaranteed to be up-to-date with upstream)*

<details><summary>'cudf' example (click me)</summary>

```shell
# clone from a fork
git clone git@github.com:jameslamb/cudf.git
cd ./cudf

# no tags!
git tag
# (empty)

# make the scripts work without access to sccache
sed -ri '/rapids-download-conda-from-s3/ s/_CHANNEL=.*/_CHANNEL=${RAPIDS_CONDA_BLD_OUTPUT_DIR}/' ci/*.sh

# try to do a cpp build
docker run \
  --rm \
  -it \
  --pull=always \
  --network=host \
  --volume $PWD:/repo \
  --workdir /repo \
  rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10 \
  ./ci/build_cpp.sh
```

</details>

Fetching all the tags from the upstream repo prior to building fixes that.

```shell
git fetch \
    git@github.com:rapidsai/cudf.git \
    --tags
```

This isn't specific to `cudf`. For example, the same thing happens with `rmm`.

<details><summary>'rmm' example (click me)</summary>

```shell
# clone fork of rmm
git clone git@github.com:jameslamb/rmm.git
cd ./rmm

# confirm 0 tags available
git tag
# (empty)

# modify scripts
sed -ri '/rapids-download-conda-from-s3/ s/_CHANNEL=.*/_CHANNEL=${RAPIDS_CONDA_BLD_OUTPUT_DIR}/' ci/*.sh

# run
docker run \
  --rm \
  -it \
  --pull=always \
  --network=host \
  --volume $PWD:/repo \
  --workdir /repo \
  rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10 \
  ./ci/build_cpp.sh
```

</details>

### Notes for Reviewers

I chose updating these docs over these other possible solutions:

* modifying the instructions in docs (e.g. to pass a placeholder value for the `GIT_*` variables through as environment variables)
* modifying those scripts to fetch tags from the upstream repo prior to running rendering the conda recipe
* modifying the recipes themselves to fall back to some other value if the `git` tags are unavailable

I think having CI continue to fail loudly if this happens is desirable, and it's not worth increasing the risk of that not happening in exchange for reducing a little bit of friction in local development.