### PR TITLE
Use CUDA version ranges in release selector.

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -244,11 +244,11 @@
                         </div>
                     </template>
                 </div>
-                <div class="options-section" x-show="active_method !== 'pip'">
+                <div class="options-section" x-show="active_method === 'Conda'">
                     <div class="option-label">ENV. CUDA</div>
-                    <template x-for="version in cuda_vers">
-                        <div x-on:click="(e) => cudaClickHandler(e, version)"
-                            x-bind:class="{'active': version === active_cuda_ver, 'disabled': disableUnsupportedCuda(version)}"
+                    <template x-for="version in conda_cuda_vers">
+                        <div x-on:click="(e) => condaCUDAClickHandler(e, version)"
+                            x-bind:class="{'active': version === active_conda_cuda_ver, 'disabled': disableUnsupportedCuda(version)}"
                             class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
@@ -258,6 +258,14 @@
                         <div x-on:click="(e) => pipCUDAClickHandler(e, version)"
                             x-bind:class="{'active': version === active_pip_cuda_ver}" class="option"
                             x-text="'CUDA ' + version"></div>
+                    </template>
+                </div>
+                <div class="options-section" x-show="active_method === 'Docker'">
+                    <div class="option-label">Image CUDA</div>
+                    <template x-for="version in docker_cuda_vers">
+                        <div x-on:click="(e) => dockerCUDAClickHandler(e, version)"
+                            x-bind:class="{'active': version === active_docker_cuda_ver, 'disabled': disableUnsupportedCuda(version)}"
+                            class="option" x-text="'CUDA ' + version"></div>
                     </template>
                 </div>
                 <div class="options-section" x-show="active_method !== 'pip'">
@@ -360,7 +368,7 @@
         Alpine.data('rapids_selector', () => ({
             // default values
             active_python_ver: "3.11",
-            active_cuda_ver: "12.2",
+            active_cuda_ver: "12.0 - 12.2",
             active_pip_cuda_ver: "12",
             active_method: "Conda",
             active_release: "Stable",
@@ -371,8 +379,9 @@
 
             // all possible values
             python_vers: ["3.9", "3.10", "3.11"],
-            cuda_vers: ["11.2", "11.8", "12.0", "12.2", "12.5"],
-            pip_cuda_vers: ["11.2 - 11.8", "12"],
+            conda_cuda_vers: ["11.4 - 11.8", "12.0 - 12.2", "12.0 - 12.5"],
+            pip_cuda_vers: ["11.4 - 11.8", "12"],
+            docker_cuda_vers: ["11.8", "12.0", "12.2", "12.5"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
             img_loc: ["NGC", "Dockerhub"],
@@ -673,9 +682,9 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                if (this.active_additional_packages.includes("TensorFlow") && (cuda_version !== "12.0")) isDisabled = true;
-                if (this.active_method === "Docker" && cuda_version < "11.8") isDisabled = true;
-                if (this.active_release === "Stable" && cuda_version === "12.5") isDisabled = true;
+                if (this.active_additional_packages.includes("TensorFlow") && (!cuda_version.startsWith("12")) isDisabled = true;
+                // Remove once stable releases support CUDA 12.5
+                if (this.active_release === "Stable" && cuda_version.includes("12.5")) isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -705,21 +714,26 @@
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
-                if ( this.active_release === "Stable" && this.active_cuda_ver === "12.5") {
-                    this.active_cuda_ver = "12.2";
+                // Remove once stable releases support CUDA 12.5
+                if ( this.active_release === "Stable" && this.active_conda_cuda_ver === "12.0 - 12.5") {
+                    this.active_conda_cuda_ver = "12.0 - 12.2";
                 }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;
                 this.active_img_type = type;
             },
-            cudaClickHandler(e, version) {
+            condaCUDAClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
-                this.active_cuda_ver = version;
+                this.active_conda_cuda_ver = version;
             },
             pipCUDAClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;
                 this.active_pip_cuda_ver = version;
+            },
+            dockerCUDAClickHandler(e, version) {
+                if (this.isDisabled(e.target)) return;
+                this.active_docker_cuda_ver = version;
             },
             pythonClickHandler(e, version) {
                 if (this.isDisabled(e.target)) return;


### PR DESCRIPTION
This PR uses CUDA version ranges in the release selector. This follows from discussions in https://github.com/rapidsai/docs/pull/522.
