### PR TITLE
Fix Jekyll Routing

### DIFF
--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -39,5 +39,5 @@ dependencies instead.
 
 ## Impact
 
-See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+See our updated [release schedule]({% link maintainers/index.md %}) for
 `v0.15`

--- a/_notices/rgn0006.md
+++ b/_notices/rgn0006.md
@@ -30,5 +30,5 @@ The RAPIDS `v0.16` release date has been extended for 1 week to 2020-10-21
 
 ## Impact
 
-See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+See our updated [release schedule]({% link maintainers/index.md %}) for
 `v0.16`

--- a/_notices/rgn0008.md
+++ b/_notices/rgn0008.md
@@ -31,7 +31,7 @@ encountered in [RDN 2](/notices/rdn0002)
 
 ## Impact
 
-- See our updated [release schedule]({% link maintainers/maintainers.md %}) for
+- See our updated [release schedule]({% link maintainers/index.md %}) for
 `v0.18`
 - Refer to [RDN 2](/notices/rdn0002) for more details on gcc `7.5.0`
 from-source build changes needed in `v0.18+`

--- a/_notices/rgn0009.md
+++ b/_notices/rgn0009.md
@@ -34,4 +34,4 @@ The release is being extended in order to fix a [bug](https://github.com/rapidsa
 
 ## Impact
 
-See our updated [release schedule]({% link maintainers/maintainers.md %}) for `v0.19`
+See our updated [release schedule]({% link maintainers/index.md %}) for `v0.19`

--- a/api.md
+++ b/api.md
@@ -2,7 +2,6 @@
 layout: default
 title: API Docs
 nav_order: 4
-permalink: api
 has_toc: false
 has_children: false
 ---

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -3,7 +3,6 @@ layout: default
 title: Contributing
 nav_order: 6
 has_children: true
-permalink: contributing
 ---
 
 # Contributing

--- a/index.md
+++ b/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: Home
 nav_order: 1
-permalink: /
 description: |
   A collection of all the documentation for RAPIDS. Whether you're new to RAPIDS, looking to contribute, or are a part of the RAPIDS team, the docs here will help guide you.
 ---
@@ -15,16 +14,16 @@ This site serves to unify the documentation for RAPIDS. Whether you're new to RA
 
 ## Sections
 
-[<i class="fa-solid fa-download"></i> Installation Guide]({% link install/install.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
-[<i class="fa-solid fa-file-circle-info"></i> User Guides]({% link user-guide/user-guide.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
+[<i class="fa-solid fa-download"></i> Installation Guide]({% link install/index.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
+[<i class="fa-solid fa-file-circle-info"></i> User Guides]({% link user-guide/index.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
 <br/>
 [<i class="fa-solid fa-file-circle-info"></i> API Documentation]({% link api.md %}){: .btn.fs-4 .mb-4 .mb-md-04 .mr-2 }
-[<i class="fa-solid fa-file-circle-info"></i> Visualization Guide]({% link visualization/visualization.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
+[<i class="fa-solid fa-file-circle-info"></i> Visualization Guide]({% link visualization/index.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
 <br/>
 [<i class="fa-solid fa-file-circle-info"></i> Deployment Guides](/deployment/stable/){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
-[<i class="fa-solid fa-file-circle-info"></i> Maintainer Documentation]({% link maintainers/maintainers.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
+[<i class="fa-solid fa-file-circle-info"></i> Maintainer Documentation]({% link maintainers/index.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
 <br/>
-[<i class="fas fa-bullhorn"></i> RAPIDS Notices]({% link notices/notices.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
+[<i class="fas fa-bullhorn"></i> RAPIDS Notices]({% link notices/index.md %}){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
 [<i class="fab fa-github"></i> RAPIDS GitHub](https://github.com/rapidsai){: .btn.fs-4 .mb-4 .mb-md-4 .mr-2 }
 
 ---

--- a/install/index.md
+++ b/install/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: Installation Guide
 nav_order: 2
-permalink: install
 description: |
   Guide to installing RAPIDS
 ---

--- a/maintainers/index.md
+++ b/maintainers/index.md
@@ -3,7 +3,6 @@ layout: default
 title: Maintainer Docs
 nav_order: 6
 has_children: true
-permalink: maintainers
 ---
 
 # RAPIDS Maintainers Docs

--- a/notices/index.md
+++ b/notices/index.md
@@ -3,7 +3,6 @@ layout: notice-index
 title: RAPIDS Notices
 nav_order: 7
 has_children: true
-permalink: notices
 has_notice_pin_index: true # shows pinned notices at end
 ---
 
@@ -16,6 +15,6 @@ Notices are our means to communicate and document changes in the project to cont
 
 Type | Code | Intended Audience | Purpose
 --- | --- | --- | ---
-[RAPIDS Developer Notice]({% link notices/rdn.md %}) | **RDN** | Contributors & Core Developers | Communicate updates to development processes
-[RAPIDS General Notice]({% link notices/rgn.md %}) | **RGN** | Everyone | Project wide announcements and updates, including breaking changes
-[RAPIDS Support Notice]({% link notices/rsn.md %}) | **RSN** | Everyone | Updates on RAPIDS support for specific versions of CUDA, Python, OS, platforms, and compilers
+[RAPIDS Developer Notice]({% link notices/rdn/index.md %}) | **RDN** | Contributors & Core Developers | Communicate updates to development processes
+[RAPIDS General Notice]({% link notices/rgn/index.md %}) | **RGN** | Everyone | Project wide announcements and updates, including breaking changes
+[RAPIDS Support Notice]({% link notices/rsn/index.md %}) | **RSN** | Everyone | Updates on RAPIDS support for specific versions of CUDA, Python, OS, platforms, and compilers

--- a/notices/rdn/index.md
+++ b/notices/rdn/index.md
@@ -4,7 +4,6 @@ notice_type: rdn
 title: RAPIDS Developer Notices
 nav_order: 1
 has_children: true
-permalink: notices/rdn
 parent: RAPIDS Notices
 has_notice_index: true # shows list of notices for this 'notice_type'
 ---

--- a/notices/rgn/index.md
+++ b/notices/rgn/index.md
@@ -4,7 +4,6 @@ notice_type: rgn
 title: RAPIDS General Notices
 nav_order: 2
 has_children: true
-permalink: notices/rgn
 parent: RAPIDS Notices
 has_notice_index: true # shows list of notices for this 'notice_type'
 ---

--- a/notices/rsn/index.md
+++ b/notices/rsn/index.md
@@ -4,7 +4,6 @@ notice_type: rsn
 title: RAPIDS Support Notices
 nav_order: 3
 has_children: true
-permalink: notices/rsn
 parent: RAPIDS Notices
 has_notice_index: true # shows list of notices for this 'notice_type'
 ---

--- a/releases/index.md
+++ b/releases/index.md
@@ -4,7 +4,6 @@ title: Release Docs
 parent: Maintainer Docs
 nav_order: 6
 has_children: true
-permalink: releases
 ---
 
 # Releases

--- a/releases/schedule.md
+++ b/releases/schedule.md
@@ -26,7 +26,7 @@ Operations
 
 ## Current release
 
-The current release schedule is posted on the [RAPIDS Maintainers Docs]({% link maintainers/maintainers.md %}) page.
+The current release schedule is posted on the [RAPIDS Maintainers Docs]({% link maintainers/index.md %}) page.
 
 ## Completed Releases
 

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,7 +4,6 @@ title: Resources
 parent: Maintainer Docs
 nav_order: 6
 has_children: true
-permalink: resources
 ---
 
 # Resources

--- a/user-guide/index.md
+++ b/user-guide/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: User Guides
 nav_order: 3
-permalink: user-guide
 description: |
   Guide to Getting Started Using RAPIDS
 ---

--- a/visualization/index.md
+++ b/visualization/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: Visualization Guide
 nav_order: 5
-permalink: visualization
 ---
 
 # RAPIDS Visualization Guide


### PR DESCRIPTION
**NOTE:** These changes are necessary for #541. They are included in that PR. This PR is not meant to be merged, it only exists so that these individual changes can be viewed separately from #541.

This PR fixes some routing issues with our site. The issue stems from using the `permalink`  property on certain pages. Using `permalink` causes the generated HTML output to differ from pages that don't use it.

For example, when the `api.md` page uses `permalink: api`, the generated HTML output looks like this:

```
dist/
└── api.html
```

This causes the final webpage to be available at https://docs.rapids.ai/api (note the missing trailing slash at the end of the URL).

Compare that to the HTML output of pages that _don't_ use the `permalink` property, like `resources/auto-merger.md`:

```
dist/resources/
└── auto-merger
    └── index.html
```

The difference is that the output file is named `index.html` and placed in a directory called `auto-merger`. Webservers handle directories with `index.html` differently. Therefore, the above page is served at https://docs.rapids.ai/resources/auto-merger/ (note the trailing slash at the end of the URL).

To make all of our paths consistent (which is necessary for #541), this PR removes all `permalink` property usage and moves the affected files to the appropriate directory with a new `index.md` name.

It also updates any references to the affected files.