### PR TITLE
Add redirect for /deployment to /deployment/stable

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,3 +38,5 @@
 /api/rapids-cmake/ /api/rapids-cmake/stable/
 /api/rmm /api/rmm/stable/
 /api/rmm/ /api/rmm/stable/
+/deployment /deployment/stable/
+/deployment/ /deployment/stable/


### PR DESCRIPTION
https://docs.rapids.ai/deployment should point to https://docs.rapids.ai/deployment/stable/
