### PR TITLE
Remove unused versions.yml file.

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,4 +1,0 @@
-# Default values used throughout the docs (UNUSED?)
-PYTHON_VER: "3.10"
-CUDA_VER: "12.0"
-UBUNTU_VER: "22.04"


### PR DESCRIPTION
It appears this file is unused. It should be safe to remove. I searched for these variables in this repo, as well as [references to versions.yml across `org:rapidsai`](https://github.com/search?q=org%3Arapidsai%20versions.yml&type=code) and found none.