### PR TITLE
add automation for cudf-java docs

### DIFF
--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -63,4 +63,4 @@ jobs:
           title: ${{ inputs.new_stable_value == '1' && 'Enable' || 'Disable' }} cudf-java docs for version ${{ inputs.version }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           body: |
-            This PR updates the stable value for cudf-java in docs.yml to ${{ inputs.new_stable_value }}.
+            This PR cudf-java docs for version ${{ inputs.version }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -39,14 +39,13 @@ jobs:
           role-duration-seconds: 7200 # 2h
 
       - name: Upload cudf-java docs to S3
-        if: ${{ inputs.new_stable_value == '1' }}
         run: ci/upload_cudf_java_docs.sh ${{ inputs.version }}
 
       - name: Run script to update stable value for cudf-java in docs.yml
         env :
           NEW_STABLE_VALUE: ${{ inputs.new_stable_value }}
         run: |
-          if [ "$NEW_STABLE_VALUE" != "1" ] && [ "$NEW_STABLE_VALUE" != "0" ]; then
+          if [ "$NEW_STABLE_VALUE" != "1" ]; then
             echo "Invalid value for new_stable_value: $NEW_STABLE_VALUE"
             exit 1
           fi
@@ -61,7 +60,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update stable value for cudf-java in docs.yml"
           branch: "update-stable-value-for-cudf-java"
-          title: ${{ inputs.new_stable_value == '1' && 'Enable' || 'Disable' }} cudf-java docs for version ${{ inputs.version }}
+          title: Enable cudf-java docs for version ${{ inputs.version }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           body: |
-            This PR ${{ inputs.new_stable_value == '1' && 'enables' || 'disables' }} cudf-java docs for version ${{ inputs.version }}.
+            This PR enables cudf-java docs for version ${{ inputs.version }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -1,0 +1,66 @@
+name: Deploy cudf-java docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_stable_value:
+        description: "New stable value for cudf-java"
+        required: true
+        default: "1"
+      version:
+        description: "Version being released. Format: YY.MM or YY.MM.P e.g 24.08 or 24.08.1"
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-cudf-java-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 7200 # 2h
+
+      - name: Upload cudf-java docs to S3
+        run: ci/upload_cudf_java_docs.sh ${{ inputs.version }}
+
+      - name: Run script to update stable value for cudf-java in docs.yml
+        env :
+          NEW_STABLE_VALUE: ${{ inputs.new_stable_value }}
+        run: |
+          if [ "$NEW_STABLE_VALUE" != "1" ] && [ "$NEW_STABLE_VALUE" != "0" ]; then
+            echo "Invalid value for new_stable_value: $NEW_STABLE_VALUE"
+            exit 1
+          fi
+
+          sed -i '/cudf-java:/,/stable:/s/stable: .*/stable: '"$NEW_STABLE_VALUE"'/' _data/docs.yml
+
+          echo "Updated stable value for cudf-java to $NEW_STABLE_VALUE in _data/docs.yml"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update stable value for cudf-java in docs.yml"
+          branch: "update-stable-value-for-cudf-java"
+          title: "Enable cudf-java docs for version ${{ inputs.version }}"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          body: |
+            This PR updates the stable value for cudf-java in docs.yml to ${{ inputs.new_stable_value }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -61,6 +61,6 @@ jobs:
           commit-message: "Update stable value for cudf-java in docs.yml"
           branch: "update-stable-value-for-cudf-java"
           title: "Enable cudf-java docs for version ${{ inputs.version }}"
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           body: |
             This PR updates the stable value for cudf-java in docs.yml to ${{ inputs.new_stable_value }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -60,7 +60,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update stable value for cudf-java in docs.yml"
           branch: "update-stable-value-for-cudf-java"
-          title: "Enable cudf-java docs for version ${{ inputs.version }}"
+          title: ${{ inputs.new_stable_value == '1' && 'Enable' || 'Disable' }} cudf-java docs for version ${{ inputs.version }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           body: |
             This PR updates the stable value for cudf-java in docs.yml to ${{ inputs.new_stable_value }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -39,6 +39,7 @@ jobs:
           role-duration-seconds: 7200 # 2h
 
       - name: Upload cudf-java docs to S3
+        if: ${{ inputs.new_stable_value == '1' }}
         run: ci/upload_cudf_java_docs.sh ${{ inputs.version }}
 
       - name: Run script to update stable value for cudf-java in docs.yml

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -64,4 +64,4 @@ jobs:
           title: ${{ inputs.new_stable_value == '1' && 'Enable' || 'Disable' }} cudf-java docs for version ${{ inputs.version }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           body: |
-            This PR cudf-java docs for version ${{ inputs.version }}.
+            This PR ${{ inputs.new_stable_value == '1' && 'enables' || 'disables' }} cudf-java docs for version ${{ inputs.version }}.

--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -45,6 +45,7 @@ main() {
     wget "$url"
     unzip cudf-*-javadoc.jar -d cudf-docs
     aws s3 sync --delete cudf-docs/ "s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
+    echo "Documentation successfully uploaded to s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
 }
 
 main "$@"

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -37,11 +37,6 @@ main() {
 
     local url="https://repo1.maven.org/maven2/ai/rapids/cudf/${major}.${minor}.${patch}/cudf-${major}.${minor}.${patch}-javadoc.jar"
 
-    if ! wget --spider "$url" 2>/dev/null; then
-        echo "Error: Documentation not found at $url" >&2
-        exit 1
-    fi
-
     wget "$url"
     unzip cudf-*-javadoc.jar -d cudf-docs
     aws s3 sync --delete cudf-docs/ "s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -11,13 +11,7 @@ validate_version() {
     fi
 }
 
-cleanup() {
-    rm -rf cudf-*-javadoc.jar cudf-docs 2>/dev/null || true
-}
-
 main() {
-    trap cleanup EXIT
-
     if [ $# -ne 1 ]; then
         echo "Usage: $0 <version>"
         echo "Version format: YY.MM or YY.MM.P"
@@ -37,9 +31,11 @@ main() {
 
     local url="https://repo1.maven.org/maven2/ai/rapids/cudf/${major}.${minor}.${patch}/cudf-${major}.${minor}.${patch}-javadoc.jar"
 
-    wget "$url"
-    unzip cudf-*-javadoc.jar -d cudf-docs
-    aws s3 sync --delete cudf-docs/ "s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
+    TMP_FILE=$(mktemp)
+    TMP_DIR=$(mktemp -d)
+    wget -O "${TMP_FILE}" "$url"
+    unzip "${TMP_FILE}" -d "${TMP_DIR}"
+    aws s3 sync --delete "${TMP_DIR}"/ "s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
     echo "Documentation successfully uploaded to s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
 }
 

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -35,7 +36,7 @@ main() {
     patch=${patch:-0} # handle patch values like 00
 
     local url="https://repo1.maven.org/maven2/ai/rapids/cudf/${major}.${minor}.${patch}/cudf-${major}.${minor}.${patch}-javadoc.jar"
-    
+
     if ! wget --spider "$url" 2>/dev/null; then
         echo "Error: Documentation not found at $url" >&2
         exit 1

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+validate_version() {
+    local version=$1
+    if ! [[ $version =~ ^[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$ ]]; then
+        echo "Error: Version must be in format YY.MM or YY.MM.P" >&2
+        return 1
+    fi
+}
+
+cleanup() {
+    rm -rf cudf-*-javadoc.jar cudf-docs 2>/dev/null || true
+}
+
+main() {
+    trap cleanup EXIT
+
+    if [ $# -ne 1 ]; then
+        echo "Usage: $0 <version>"
+        echo "Version format: YY.MM or YY.MM.P"
+        echo "Examples: 23.12, 24.02, 23.12.1"
+        exit 1
+    fi
+
+    DOCS_VERSION=$1
+    if ! validate_version "$DOCS_VERSION"; then
+        exit 1
+    fi
+
+    IFS='.' read -r major minor patch <<< "$DOCS_VERSION"
+    patch=${patch:-0} # when no patch is given, use 0
+    patch=$(echo "$patch" | sed 's/^0*//') # strip leading zeros if present
+    patch=${patch:-0} # handle patch values like 00
+
+    local url="https://repo1.maven.org/maven2/ai/rapids/cudf/${major}.${minor}.${patch}/cudf-${major}.${minor}.${patch}-javadoc.jar"
+    
+    if ! wget --spider "$url" 2>/dev/null; then
+        echo "Error: Documentation not found at $url" >&2
+        exit 1
+    fi
+
+    wget "$url"
+    unzip cudf-*-javadoc.jar -d cudf-docs
+    aws s3 sync --delete cudf-docs/ "s3://rapidsai-docs/cudf-java/html/${DOCS_VERSION}/"
+}
+
+main "$@"


### PR DESCRIPTION
- Adds script to upload the new docs to `s3`
- Adds a workflow to automate the upload and PR creation.

Tested here:
- https://github.com/rapidsai/literate-octo-potato/pull/850

I tested (using the `literate-octo-potato` repository) that:

- AWS credentials are correctly assigned through OIDC (all repos in `rapidsai` have access to the `rapidsai-docs` bucket via [this line](https://github.com/rapidsai/cloud-infrastructure/blob/main/gh-oidc/main.tf#L34))
- (locally) The `upload_cudf_java_docs.sh` script works correctly
- The find and replace logic to enable the stable docs version for cudf-java works correctly
- The pull request is correctly created. (e.g https://github.com/rapidsai/literate-octo-potato/pull/850)