### PR TITLE
Remove librmm docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -216,17 +216,6 @@ libs:
       legacy: 1
       stable: 1
       nightly: 1
-  librmm:
-    name: librmm
-    path: librmm
-    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
-    ghlink: https://github.com/rapidsai/rmm
-    cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
-    versions:
-      # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 1
-      stable: 0
-      nightly: 0
   libkvikio:
     name: libkvikio
     path: libkvikio

--- a/_redirects
+++ b/_redirects
@@ -30,8 +30,8 @@
 /api/libcuspatial/ /api/libcuspatial/stable/
 /api/libkvikio /api/libkvikio/stable/
 /api/libkvikio/ /api/libkvikio/stable/
-/api/librmm /api/librmm/stable/
-/api/librmm/ /api/librmm/stable/
+/api/librmm /api/rmm/stable/
+/api/librmm/ /api/rmm/stable/
 /api/raft /api/raft/stable/
 /api/raft/ /api/raft/stable/
 /api/rapids-cmake /api/rapids-cmake/stable/

--- a/ci/customization/lib_map.sh
+++ b/ci/customization/lib_map.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # This script generates a lib_map.json file that maps each RAPIDS library
 # to its default documentation page for each version (legacy, stable, nightly).
@@ -35,10 +36,7 @@ for FOLDER in _site/api/*/ ; do
     if [ -d "${VERSION}" ]; then
       DEFAULT_PATH+="/${VERSION}"
 
-      if [[ "${LIB}" = librmm ]]; then
-        DEFAULT_PATH+="/annotated/"
-
-      elif [ "${LIB}" = libcudf ]; then
+      if [ "${LIB}" = libcudf ]; then
         DEFAULT_PATH+="/namespacecudf/"
 
       elif [ "${LIB}" = cudf ]; then


### PR DESCRIPTION
`librmm` docs were merged into `rmm` docs and `24.02` was the last version to have separated `librmm` docs.

Now that the legacy version is `24.04`, the `librmm` docs can be removed.

Ref: https://github.com/rapidsai/docs/pull/478
https://github.com/rapidsai/docs/actions/runs/9421083274/job/25954311807
