### PR TITLE
Add `nx-cugraph` Landing Page to User Guides

### DIFF
--- a/user-guide/user-guide.md
+++ b/user-guide/user-guide.md
@@ -39,7 +39,7 @@ The RAPIDS data science framework is a collection of libraries for running end-t
 
 
 **<i class="fa-light fa-chart-network"></i> Graph Analytics with [cuGraph](https://github.com/rapidsai/cugraph){: target="_blank"}**:
- Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero code-change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
+ Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero code change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
 {: .mb-8 }
 
 

--- a/user-guide/user-guide.md
+++ b/user-guide/user-guide.md
@@ -39,7 +39,7 @@ The RAPIDS data science framework is a collection of libraries for running end-t
 
 
 **<i class="fa-light fa-chart-network"></i> Graph Analytics with [cuGraph](https://github.com/rapidsai/cugraph){: target="_blank"}**:
- Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
+ Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero code-change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
 {: .mb-8 }
 
 

--- a/user-guide/user-guide.md
+++ b/user-guide/user-guide.md
@@ -39,7 +39,7 @@ The RAPIDS data science framework is a collection of libraries for running end-t
 
 
 **<i class="fa-light fa-chart-network"></i> Graph Analytics with [cuGraph](https://github.com/rapidsai/cugraph){: target="_blank"}**:
- Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero-code-change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
+ Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero code change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
 {: .mb-8 }
 
 

--- a/user-guide/user-guide.md
+++ b/user-guide/user-guide.md
@@ -39,7 +39,7 @@ The RAPIDS data science framework is a collection of libraries for running end-t
 
 
 **<i class="fa-light fa-chart-network"></i> Graph Analytics with [cuGraph](https://github.com/rapidsai/cugraph){: target="_blank"}**:
- Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero code change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
+ Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-use-networkx-graph-objects-accelerated-algorithms){: target="_blank"} to use NetworkX graph objects with accelerated algorithms. Or, use [nx-cugraph](/api/cugraph/stable/nx_cugraph/nx_cugraph/){: target="_blank"} to use the NetworkX API with a zero-code-change GPU accelerated backend. There is also a general [cuGraph Introduction](/api/cugraph/stable/basics/cugraph_intro/){: target="_blank"}.
 {: .mb-8 }
 
 


### PR DESCRIPTION
Closes https://github.com/rapidsai/graph_dl/issues/605

### Proposed Changes:

 - Adds a sentence to the RAPIDS Docs > User Guides > Graph Analytics with cuGraph section for `nx-cugraph`, with a link pointing to [this](https://docs.rapids.ai/api/cugraph/stable/nx_cugraph/nx_cugraph/) docs landing page.

![blurb](https://github.com/user-attachments/assets/7dec4419-d4e8-41b9-b559-9c4ade1dd0e3)
