### PR TITLE
Disable librmm docs for 24.02/24.04

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -214,8 +214,8 @@ libs:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
-      nightly: 1
+      stable: 0
+      nightly: 0
   libkvikio:
     name: libkvikio
     path: libkvikio


### PR DESCRIPTION
Following https://github.com/rapidsai/rmm/pull/1415 (In `24.02`), `rmm` no longer publishes separate docs, so disable `24.02` & `24.04` docs for `librmm`.