### PR TITLE
Fix ucxx versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib_map.json
 .jekyll-cache
 .jekyll-metadata
 .netlify
+__pycache__/

--- a/ci/customization/customize_docs_in_folder.sh
+++ b/ci/customization/customize_docs_in_folder.sh
@@ -46,7 +46,11 @@ for FILE in $(grep "${JTD_SEARCH_TERM}\|${DOXYGEN_SEARCH_TERM}\|${PYDATA_SEARCH_
   --exclude-dir=legacy \
   --exclude-dir=cudf-java \
   ${FOLDER_TO_CUSTOMIZE} ); do
-  python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})
+  if [[ ${FILE} == *"libucxx"* ]]; then
+    python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE}) --is-ucxx
+  else
+    python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})
+  fi
   echo "" # line break for readability
 done
 IFS="$OIFS"

--- a/ci/customization/customize_docs_in_folder.sh
+++ b/ci/customization/customize_docs_in_folder.sh
@@ -46,7 +46,7 @@ for FILE in $(grep "${JTD_SEARCH_TERM}\|${DOXYGEN_SEARCH_TERM}\|${PYDATA_SEARCH_
   --exclude-dir=legacy \
   --exclude-dir=cudf-java \
   ${FOLDER_TO_CUSTOMIZE} ); do
-  if [[ ${FILE} == *"libucxx"* ]]; then
+  if [[ ${FILE} == *"ucxx"* ]]; then
     python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE}) --is-ucxx
   else
     python ${SCRIPT_SRC_FOLDER}/customize_doc.py $(realpath ${FILE})

--- a/ci/customization/util.py
+++ b/ci/customization/util.py
@@ -1,0 +1,17 @@
+class r_versions(str):
+    def compare(self, other: str) -> int:
+        yearA, monthA = map(int, self.split("."))
+        yearB, monthB = map(int, other.split("."))
+
+        if yearA < yearB or (yearA == yearB and monthA < monthB):
+            return -1
+        elif yearA == yearB and monthA == monthB:
+            return 0
+        else:
+            return 1
+
+    def is_less_than(self, other: str) -> bool:
+        return self.compare(other) == -1
+
+    def is_greater_than(self, other: str) -> bool:
+        return self.compare(other) == 1

--- a/ci/download_from_s3.sh
+++ b/ci/download_from_s3.sh
@@ -74,7 +74,7 @@ download_lib_docs() {
   for VERSION_NAME in $(jq -r 'keys | .[]' <<< "$VERSION_MAP"); do
     for PROJECT in $(yq -r 'keys | .[]' <<< "$PROJECT_MAP"); do
       VERSION_NUMBER=$(jq -r --arg vn "$VERSION_NAME" --arg pr "$PROJECT" '
-        if $pr == "libucxx" then
+        if ($pr | contains("ucxx")) then
           .[$vn].ucxx_version
         else
           .[$vn].version

--- a/ci/update_symlinks.sh
+++ b/ci/update_symlinks.sh
@@ -18,7 +18,7 @@ NIGHTLY_UCXX_VERSION=$(jq -r '.nightly.ucxx_version' < "${RELEASES}")
 echo "Updating symlinks..."
 echo ""
 for FOLDER in _site/api/*/ ; do
-  if [[ "${FOLDER}" == *"libucxx"* ]]; then
+  if [[ "${FOLDER}" == *"ucxx"* ]]; then
     STABLE_FOLDER=$STABLE_UCXX_VERSION
     LEGACY_FOLDER=$LEGACY_UCXX_VERSION
     NIGHTLY_FOLDER=$NIGHTLY_UCXX_VERSION

--- a/ci/update_symlinks.sh
+++ b/ci/update_symlinks.sh
@@ -13,6 +13,11 @@ NIGHTLY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.nightly.versi
 echo "Updating symlinks..."
 echo ""
 for FOLDER in _site/api/*/ ; do
+  if [[ "${FOLDER}" == *"libucxx"* ]]; then
+    STABLE_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.stable.ucxx_version')
+    LEGACY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.legacy.ucxx_version')
+    NIGHTLY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.nightly.ucxx_version')
+  fi
 
   cd ${FOLDER}
   echo ""

--- a/ci/update_symlinks.sh
+++ b/ci/update_symlinks.sh
@@ -5,18 +5,27 @@
 set -euEo pipefail
 
 PROJ_ROOT=$(realpath "$(dirname $(realpath $0))/../")
+RELEASES="${PROJ_ROOT}/_data/releases.json"
 
-STABLE_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.stable.version')
-LEGACY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.legacy.version')
-NIGHTLY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.nightly.version')
+STABLE_VERSION=$(jq -r '.stable.version' < "${RELEASES}")
+LEGACY_VERSION=$(jq -r '.legacy.version' < "${RELEASES}")
+NIGHTLY_VERSION=$(jq -r '.nightly.version' < "${RELEASES}")
+
+STABLE_UCXX_VERSION=$(jq -r '.stable.ucxx_version' < "${RELEASES}")
+LEGACY_UCXX_VERSION=$(jq -r '.legacy.ucxx_version' < "${RELEASES}")
+NIGHTLY_UCXX_VERSION=$(jq -r '.nightly.ucxx_version' < "${RELEASES}")
 
 echo "Updating symlinks..."
 echo ""
 for FOLDER in _site/api/*/ ; do
   if [[ "${FOLDER}" == *"libucxx"* ]]; then
-    STABLE_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.stable.ucxx_version')
-    LEGACY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.legacy.ucxx_version')
-    NIGHTLY_FOLDER=$( cat "${PROJ_ROOT}/_data/releases.json" | jq -r '.nightly.ucxx_version')
+    STABLE_FOLDER=$STABLE_UCXX_VERSION
+    LEGACY_FOLDER=$LEGACY_UCXX_VERSION
+    NIGHTLY_FOLDER=$NIGHTLY_UCXX_VERSION
+  else
+    STABLE_FOLDER=$STABLE_VERSION
+    LEGACY_FOLDER=$LEGACY_VERSION
+    NIGHTLY_FOLDER=$NIGHTLY_VERSION
   fi
 
   cd ${FOLDER}


### PR DESCRIPTION
This PR addresses the versioning discrepancy in the documentation of the `ucxx` library. Previously, we used the RAPIDS versioning convention for `ucxx` in our docs workflow and overwrote the RAPIDS versioning with `ucxx`'s actual versioning during the deploy step. This PR updates the workflow to use the correct `ucxx` version number directly in our docs deployment workflow.

Before this PR is merged, [this PR](https://github.com/rapidsai/ucxx/pull/215) should be merged - the PR updates the build step in `build_docs.sh` to use the correct version numbers when uploading docs to s3. 

Before both these PRs are merged, we should rename/re-sync the relevant directories up in `s3` from the RAPIDS versioning used to `ucxx`'s.


**Testing:**
Changes in `download_from_s3.sh` were tested by running the `download_lib_docs` function locally. Other processing scripts were tested locally by downloading `rmm` and `libucxx` (legacy, stable, nightly) docs and running `ci/post_process.sh`. Outputs were as expected.