### PR TITLE
Enable 24.04 cudf-java docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
I uploaded the javadocs for `24.04` from https://repo1.maven.org/maven2/ai/rapids/cudf/24.04.0/ to S3, so this PR enables the stable (24.04) docs.