### PR TITLE
Updates for the 24.02 release

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,43 @@
 [
   {
+    "version": "24.02",
+    "cudf_dev": {
+      "start": "Nov 9 2023",
+      "end": "Jan 17 2024",
+      "days": "42"
+    },
+    "other_dev": {
+      "start": "Nov 16 2023",
+      "end": "Jan 24 2024",
+      "days": "43"
+    },
+    "cudf_burndown": {
+      "start": "Jan 18 2024",
+      "end": "Jan 24 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Jan 25 2024",
+      "end": "Jan 31 2024",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Jan 25 2024",
+      "end": "Feb 6 2024",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Feb 1 2024",
+      "end": "Feb 6 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Feb 7 2024",
+      "end": "Feb 8 2024",
+      "days": "2"
+    }
+  },
+  {
     "version": "23.12",
     "cudf_dev": {
       "start": "Sep 21 2023",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -46,7 +46,7 @@
     }
   },
   "next_nightly": {
-    "version": "24.04",
+    "version": "24.06",
     "cudf_dev": {
       "start": "Mar 14 2024",
       "end": "May 15 2024",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,51 +1,13 @@
 {
   "legacy": {
-    "version": "23.10",
-    "date": "Oct 12 2023"
-  },
-  "stable": {
     "version": "23.12",
     "date": "Dec 7 2023"
   },
-  "nightly": {
+  "stable": {
     "version": "24.02",
-    "cudf_dev": {
-      "start": "Nov 9 2023",
-      "end": "Jan 17 2024",
-      "days": "42"
-    },
-    "other_dev": {
-      "start": "Nov 16 2023",
-      "end": "Jan 24 2024",
-      "days": "43"
-    },
-    "cudf_burndown": {
-      "start": "Jan 18 2024",
-      "end": "Jan 24 2024",
-      "days": "5"
-    },
-    "other_burndown": {
-      "start": "Jan 25 2024",
-      "end": "Jan 31 2024",
-      "days": "5"
-    },
-    "cudf_codefreeze": {
-      "start": "Jan 25 2024",
-      "end": "Feb 6 2024",
-      "days": "9"
-    },
-    "other_codefreeze": {
-      "start": "Feb 1 2024",
-      "end": "Feb 6 2024",
-      "days": "4"
-    },
-    "release": {
-      "start": "Feb 7 2024",
-      "end": "Feb 8 2024",
-      "days": "2"
-    }
+    "date": "Feb 13 2024"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "24.04",
     "cudf_dev": {
       "start": "Jan 18 2024",
@@ -80,6 +42,44 @@
     "release": {
       "start": "Apr 10 2024",
       "end": "Apr 11 2024",
+      "days": "2"
+    }
+  },
+  "next_nightly": {
+    "version": "24.04",
+    "cudf_dev": {
+      "start": "Mar 14 2024",
+      "end": "May 15 2024",
+      "days": "43"
+    },
+    "other_dev": {
+      "start": "Mar 21 2024",
+      "end": "May 22 2024",
+      "days": "43"
+    },
+    "cudf_burndown": {
+      "start": "May 16 2024",
+      "end": "May 22 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "May 23 2024",
+      "end": "May 29 2024",
+      "days": "4"
+    },
+    "cudf_codefreeze": {
+      "start": "May 23 2024",
+      "end": "Jun 4 2024",
+      "days": "8"
+    },
+    "other_codefreeze": {
+      "start": "May 30 2024",
+      "end": "Jun 4 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Jun 5 2024",
+      "end": "Jun 6 2024",
       "days": "2"
     }
   }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -662,7 +662,7 @@
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
                 if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "12.0")) isDisabled = true;
-                if (this.active_method === "Docker" && this.active_release === "Nightly") isDisabled = true;
+                if (this.active_method === "Docker" && cuda_version < "11.8") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {

--- a/_notices/rsn0034.md
+++ b/_notices/rsn0034.md
@@ -30,7 +30,7 @@ RAPIDS team is planning to deprecate support for Pascal GPUs in its `v23.12` rel
 
 ## Impact
 
-Effective RAPIDS `v24.02` release, RAPIDS will no longer support Pascal GPUs. GPUs with Compute Capability 7.0 or higher will be required. Users of Pascal GPUs will be able to continue to use RAPIDS `v23.12`.
+Effective RAPIDS `v24.02` release, RAPIDS will no longer support Pascal GPUs. GPUs with Compute Capability 7.0 or higher will be required. The last release with support for Pascal GPUs is RAPIDS `v23.12`.
 
 
 

--- a/_notices/rsn0034.md
+++ b/_notices/rsn0034.md
@@ -9,8 +9,8 @@ notice_id: 34 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation announcement for Pascal GPU support in Release v23.12"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v23.12"
 notice_created: 2023-10-04
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2023-10-04
+notice_updated: 2024-02-13
 ---
 
 ## Overview
@@ -30,7 +30,7 @@ RAPIDS team is planning to deprecate support for Pascal GPUs in its `v23.12` rel
 
 ## Impact
 
-Effective RAPIDS `v24.02` release, RAPIDS will no longer support Pascal GPUs. GPUs with Compute Capability 7.0 or higher will be required. Users of Pascal GPUs will be able to continue to use RAPIDS `v23.12`.  
- 
- 
+Effective RAPIDS `v24.02` release, RAPIDS will no longer support Pascal GPUs. GPUs with Compute Capability 7.0 or higher will be required. Users of Pascal GPUs will be able to continue to use RAPIDS `v23.12`.
+
+
 

--- a/_notices/rsn0035.md
+++ b/_notices/rsn0035.md
@@ -9,8 +9,8 @@ notice_id: 35 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation Announcement Dropping CUDA 11.2 support in our Docker Images in Release v23.12"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,15 +21,15 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v23.12"
 notice_created: 2023-10-05
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2023-10-05
+notice_updated: 2024-02-13
 ---
 
 ## Overview
 
-RAPIDS is planning to deprecate support for its CUDA 11.2 Docker containers in Release `v23.12`, and to cease publishing CUDA 11.2 Docker containers in the `v24.02` release. `v23.12` will be the last version of RAPIDS to distribute CUDA 11.2 Docker containers. 
+RAPIDS is planning to deprecate support for its CUDA 11.2 Docker containers in Release `v23.12`, and to cease publishing CUDA 11.2 Docker containers in the `v24.02` release. `v23.12` will be the last version of RAPIDS to distribute CUDA 11.2 Docker containers.
 
 ## Impact
 
 Effective RAPIDS `v24.02` release, RAPIDS will cease distribution of CUDA 11.2 Docker containers. RAPIDS will continue to distribute CUDA 12.0 and 11.8 containers. Users who still wish to use CUDA 11.2 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda installation.
- 
+
 

--- a/install/install.md
+++ b/install/install.md
@@ -121,8 +121,8 @@ See the WSL2 setup [troubleshooting section](#wsl2-troubleshooting).
 ## **OS / GPU Driver / CUDA Versions**
 All provisioned systems need to be RAPIDS capable. Here's what is required:
 
-<i class="fas fa-microchip"></i> **GPU:** NVIDIA Pascal™ or better with [compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 6.0+
-- <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support [is deprecated and will be removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ will be required for RAPIDS 24.02 and later.
+<i class="fas fa-microchip"></i> **GPU:** NVIDIA Volta™ or better with [compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 6.0+
+- <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support [was removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ is required for RAPIDS 24.02 and later.
 
 <i class="fas fa-desktop"></i> **OS:** One of the following OS versions:
 - <i class="fas fa-check-circle"></i> Ubuntu 20.04/22.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+

--- a/install/install.md
+++ b/install/install.md
@@ -121,8 +121,8 @@ See the WSL2 setup [troubleshooting section](#wsl2-troubleshooting).
 ## **OS / GPU Driver / CUDA Versions**
 All provisioned systems need to be RAPIDS capable. Here's what is required:
 
-<i class="fas fa-microchip"></i> **GPU:** NVIDIA Volta™ or better with [compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 6.0+
-- <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support [was removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ is required for RAPIDS 24.02 and later.
+<i class="fas fa-microchip"></i> **GPU:** NVIDIA Volta™ or higher with [compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0+
+- <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support was [removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ is required for RAPIDS 24.02 and later.
 
 <i class="fas fa-desktop"></i> **OS:** One of the following OS versions:
 - <i class="fas fa-check-circle"></i> Ubuntu 20.04/22.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+


### PR DESCRIPTION
1. Standard release updates to data files.
2. Update phrasing for Pascal deprecation notice
3. Selector changes: re-enable nightly docker image and drop CUDA 11.2
4. Update RSN 34/35 (Pascal deprecation/Docker CUDA 11.2 deprecation) to completed
