### PR TITLE
Remove leading zeros from pip install commands

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -488,6 +488,9 @@
 
                 return lines;
             },
+            removeLeadingZeros(version) {
+                return version.split(".").map(Number).join(".");
+            },
             getpipCmdHtml() {
                 var pip_install = `${this.highlightCmd("pip")} install`;
                 var cuda_suffix = "-cu12";
@@ -502,7 +505,8 @@
                 // This has duplicate code, but makes for easier edits in the future
                 if (this.active_release === "Stable") {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.nvidia.com`;
-                    cuda_suffix = cuda_suffix + "=={{ site.data.releases.stable.version }}.*";
+                    var version = this.removeLeadingZeros("{{ site.data.releases.stable.version }}")
+                    cuda_suffix = cuda_suffix + `==${version}.*`;
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
@@ -512,7 +516,8 @@
                 }
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
-                    cuda_suffix = cuda_suffix + ">={{ site.data.releases.nightly.version }}.0a0,<={{ site.data.releases.nightly.version }}\"";
+                    var version = this.removeLeadingZeros("{{ site.data.releases.nightly.version }}")
+                    cuda_suffix = cuda_suffix + `>=${version}.0a0,<=${version}"`;
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
                         if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];


### PR DESCRIPTION
I'm unsure when this changed, but `pip install` commands with leading zeros (not PEP-440 compliant) fail.

For example:
```
$ pip install --extra-index-url=https://pypi.nvidia.com cugraph-cu12==24.02.*
Looking in indexes: https://pypi.org/simple, https://pypi.nvidia.com
ERROR: Could not find a version that satisfies the requirement cugraph-cu12==24.02.* (from versions: 23.6.0, 23.6.1, 23.6.2, 23.8.0, 23.10.0, 23.12.0, 24.2.0)
ERROR: No matching distribution found for cugraph-cu12==24.02.*

$ pip install --extra-index-url=https://pypi.nvidia.com cugraph-cu12==24.2.*
Looking in indexes: https://pypi.org/simple, https://pypi.nvidia.com
Collecting cugraph-cu12==24.2.*
  Downloading https://pypi.nvidia.com/cugraph-cu12/cugraph_cu12-24.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1311.2 MB)
```

So this PR removes the leading zeros.
