### PR TITLE
Update Mamba installation link in install.md

### DIFF
--- a/install/install.md
+++ b/install/install.md
@@ -189,7 +189,7 @@ For most installations, you will need a Conda or Docker environments installed f
 RAPIDS can use several versions of conda:
 - Full installation with [Anaconda](https://www.anaconda.com/download){: target="_blank"} (with optional faster [libmamba solver](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community/){: target="_blank"}).
 - Minimal installation with [Miniconda](https://conda.io/miniconda.html){: target="_blank"}
-- Faster environment solving installation with standalone [Mamba](https://mamba.readthedocs.io/en/latest/installation.html){: target="_blank"}.
+- Faster environment solving installation with standalone [Mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html){: target="_blank"}.
 
 Below is a quick installation guide using miniconda.
 


### PR DESCRIPTION
This PR fixes the hyper link for Mamba installlation
- before (404 Error) : https://mamba.readthedocs.io/en/latest/installation.html 
- after : https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html