### PR TITLE
Display UCXX in docs.rapids.ai/api

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -227,6 +227,17 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
+  libucxx:
+    name: libucxx
+    path: libucxx
+    desc: "UCXX is an object-oriented C++ interface for UCX, with native support for Python bindings."
+    ghlink: https://github.com/rapidsai/ucxx
+    cllink: https://github.com/rapidsai/ucxx/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1
   rapids-cmake:
     name: rapids-cmake
     path: rapids-cmake

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -6,6 +6,5 @@
 {{ api.desc }}
 #### DOCS {% for version_name in versions %} {% if api.name == 'libucxx' %} {% case version_name %}
 {% when 'legacy' %}{% assign display_version = '0.34' %} {% when 'stable' %}{% assign display_version = '0.35' %} {% else %}{% assign display_version = '0.36' %} {% endcase %} {% else %} {% assign display_version = site.data.releases[version_name].version %} {% endif %} **[{{ version_name }} ({{ display_version }})](/api/{{ api.path }}/{{ version_name }})** {% unless forloop.last %}|{% endunless %} {% endfor %}
-#### LINKS **[changelog]({{ api.cllink }}){:target="_blank"}** | **[github]({{ api.ghlink }}){:target="_blank"}**
-{: .mb-7 }
+{% if api.name != 'libucxx' %}#### LINKS **[changelog]({{ api.cllink }}){:target="_blank"}** | **[github]({{ api.ghlink }}){:target="_blank"}**{: .mb-7 }{% else %}#### LINKS **[github]({{ api.ghlink }}){:target="_blank"}**{: .mb-7 }{% endif %}
 {% endfor %}

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -4,7 +4,8 @@
 {% assign versions = api.versions | sort | where_exp: "item", "item[1] == 1" | join: "" | split: "1" | reverse %}
 ### {{ api.name }}
 {{ api.desc }}
-#### DOCS {% for version_name in versions %} **[{{ version_name }} ({{ site.data.releases[version_name].version }})](/api/{{ api.path }}/{{ version_name }})** {% unless forloop.last %}|{% endunless %} {% endfor %}
+#### DOCS {% for version_name in versions %} {% if api.name == 'libucxx' %} {% case version_name %}
+{% when 'legacy' %}{% assign display_version = '0.34' %} {% when 'stable' %}{% assign display_version = '0.35' %} {% else %}{% assign display_version = '0.36' %} {% endcase %} {% else %} {% assign display_version = site.data.releases[version_name].version %} {% endif %} **[{{ version_name }} ({{ display_version }})](/api/{{ api.path }}/{{ version_name }})** {% unless forloop.last %}|{% endunless %} {% endfor %}
 #### LINKS **[changelog]({{ api.cllink }}){:target="_blank"}** | **[github]({{ api.ghlink }}){:target="_blank"}**
 {: .mb-7 }
 {% endfor %}


### PR DESCRIPTION
UCXX docs is being deployed [here](https://github.com/rapidsai/ucxx/pull/164/files#diff-17e8ca0c6c748293e3ef7d9837679b7d09ffecb5307af0e85290cfbec2fb9d77R28) to s3 not with its own versioning convention (`0.36`, etc) but with RAPIDS versioning convention (`24.xx`, etc). This PR updates the publishing template script [here](https://github.com/rapidsai/docs/blob/main/_includes/api-docs.html) to overwrite the RAPIDS versions for UCXX to display the correct UCXX versions.

The changes in this PR should be sufficient to have `libucxx` docs display over at docs.rapids.ai/api

NOTE: the `cllink` anchor for `libucxx` is hidden as we currently do not have a CHANGELOG.md for the library. Adding one would imply significantly altering certain sections of our workflow which might not be worth the effort seeing that there is the intention to move `UCXX` to the [openucx](https://github.com/openucx) org.