### PR TITLE
add note on putting channel_priority: flexible in your .condarc

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -343,7 +343,8 @@
             <div class="cmd">
                 <div class="cmd-label">Command</div>
                 <div class="cmd-box">
-                    <pre class="highlight"><code><span x-ref="cmd" x-html="getCmdHtml" x-on:mouseup.once="copyToGA"></span></code></pre>
+                    <pre
+                        class="highlight"><code><span x-ref="cmd" x-html="getCmdHtml" x-on:mouseup.once="copyToGA"></span></code></pre>
                 </div>
             </div>
         </div>
@@ -609,7 +610,7 @@
             },
             getCondaNotes() {
                 var notes = [];
-                notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
+                notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead in your .condarc"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
@@ -793,12 +794,12 @@
                 window.getSelection().removeAllRanges();
 
                 /** checks number of installs from copy command vs downloads **/
-                 gtag('event', 'copyClick', {
+                gtag('event', 'copyClick', {
                     'button': 'CopyCommand',
                     'install_copy_cmd': text
                 });
             },
-            copyToGA(){
+            copyToGA() {
                 let range = document.createRange();
                 range.selectNode(this.$refs.cmd);
                 window.getSelection().removeAllRanges();


### PR DESCRIPTION
Just adding a small note that users should put channel_priority: flexible in their .condarc. Apologies my linter made some other changes. Happy to revert if need be.

Hope this doesn't bloat the selector and still looks ok. I'm happy for it be moved elsewhere or left out if preferred.

Edit: Looks as expected in preview

![Screenshot 2024-03-03 at 2 54 27 PM](https://github.com/rapidsai/docs/assets/17162724/bfe0ba0a-1ef5-42a0-bb14-5953a5119452)

Edit: if I give this a second thought you can also recommend using `--no-channel-priority` in the off chance a user needs strict channel priority in another project.