### PR TITLE
update pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         exclude: |
@@ -20,7 +20,7 @@ repos:
       - id: check-builtin-literals
       - id: check-executables-have-shebangs
   - repo: https://github.com/sirosen/texthooks
-    rev: 0.6.4
+    rev: 0.6.7
     hooks:
       - id: fix-smartquotes
         exclude: |
@@ -29,18 +29,22 @@ repos:
             licenses/.*
           )
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         types: [markdown]
+        exclude: |
+          (?x)^(
+            resources/conduct\.md
+          )$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.1
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.0.3
+    rev: v0.4.0
     hooks:
       - id: verify-copyright
 

--- a/releases/planning.md
+++ b/releases/planning.md
@@ -56,7 +56,7 @@ Each Release board has the following columns:
 #### Using the release board
 - Assigning and prioritizing work
   - Scroll to the left to see all the columns labeled `Issue-*`
-  - Re-prioritize issues in `P0`, `P1`, `P2` by moving issuses between columns
+  - Re-prioritize issues in `P0`, `P1`, `P2` by moving issues between columns
   - Move high priority issues within a column to the top; this promotes "pop off the top of the stack" development
 - Expediting and finishing work
   - Scroll to the right to see all columns labeled `PR-*`


### PR DESCRIPTION
Updates all of the `pre-commit` hook versions here, like this:

```shell
pre-commit autoupdate
```

The latest version of `codespell` caught 2 spelling errors:

```text
resources/conduct.md:32: socio-economic ==> socioeconomic
releases/planning.md:59: issuses ==> issues
```

This proposes ignoring the suggestion about the code of conduct by skipping spell-checking for that entire file... I'm assuming we want to only change that language in substantive ways. Let me know if you disagree and I'd be happy to just accept the suggestion (or just skip that one word via configuration).