### PR TITLE
Updates for 24.10 release

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,44 @@
 [
   {
+    "version": "24.10",
+    "ucxx_version": "0.40",
+    "cudf_dev": {
+      "start": "Jul 18 2024",
+      "end": "Sep 18 2024",
+      "days": "42"
+    },
+    "other_dev": {
+      "start": "Jul 25 2024",
+      "end": "Sep 25 2024",
+      "days": "42"
+    },
+    "cudf_burndown": {
+      "start": "Sep 19 2024",
+      "end": "Sep 25 2024",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Sep 26 2024",
+      "end": "Oct 2 2024",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Sep 26 2024",
+      "end": "Oct 8 2024",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Oct 3 2024",
+      "end": "Oct 8 2024",
+      "days": "4"
+    },
+    "release": {
+      "start": "Oct 9 2024",
+      "end": "Oct 10 2024",
+      "days": "2"
+    }
+  },
+  {
     "version": "24.08",
     "ucxx_version": "0.39",
     "cudf_dev": {

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,54 +1,15 @@
 {
   "legacy": {
-    "version": "24.06",
-    "ucxx_version": "0.38",
-    "date": "Jun 6 2024"
-  },
-  "stable": {
     "version": "24.08",
     "ucxx_version": "0.39",
     "date": "Aug 8 2024"
   },
-  "nightly": {
+  "stable": {
     "version": "24.10",
     "ucxx_version": "0.40",
-    "cudf_dev": {
-      "start": "Jul 18 2024",
-      "end": "Sep 18 2024",
-      "days": "42"
-    },
-    "other_dev": {
-      "start": "Jul 25 2024",
-      "end": "Sep 25 2024",
-      "days": "42"
-    },
-    "cudf_burndown": {
-      "start": "Sep 19 2024",
-      "end": "Sep 25 2024",
-      "days": "5"
-    },
-    "other_burndown": {
-      "start": "Sep 26 2024",
-      "end": "Oct 2 2024",
-      "days": "5"
-    },
-    "cudf_codefreeze": {
-      "start": "Sep 26 2024",
-      "end": "Oct 8 2024",
-      "days": "9"
-    },
-    "other_codefreeze": {
-      "start": "Oct 3 2024",
-      "end": "Oct 8 2024",
-      "days": "4"
-    },
-    "release": {
-      "start": "Oct 9 2024",
-      "end": "Oct 10 2024",
-      "days": "2"
-    }
+    "date": "Oct 10 2024"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "24.12",
     "ucxx_version": "0.41",
     "cudf_dev": {
@@ -84,6 +45,45 @@
     "release": {
       "start": "Dec 11 2024",
       "end": "Dec 12 2024",
+      "days": "2"
+    }
+  },
+  "next_nightly": {
+    "version": "25.02",
+    "ucxx_version": "0.42",
+    "cudf_dev": {
+      "start": "Nov 14 2024",
+      "end": "Jan 22 2025",
+      "days": "43"
+    },
+    "other_dev": {
+      "start": "Nov 21 2024",
+      "end": "Jan 29 2025",
+      "days": "43"
+    },
+    "cudf_burndown": {
+      "start": "Jan 23 2025",
+      "end": "Jan 29 2025",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Jan 30 2025",
+      "end": "Feb 5 2025",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Jan 30 2025",
+      "end": "Feb 11 2025",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Feb 6 2025",
+      "end": "Feb 11 2025",
+      "days": "4"
+    },
+    "release": {
+      "start": "Feb 12 2025",
+      "end": "Feb 13 2025",
       "days": "2"
     }
   }

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -367,7 +367,7 @@
     document.addEventListener('alpine:init', () => {
         Alpine.data('rapids_selector', () => ({
             // default values
-            active_python_ver: "3.11",
+            active_python_ver: "3.12",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
             active_docker_cuda_ver: "12.5",
@@ -379,8 +379,8 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.9", "3.10", "3.11", "3.12"],
-            python_vers_stable: ["3.9", "3.10", "3.11"],
+            python_vers: ["3.10", "3.11", "3.12"],
+            python_vers_stable: ["3.10", "3.11", "3.12"],
             python_vers_nightly: ["3.10", "3.11", "3.12"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],


### PR DESCRIPTION
Updates for `24.10` release

Rotates the version json files and set new Python versions for stable on the selector.
