### PR TITLE
Remove centos refs from installation guide

### DIFF
--- a/install/install.md
+++ b/install/install.md
@@ -132,9 +132,9 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support was [removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ is required for RAPIDS 24.02 and later.
 
 <i class="fas fa-desktop"></i> **OS:** One of the following OS versions:
-- <i class="fas fa-check-circle"></i> Ubuntu 20.04/22.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+
+- <i class="fas fa-check-circle"></i> Ubuntu 20.04/22.04 or Rocky Linux 8 with <code>gcc/++</code> 9.0+
 - <i class="fas fa-check-circle"></i> Windows 11 using a [WSL2 specific install](#wsl2)
-- <i class="fas fa-check-circle"></i> RHEL 7/8 support is provided through CentOS 7 / Rocky Linux 8 builds/installs
+- <i class="fas fa-check-circle"></i> RHEL 7/8 support is provided through Rocky Linux 8 builds/installs
 
 <i class="fas fa-download text-purple"></i> **CUDA & NVIDIA Drivers:** One of the following supported versions:
 {: .no-tb-margins }
@@ -187,7 +187,7 @@ Several services also offer **free and limited** trials with GPU resources:
 <div id="environment"></div>
 
 # Environment Setup
-For most installations, you will need a Conda or Docker environments installed for RAPIDS. Note, these examples are structured for installing on **Ubuntu**. Please modify appropriately for CentOS / Rocky Linux. **Windows 11** has a [WSL2 specific install](#wsl2).
+For most installations, you will need a Conda or Docker environments installed for RAPIDS. Note, these examples are structured for installing on **Ubuntu**. Please modify appropriately for Rocky Linux. **Windows 11** has a [WSL2 specific install](#wsl2).
 
 <br>
 <div id="conda"></div>


### PR DESCRIPTION
Following the removal of Cent OS 7 support across RAPIDS for `24.06`, this PR removes any Cent OS 7 references from the installation guide