### PR TITLE
Updates for RAPIDS 24.08

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,44 @@
 [
   {
+    "version": "24.08",
+    "ucxx_version": "0.39",
+    "cudf_dev": {
+      "start": "May 16 2024",
+      "end": "Jul 17 2024",
+      "days": "40"
+    },
+    "other_dev": {
+      "start": "May 23 2024",
+      "end": "Jul 24 2024",
+      "days": "40"
+    },
+    "cudf_burndown": {
+      "start": "Jul 18 2024",
+      "end": "Jul 24 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Jul 25 2024",
+      "end": "Jul 31 2024",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Jul 25 2024",
+      "end": "Aug 6 2024",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Aug 1 2024",
+      "end": "Aug 6 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Aug 7 2024",
+      "end": "Aug 8 2024",
+      "days": "2"
+    }
+  },
+  {
     "version": "24.06",
     "ucxx_version": "0.38",
     "cudf_dev": {

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,54 +1,15 @@
 {
   "legacy": {
-    "version": "24.04",
-    "ucxx_version": "0.37",
-    "date": "Apr 11 2024"
-  },
-  "stable": {
     "version": "24.06",
     "ucxx_version": "0.38",
     "date": "Jun 6 2024"
   },
-  "nightly": {
+  "stable": {
     "version": "24.08",
     "ucxx_version": "0.39",
-    "cudf_dev": {
-      "start": "May 16 2024",
-      "end": "Jul 17 2024",
-      "days": "40"
-    },
-    "other_dev": {
-      "start": "May 23 2024",
-      "end": "Jul 24 2024",
-      "days": "40"
-    },
-    "cudf_burndown": {
-      "start": "Jul 18 2024",
-      "end": "Jul 24 2024",
-      "days": "5"
-    },
-    "other_burndown": {
-      "start": "Jul 25 2024",
-      "end": "Jul 31 2024",
-      "days": "5"
-    },
-    "cudf_codefreeze": {
-      "start": "Jul 25 2024",
-      "end": "Aug 6 2024",
-      "days": "9"
-    },
-    "other_codefreeze": {
-      "start": "Aug 1 2024",
-      "end": "Aug 6 2024",
-      "days": "4"
-    },
-    "release": {
-      "start": "Aug 7 2024",
-      "end": "Aug 8 2024",
-      "days": "2"
-    }
+    "date": "Aug 8 2024"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "24.10",
     "ucxx_version": "0.40",
     "cudf_dev": {
@@ -84,6 +45,45 @@
     "release": {
       "start": "Oct 9 2024",
       "end": "Oct 10 2024",
+      "days": "2"
+    }
+  },
+  "next_nightly": {
+    "version": "24.12",
+    "ucxx_version": "0.41",
+    "cudf_dev": {
+      "start": "Sep 19 2024",
+      "end": "Nov 13 2024",
+      "days": "39"
+    },
+    "other_dev": {
+      "start": "Sep 26 2024",
+      "end": "Nov 20 2024",
+      "days": "39"
+    },
+    "cudf_burndown": {
+      "start": "Nov 14 2024",
+      "end": "Nov 20 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Nov 21 2024",
+      "end": "Dec 4 2024",
+      "days": "8"
+    },
+    "cudf_codefreeze": {
+      "start": "Nov 21 2024",
+      "end": "Dec 10 2024",
+      "days": "12"
+    },
+    "other_codefreeze": {
+      "start": "Dec 5 2024",
+      "end": "Dec 10 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Dec 11 2024",
+      "end": "Dec 12 2024",
       "days": "2"
     }
   }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -438,7 +438,7 @@
                 var cuda_version_info = {
                     "Stable": {
                         "11": ["11.4", "11.8"],
-                        "12": ["12.0", "12.2"]
+                        "12": ["12.0", "12.5"]
                     },
                     "Nightly": {
                         "11": ["11.4", "11.8"],
@@ -704,7 +704,6 @@
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
                 if (this.active_additional_packages.includes("TensorFlow") && (!cuda_version.startsWith("12"))) isDisabled = true;
-                if (this.active_release === "Stable" && cuda_version === "12.5") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -734,9 +733,6 @@
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
-                if (this.active_release === "Stable" && this.active_docker_cuda_ver === "12.5") {
-                    this.active_docker_cuda_ver = "12.2";
-                }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;


### PR DESCRIPTION
1. Updates stable version to `24.08`
2. Disables `cudf-java` stable docs (they are uploaded later)
3. Reverts the nightly-only changes in #522
    1. Part of rapidsai/build-planning#73
4. Update `getCondaVersionSupport` for `12.5` (see #524)
