### PR TITLE
Enable stable/24.06 cudf javadocs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
`24.06` javadocs are available and pushed to the docs S3 bucket, so just need to enable them.