### PR TITLE
Fix ucxx docs & enable docs for newer libs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -76,7 +76,7 @@ apis:
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # cuProj is housed within cuSpatial so updates remain in the cuSpatial changelog
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 0
+      legacy: 1
       stable: 1
       nightly: 1
   cusignal:
@@ -120,8 +120,8 @@ apis:
     cllink: https://github.com/rapidsai/cuvs/blob/main/CHANGELOG.md
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 0
-      stable: 0
+      legacy: 1
+      stable: 1
       nightly: 1
   kvikio:
     name: KvikIO
@@ -202,7 +202,7 @@ libs:
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # Shares a changelog with cuSpatial
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 0
+      legacy: 1
       stable: 1
       nightly: 1
   libcuml:
@@ -234,8 +234,8 @@ libs:
     ghlink: https://github.com/rapidsai/ucxx
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
-      legacy: 0
-      stable: 0
+      legacy: 1
+      stable: 1
       nightly: 1
   rapids-cmake:
     name: rapids-cmake

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -11,6 +11,7 @@
   },
   "nightly": {
     "version": "24.08",
+    "ucxx_version": "0.39",
     "cudf_dev": {
       "start": "May 16 2024",
       "end": "Jul 17 2024",
@@ -49,6 +50,7 @@
   },
   "next_nightly": {
     "version": "24.10",
+    "ucxx_version": "0.40",
     "cudf_dev": {
       "start": "Jul 18 2024",
       "end": "Sep 18 2024",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,13 +1,13 @@
 {
   "legacy": {
     "version": "24.04",
-    "date": "Apr 11 2024",
-    "ucxx_version": "0.37"
+    "ucxx_version": "0.37",
+    "date": "Apr 11 2024"
   },
   "stable": {
     "version": "24.06",
-    "date": "Jun 6 2024",
-    "ucxx_version": "0.38"
+    "ucxx_version": "0.38",
+    "date": "Jun 6 2024"
   },
   "nightly": {
     "version": "24.08",


### PR DESCRIPTION
Fixes pulling `libucxx` docs by adding the `ucxx_version` to `releases.json`.

Also enables various doc versions for newer libraries that now have legacy or stable docs.

I manually ran `./ci/download_from_s3.sh` locally to verify all of the docs exist.
