### PR TITLE
install selector: Drop python 3.9 for nightlies, default to CUDA 12.5 for stable and nightly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ docker run --rm \
   --volume="$PWD:/srv/jekyll" \
   --publish [::1]:4000:4000 \
   jekyll/jekyll \
-  jekyll serve
+  bash -c 'rm -rf ./_site && jekyll serve'
 ```
 
 ## PR submissions

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -370,7 +370,7 @@
             active_python_ver: "3.11",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
-            active_docker_cuda_ver: "12.2",
+            active_docker_cuda_ver: "12.5",
             active_method: "Conda",
             active_release: "Stable",
             active_img_type: "Base",
@@ -379,7 +379,9 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.10", "3.11"],
+            python_vers: ["3.9", "3.10", "3.11"],
+            python_vers_stable: ["3.9", "3.10", "3.11"],
+            python_vers_nightly: ["3.10", "3.11"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
             docker_cuda_vers: ["11.8", "12.0", "12.2", "12.5"],
@@ -708,6 +710,11 @@
             },
             disableUnsupportedPython(python_version) {
                 var isDisabled = false;
+                if (this.active_release === "Stable") {
+                    isDisabled = !this.python_vers_stable.includes(python_version)
+                } else if (this.active_release === "Nightly") {
+                    isDisabled = !this.python_vers_nightly.includes(python_version)
+                }
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -384,7 +384,7 @@
             python_vers_nightly: ["3.10", "3.11"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
-            docker_cuda_vers: ["11.8", "12.0", "12.2", "12.5"],
+            docker_cuda_vers: ["11.8", "12.0", "12.5"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
             img_loc: ["NGC", "Dockerhub"],

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -740,6 +740,18 @@
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
                 this.active_release = release;
+
+                /*
+                    It's possible that the active Python version prior to someone changing releases
+                    isn't supported by whatever release was chosen in the selector.
+
+                    This handles that case, updating to the oldest Python version supported by the chosen release.
+                */
+                if (this.active_release === "Stable" && !this.python_vers_stable.includes(this.active_python_ver)) {
+                    this.active_python_ver = this.python_vers_stable[0];
+                } else if (this.active_release === "Nightly" && !this.python_vers_nightly.includes(this.active_python_ver)) {
+                    this.active_python_ver = this.python_vers_nightly[0];
+                }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -379,7 +379,7 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.9", "3.10", "3.11"],
+            python_vers: ["3.10", "3.11"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
             docker_cuda_vers: ["11.8", "12.0", "12.2", "12.5"],

--- a/install/install.md
+++ b/install/install.md
@@ -98,7 +98,7 @@ ERROR: No matching distribution found for cudf-cu12
 ```
 Check the suggestions below for possible resolutions:
 - The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
-- Only Python versions 3.9, 3.10, and 3.11 are supported
+- Only Python versions 3.10 and 3.11 are supported
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip`
 
 <br/>


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/88.

Proposes the following changes to the install selector:

* disabling Python 3.9 for nightlies
* defaulting to CUDA 12.5 for stable and nightlies
* dropping CUDA 12.2 from the Docker selector

## Notes for Reviewers

### How I tested this

Followed the instructions in the README. Ran locally and saw what I expected... Python 3.9 disabled when I tried selected `Nightly`.

<img width="1074" alt="Screenshot 2024-08-27 at 1 45 02 PM" src="https://github.com/user-attachments/assets/07139df1-7837-4993-83af-17611c3d4552">

But enabled when I selected `Stable`

<img width="1069" alt="Screenshot 2024-08-27 at 1 46 06 PM" src="https://github.com/user-attachments/assets/d220da77-6b1c-41f3-8568-b03f4770e227">
