### PR TITLE
Enable cudf java docs for 24.02

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
The docs for cudf-java have been published to S3, so updating here to make them available on the site.