### PR TITLE
Add CUDA 12.5 to conda nightlys in the selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -371,7 +371,7 @@
 
             // all possible values
             python_vers: ["3.9", "3.10", "3.11"],
-            cuda_vers: ["11.2", "11.8", "12.0", "12.2"],
+            cuda_vers: ["11.2", "11.8", "12.0", "12.2", "12.5"],
             pip_cuda_vers: ["11.2 - 11.8", "12"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
@@ -675,6 +675,7 @@
                 var isDisabled = false;
                 if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "12.0")) isDisabled = true;
                 if (this.active_method === "Docker" && cuda_version < "11.8") isDisabled = true;
+                if (this.active_release === "Stable" && cuda_version === "12.5") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -705,6 +705,9 @@
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
+                if ( this.active_release === "Stable" && this.active_cuda_ver === "12.5") {
+                    this.active_cuda_ver = "12.2";
+                }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;


### PR DESCRIPTION
Small PR that adds CUDA 12.5 to the conda nightlys.

When 24.08 releases a followup PR will be made that:
1. Sets 12.5 as the default
2. Removes 12.2 as an option (still supported but not necessary for the selector)