### PR TITLE
add Python 3.12 support in install selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -748,7 +748,7 @@
                 */
                var supported_python_versions = this.getSupportedPythonVersions()
                if (!supported_python_versions.includes(this.active_python_ver)) {
-                   this.active_python_ver = supported_python_versions[0];
+                   this.active_python_ver = supported_python_versions[supported_python_versions.length - 1];
                }
             },
             imgTypeClickHandler(e, type) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -664,8 +664,9 @@
             getpipNotes() {
                 var notes = [];
                 var install_location_notes = "RAPIDS pip packages are hosted by NVIDIA<br>"
+                var version_string = this.getSupportedPythonVersions().map((v) => `<code>${v}</code>`).join(", ")
                 notes = [...notes, install_location_notes,
-                    'pip installation supports Python <code>3.9</code>, <code>3.10</code>, and <code>3.11</code>.<br>'];
+                    `pip installation supports the following Python versions: ${version_string}.<br>`];
 
                 return notes.map(note => this.note_prefix + " " + note);
             },
@@ -712,7 +713,7 @@
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
-                var isDisabled = getSupportedPythonVersions().includes(python_version)
+                var isDisabled = !this.getSupportedPythonVersions().includes(python_version)
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {
@@ -746,7 +747,7 @@
                     This handles that case, updating to the oldest Python version supported by the chosen release.
                 */
                var supported_python_versions = this.getSupportedPythonVersions()
-               if (!supported_python_version.includes(this.active_python_ver)) {
+               if (!supported_python_versions.includes(this.active_python_ver)) {
                    this.active_python_ver = supported_python_versions[0];
                }
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -379,9 +379,9 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.9", "3.10", "3.11"],
+            python_vers: ["3.9", "3.10", "3.11", "3.12"],
             python_vers_stable: ["3.9", "3.10", "3.11"],
-            python_vers_nightly: ["3.10", "3.11"],
+            python_vers_nightly: ["3.10", "3.11", "3.12"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
             docker_cuda_vers: ["11.8", "12.0", "12.5"],
@@ -695,6 +695,12 @@
                     return this.getpipCmdHtml();
                 return "Not implemented yet!";
             },
+            getSupportedPythonVersions() {
+                if (this.active_release === "Stable") {
+                    return this.python_vers_stable;
+                }
+                return this.python_vers_nightly;
+            },
             disableUnsupportedRelease(release) {
                 var isDisabled = false;
                 if (this.active_img_loc === "NGC" && this.active_method === "Docker" && release === "Nightly") isDisabled = true;
@@ -706,12 +712,7 @@
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
-                var isDisabled = false;
-                if (this.active_release === "Stable") {
-                    isDisabled = !this.python_vers_stable.includes(python_version)
-                } else if (this.active_release === "Nightly") {
-                    isDisabled = !this.python_vers_nightly.includes(python_version)
-                }
+                var isDisabled = getSupportedPythonVersions().includes(python_version)
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {
@@ -744,11 +745,10 @@
 
                     This handles that case, updating to the oldest Python version supported by the chosen release.
                 */
-                if (this.active_release === "Stable" && !this.python_vers_stable.includes(this.active_python_ver)) {
-                    this.active_python_ver = this.python_vers_stable[0];
-                } else if (this.active_release === "Nightly" && !this.python_vers_nightly.includes(this.active_python_ver)) {
-                    this.active_python_ver = this.python_vers_nightly[0];
-                }
+               var supported_python_versions = this.getSupportedPythonVersions()
+               if (!supported_python_version.includes(this.active_python_ver)) {
+                   this.active_python_ver = supported_python_versions[0];
+               }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;

--- a/install/install.md
+++ b/install/install.md
@@ -99,7 +99,7 @@ ERROR: No matching distribution found for cudf-cu12
 Check the suggestions below for possible resolutions:
 
 - The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
-- Ensure you're using a Python version that RAPIDS supports (compare the values in the [the install selector](#selector) to the Python version reported by `pip --version`).
+- Ensure you're using a Python version that RAPIDS supports (compare the values in the [the install selector](#selector) to the Python version reported by `python --version`).
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip`
 
 <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -98,7 +98,7 @@ ERROR: No matching distribution found for cudf-cu12
 ```
 Check the suggestions below for possible resolutions:
 - The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
-- Only Python versions 3.10 and 3.11 are supported
+- Only Python versions 3.10, 3.11, and 3.12 are supported
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip`
 
 <br/>

--- a/install/install.md
+++ b/install/install.md
@@ -97,8 +97,9 @@ ERROR: Could not find a version that satisfies the requirement cudf-cu12 (from v
 ERROR: No matching distribution found for cudf-cu12
 ```
 Check the suggestions below for possible resolutions:
+
 - The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
-- Only Python versions 3.10, 3.11, and 3.12 are supported
+- Ensure you're using a Python version that RAPIDS supports (compare the values in the [the install selector](#selector) to the Python version reported by `pip --version`).
 - RAPIDS pip packages require a recent version of pip that [supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}. Some users may need to update pip: `pip install -U pip`
 
 <br/>


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/40

We're adding Python 3.12 support in RAPIDS 24.10. This adds that support to the install selector.

## Notes for Reviewers

### How I tested this

Built and served the site locally following instructions in https://github.com/rapidsai/docs/blob/main/CONTRIBUTING.md.

Tested the following cases:

<details><summary>"Python 3.9 - 3.12 show up in the selector and Python 3.11 is the default" (click me)</summary>

<img width="1331" alt="Screenshot 2024-09-10 at 3 35 08 PM" src="https://github.com/user-attachments/assets/93b465ff-8438-410c-b693-f09f59b8a816">

</details>

<details><summary>"If you select Python 3.9 then change from `Stable` to `Nightly`, selector automatically switches to Python 3.10" (click me)</summary>

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/8e8c3985-0037-4ab0-aec6-ea4c8d15255c">

</details>

<details><summary>"if you select Python 3.12 then change from `Nightly` to `Stable`, selector automatically switches to a supported Python version" (click me)</summary>

<img width="1327" alt="image" src="https://github.com/user-attachments/assets/1c86a2b0-d6e6-4de8-8b32-6791ef2e0348">

</details>

<details><summary>"the pip support note lists the correct set of Python versions based on whether `Nightly` or `Stable` is selected" (click me)</summary>

<img width="1341" alt="Screenshot 2024-09-10 at 3 54 41 PM" src="https://github.com/user-attachments/assets/e2a19960-ab62-4ca1-bb64-07dbf5ed652a">

<img width="1326" alt="Screenshot 2024-09-10 at 3 55 21 PM" src="https://github.com/user-attachments/assets/1bfcdc88-9f4d-4baf-bcf2-2d2cf84b12c4">

</details>

### This isn't ready to merge

Not all RAPIDS nightlies yet support Python 3.12.

Blocked by:

* [x] https://github.com/rapidsai/cuml/pull/6060
* [x] https://github.com/rapidsai/cugraph/pull/4647
* [x] https://github.com/rapidsai/integration/pull/719
* [x] https://github.com/rapidsai/docker/pull/711