### PR TITLE
centOS 7 - Deprecation Release v24.04

### DIFF
--- a/_notices/rsn0037.md
+++ b/_notices/rsn0037.md
@@ -1,0 +1,37 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 37 # should match notice number
+notice_pin: false # set to true to pin to notice page
+title: "Deprecation of `CentOS 7` in v24.06"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v24.04"
+notice_created: 2024-02-14
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2024-02-14
+---
+
+## Overview
+
+RAPIDS is deprecating `CentOS 7` in release v24.04, and it will be removed in release v24.06.  This is due to `CentOS7` becoming end of life in June 2024, which means RAPIDS will no longer publish any images built on `CentOS 7` following the RAPIDS `v24.04` release.
+
+
+## Impact
+
+Users should consider switching to any of the following supported operating systems for any rapidsai/rapidsai image:
+  - Ubuntu 22.04 
+  - Ubuntu 20.04
+  - Rocky 8

--- a/_notices/rsn0037.md
+++ b/_notices/rsn0037.md
@@ -31,7 +31,7 @@ RAPIDS is deprecating `CentOS 7` in release v24.04, and it will be removed in re
 
 ## Impact
 
-Users should consider installation via conda or pip, or switching to any of the following supported operating systems for any rapidsai/rapidsai image:
+Users should consider switching to any of the following supported operating systems for any rapidsai/rapidsai image:
   - Ubuntu 22.04 
   - Ubuntu 20.04
   - Rocky 8

--- a/_notices/rsn0037.md
+++ b/_notices/rsn0037.md
@@ -31,7 +31,7 @@ RAPIDS is deprecating `CentOS 7` in release v24.04, and it will be removed in re
 
 ## Impact
 
-Users should consider switching to any of the following supported operating systems for any rapidsai/rapidsai image:
+Users should consider installation via conda or pip, or switching to any of the following supported operating systems for any rapidsai/rapidsai image:
   - Ubuntu 22.04 
   - Ubuntu 20.04
   - Rocky 8

--- a/_notices/rsn0037.md
+++ b/_notices/rsn0037.md
@@ -26,7 +26,7 @@ notice_updated: 2024-02-14
 
 ## Overview
 
-RAPIDS is deprecating `CentOS 7` in release v24.04, and it will be removed in release v24.06.  This is due to `CentOS7` becoming end of life in June 2024, which means RAPIDS will no longer publish any images built on `CentOS 7` following the RAPIDS `v24.04` release.
+RAPIDS is deprecating `CentOS 7` in release v24.04, and it will be removed in release v24.06.  This is due to `CentOS 7` becoming end of life in June 2024, which means RAPIDS will no longer publish any images built on `CentOS 7` following the RAPIDS `v24.04` release.
 
 
 ## Impact

--- a/_notices/rsn0037.md
+++ b/_notices/rsn0037.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 37 # should match notice number
 notice_pin: false # set to true to pin to notice page
-title: "Deprecation of `CentOS 7` in v24.06"
+title: "Deprecation of `CentOS 7` in v24.04"
 notice_author: RAPIDS Ops
 notice_status: In Progress
 notice_status_color: yellow


### PR DESCRIPTION
RAPIDS is deprecating CentOS 7 in release v24.04, and it will be removed in release v24.06.