### PR TITLE
Dropping Support for Python v3.9 and adding Python 3.12 Support in Release v24.10

### DIFF
--- a/_notices/rsn0040.md
+++ b/_notices/rsn0040.md
@@ -1,0 +1,34 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 40 # should match notice number
+notice_pin: false # set to true to pin to notice page
+title: "Dropping Support for Python v3.9 and adding Python 3.12 Support in v24.10"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v24.10+"
+notice_created: 2024-08-06
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2024-08-06
+---
+
+## Overview
+
+RAPIDS is dropping support for Python 3.9 in the upcoming release of v24.10, scheduled for October 10, 2024.  Python 3.12 support will be added at the same time, so that v24.10 will support Python 3.10, Python 3.11, and Python 3.12.
+
+
+## Impact
+
+Users should plan to move to a supported Python version 3.10, 3.11, or 3.12 as soon as possible.

--- a/_notices/rsn0040.md
+++ b/_notices/rsn0040.md
@@ -6,7 +6,8 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 40 # should match notice number
-notice_pin: false # set to true to pin to notice page
+notice_pin: true # set to true to pin to notice page
+
 title: "Dropping Support for Python v3.9 and adding Python 3.12 Support in v24.10"
 notice_author: RAPIDS TPM
 notice_status: In Progress


### PR DESCRIPTION
This PR is Dropping Support for Python v3.9 and adding Python 3.12 Support in Release v24.10