### PR TITLE
Enable cudf-java docs for 24.10

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -99,7 +99,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
I've uploaded the javadocs from https://repo1.maven.org/maven2/ai/rapids/cudf/24.10.1/, so just need to re-enable them with this PR so that they are available.