### PR TITLE
CUDA 12.2 Deprecation Notice

### DIFF
--- a/_notices/rsn0039.md
+++ b/_notices/rsn0039.md
@@ -26,7 +26,9 @@ notice_updated: 2024-07-23
 
 ## Overview
 
-RAPIDS is planning to deprecate support of CUDA 12.2 Docker containers in Release `v24.08`, and to cease publishing CUDA 12.2 Docker containers before the `v24.10` release.  The CUDA 12.2 containers will be replaced by CUDA 12.5 containers.  We are continuing support for CUDA 11.8 and 12.0 containers
+RAPIDS is planning to deprecate support of CUDA 12.2 Docker containers in Release `v24.08`, and to cease publishing CUDA 12.2 Docker containers before the `v24.10` release.
+The CUDA 12.2 containers will be replaced by CUDA 12.5 containers.
+We are continuing support for CUDA 11.8 and 12.0 containers.
 
 ## Impact
 

--- a/_notices/rsn0039.md
+++ b/_notices/rsn0039.md
@@ -1,0 +1,33 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 39 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Deprecation Announcement Dropping CUDA 12.2 support in our Docker Images in Release v24.08"
+notice_author: RAPIDS Ops
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v24.08"
+notice_created: 2024-07-23
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2024-07-23
+---
+
+## Overview
+
+RAPIDS is planning to deprecate support of CUDA 12.2 Docker containers in Release `v24.08`, and to cease publishing CUDA 12.2 Docker containers before the `v24.10` release.  The CUDA 12.2 containers will be replaced by CUDA 12.5 containers.  We are continuing support for CUDA 11.8 and 12.0 containers
+
+## Impact
+
+Effective RAPIDS `v24.08` release, RAPIDS will cease distribution of CUDA 12.2 Docker containers. RAPIDS will continue to support CUDA 11.8, 12.0 and 12.5 containers. Users who still wish to use CUDA 12.2 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda installation.

--- a/_notices/rsn0039.md
+++ b/_notices/rsn0039.md
@@ -32,4 +32,6 @@ We are continuing support for CUDA 11.8 and 12.0 containers.
 
 ## Impact
 
-Effective RAPIDS `v24.08` release, RAPIDS will cease distribution of CUDA 12.2 Docker containers. RAPIDS will continue to support CUDA 11.8, 12.0 and 12.5 containers. Users who still wish to use CUDA 12.2 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda installation.
+Effective RAPIDS `v24.08` release, RAPIDS will cease distribution of CUDA 12.2 Docker containers.
+RAPIDS will continue to support CUDA 11.8, 12.0 and 12.5 containers.
+Users who still wish to use CUDA 12.2 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.


### PR DESCRIPTION
RAPIDS is planning to deprecate support of CUDA 12.2 Docker containers in Release `v24.08`, and to cease publishing CUDA 12.2 Docker containers before the `v24.10` release.  The CUDA 12.2 containers will be replaced by CUDA 12.5 containers.  We are continuing support for CUDA 11.8 and 12.0 containers