### PR TITLE
Adds RSN 38 for 24.02 MG cugraph `degree()` bug workaround.

### DIFF
--- a/_notices/rsn0038.md
+++ b/_notices/rsn0038.md
@@ -1,0 +1,52 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 38 # should match notice number
+notice_pin: false # set to true to pin to notice page
+title: "Support for 24.02 cugraph Users"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v24.02"
+notice_created: 2024-02-20
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2024-02-20
+---
+
+## Overview
+
+RAPIDS 24.02 cuGraph users of graph `degree` functions on undirected multi-GPU distributed graphs will need to apply a temporary workaround to compute correct results.
+
+### Example
+```
+...
+# create a distributed undirected graph from a dask DataFrame
+dG = cugraph.Graph(directed=False)
+dG.from_dask_cudf_edgelist(ddf, source="src", destination="dst")
+...
+result_df = dG.degree()
+# Temporary workaround for 24.02 only:
+#   MG degree() results for undirected graphs are doubled so divide by 2
+result_df["degree"] //= 2
+```
+
+## Impact
+
+Impact is limited to RAPIDS 24.02 `cugraph` users using the graph `degree` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on undirected, multi-GPU distributed graphs.
+
+## Background
+
+A bug was noticed late in the 24.02 release process for `cugraph` users using the `degrees` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on multi-GPU distributed graphs.  The bug causes the returned values to be doubled, and users of these functions must apply a workaround to divide the result by two in order to obtain the correct values as seen in the example above.
+
+This workaround should only be used for RAPIDS releases 24.02, and only for undirected multi-GPU distributed graphs.

--- a/_notices/rsn0038.md
+++ b/_notices/rsn0038.md
@@ -47,6 +47,6 @@ Impact is limited to RAPIDS 24.02 `cugraph` users using the graph `degree` funct
 
 ## Background
 
-A bug was noticed late in the 24.02 release process for `cugraph` users using the `degrees` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on multi-GPU distributed graphs.  The bug causes the returned values to be doubled, and users of these functions must apply a workaround to divide the result by two in order to obtain the correct values as seen in the example above.
+A bug was noticed late in the 24.02 release process for `cugraph` users using the `degrees` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on undirected multi-GPU distributed graphs.  The bug causes the returned values to be doubled, and users of these functions for these graph types must apply a workaround to divide the result by two in order to obtain the correct values as seen in the example above.
 
 This workaround should only be used for RAPIDS releases 24.02, and only for undirected multi-GPU distributed graphs.

--- a/_notices/rsn0038.md
+++ b/_notices/rsn0038.md
@@ -47,6 +47,6 @@ Impact is limited to RAPIDS 24.02 `cugraph` users using the graph `degree` funct
 
 ## Background
 
-A bug was noticed late in the 24.02 release process for `cugraph` users using the `degrees` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on undirected multi-GPU distributed graphs.  The bug causes the returned values to be doubled, and users of these functions for these graph types must apply a workaround to divide the result by two in order to obtain the correct values as seen in the example above.
+A bug was noticed late in the 24.02 release process for `cugraph` users using the `degree` functions (`G.degree()`, `G.in_degree()`, `G.out_degree()`) on undirected multi-GPU distributed graphs.  The bug causes the returned values to be doubled, and users of these functions for these graph types must apply a workaround to divide the result by two in order to obtain the correct values as seen in the example above.
 
 This workaround should only be used for RAPIDS releases 24.02, and only for undirected multi-GPU distributed graphs.


### PR DESCRIPTION
Adds RSN 38 for 24.02 MG cugraph `degree()` bug workaround.