### PR TITLE
Fix release dates

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -11,75 +11,75 @@
     "version": "24.02",
     "cudf_dev": {
       "start": "Nov 9 2023",
-      "end": "Wed Jan 17 2024",
+      "end": "Jan 17 2024",
       "days": "42"
     },
     "other_dev": {
       "start": "Nov 16 2023",
-      "end": "Wed Jan 24 2024",
+      "end": "Jan 24 2024",
       "days": "43"
     },
     "cudf_burndown": {
       "start": "Jan 18 2024",
-      "end": "Wed Jan 24 2024",
+      "end": "Jan 24 2024",
       "days": "5"
     },
     "other_burndown": {
       "start": "Jan 25 2024",
-      "end": "Wed Jan 31 2024",
+      "end": "Jan 31 2024",
       "days": "5"
     },
     "cudf_codefreeze": {
       "start": "Jan 25 2024",
-      "end": "Tue Feb 6 2024",
+      "end": "Feb 6 2024",
       "days": "9"
     },
     "other_codefreeze": {
       "start": "Feb 1 2024",
-      "end": "Tue Feb 6 2024",
+      "end": "Feb 6 2024",
       "days": "4"
     },
     "release": {
       "start": "Feb 7 2024",
-      "end": "Thu Feb 8 2024",
+      "end": "Feb 8 2024",
       "days": "2"
     }
   },
   "next_nightly": {
     "version": "24.04",
     "cudf_dev": {
-      "start": "Jan 19 2024",
-      "end": "Wed Mar 22 2024",
-      "days": "42"
+      "start": "Jan 18 2024",
+      "end": "Mar 13 2024",
+      "days": "39"
     },
     "other_dev": {
-      "start": "Jan 26 2024",
-      "end": "Wed Mar 29 2024",
-      "days": "42"
+      "start": "Jan 25 2024",
+      "end": "Mar 20 2024",
+      "days": "39"
     },
     "cudf_burndown": {
-      "start": "Mar 23 2024",
-      "end": "Wed Mar 29 2024",
+      "start": "Mar 14 2024",
+      "end": "Mar 20 2024",
       "days": "5"
     },
     "other_burndown": {
-      "start": "Mar 30 2024",
-      "end": "Wed Apr 5 2024",
-      "days": "5"
+      "start": "Mar 21 2024",
+      "end": "Apr 3 2024",
+      "days": "8"
     },
     "cudf_codefreeze": {
-      "start": "Mar 25 2024",
-      "end": "Wed Mar 31 2024",
-      "days": "4"
+      "start": "Mar 21 2024",
+      "end": "Apr 9 2024",
+      "days": "12"
     },
     "other_codefreeze": {
-      "start": "Apr 6 2024",
-      "end": "Wed Apr 11 2024",
+      "start": "Apr 4 2024",
+      "end": "Apr 9 2024",
       "days": "4"
     },
     "release": {
-      "start": "Apr 12 2024",
-      "end": "Thu Apr 13 2024",
+      "start": "Apr 10 2024",
+      "end": "Apr 11 2024",
       "days": "2"
     }
   }


### PR DESCRIPTION
This PR fixes the release dates for `24.04`.

The dates were incorrect and they also incorrectly included the weekday (e.g. `Mon`, `Tue`, etc.).