### PR TITLE
add uv pip install method

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -343,7 +343,8 @@
             <div class="cmd">
                 <div class="cmd-label">Command</div>
                 <div class="cmd-box">
-                    <pre class="highlight"><code><span x-ref="cmd" x-html="getCmdHtml" x-on:mouseup.once="copyToGA"></span></code></pre>
+                    <pre
+                        class="highlight"><code><span x-ref="cmd" x-html="getCmdHtml" x-on:mouseup.once="copyToGA"></span></code></pre>
                 </div>
             </div>
         </div>
@@ -372,7 +373,7 @@
             python_vers: ["3.9", "3.10", "3.11"],
             cuda_vers: ["11.2", "11.8", "12.0", "12.2"],
             pip_cuda_vers: ["11.2 - 11.8", "12"],
-            methods: ["Conda", "pip", "Docker"],
+            methods: ["Conda", "pip", "uv pip", "Docker"],
             releases: ["Stable", "Nightly"],
             img_loc: ["NGC", "Dockerhub"],
             img_types: ["Base", "Notebooks"],
@@ -495,8 +496,8 @@
             removeLeadingZeros(version) {
                 return version.split(".").map(Number).join(".");
             },
-            getpipCmdHtml() {
-                var pip_install = `${this.highlightCmd("pip")} install`;
+            getpipCmdHtml(commandType = "pip") {
+                var pip_install = `${this.highlightCmd(`${commandType}`)} install`;
                 var cuda_suffix = "-cu12";
                 var indentation = "    ";
 
@@ -663,6 +664,8 @@
                     return this.getCondaCmdHtml();
                 if (this.active_method === "pip")
                     return this.getpipCmdHtml();
+                if (this.active_method === "uv pip")
+                    return this.getpipCmdHtml("uv pip");
                 return "Not implemented yet!";
             },
             disableUnsupportedRelease(release) {
@@ -796,12 +799,12 @@
                 window.getSelection().removeAllRanges();
 
                 /** checks number of installs from copy command vs downloads **/
-                 gtag('event', 'copyClick', {
+                gtag('event', 'copyClick', {
                     'button': 'CopyCommand',
                     'install_copy_cmd': text
                 });
             },
-            copyToGA(){
+            copyToGA() {
                 let range = document.createRange();
                 range.selectNode(this.$refs.cmd);
                 window.getSelection().removeAllRanges();


### PR DESCRIPTION
Closes https://github.com/rapidsai/docs/issues/498

See the build at https://deploy-preview-510--docs-rapids-ai.netlify.app/install

Works as expected

![Screenshot 2024-04-13 at 10 45 03 PM](https://github.com/rapidsai/docs/assets/17162724/d0bf4da5-3a7d-4fc4-a1f6-7bc69c42c2f5)

Apologies for the linting edits as well

While uv pip offers a ~2-3 x RAPIDS install (4 min 19 s -> 1 min 34 s: https://colab.research.google.com/drive/1d3_gb_4y2Xgvl6xBBdknfwUV8Heq-nzJ) compared to pip it may not be as stable. However, from my experience the astral folks are pretty quick at fixing bugs (e.g. https://github.com/astral-sh/uv/issues/2477). I don't know if the docs here also need to include a section on how to download uv and troubleshoot.