### PR TITLE
Declare Linux support via glibc versions

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -68,13 +68,13 @@ If conda has incorrectly identified the CUDA driver, you can [override by settin
 ### **Docker Issues**
 <i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brought significant Docker changes. <br/>
 To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/base){: target="_blank"}. Some key notes below:
-- `Development` images are no longer being published, in the coming releases RAPIDS will roll out [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
+- `Development` images are no longer being published, RAPIDS now uses [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
   - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
-  - CUDA 12.5+ images are Ubuntu `24.04`
-  - All other images are Ubuntu `22.04`
+  - CUDA 12.5+ images use Ubuntu 24.04
+  - All other images use Ubuntu 22.04
 - All images are multiarch (x86_64 and ARM)
-- The `Base` image starts in an ipython shell
+- The `base` image starts in an ipython shell
   - To run bash commands inside the ipython shell prefix the command with `!`
   - To run the image without the ipython shell add `/bin/bash` to the end of the `docker run` command
 - For a full list of changes please see this [RAPIDS Docker Issue](https://github.com/rapidsai/docker/issues/539){: target="_blank"}
@@ -289,7 +289,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 ### **WSL2 Additional Prerequisites**
 
-<i class="fas fa-desktop text-white"></i> **OS:** Windows 11 with Ubuntu 22.04 instance for WSL2. <br/>
+<i class="fas fa-desktop text-white"></i> **OS:** Windows 11 with a WSL2 installation of Ubuntu (minimum version 20.04). <br/>
 <i class="fas fa-info-circle text-white"></i> **WSL Version:** WSL2 (WSL1 not supported). <br/>
 <i class="fas fa-microchip text-white"></i> **GPU:** GPUs with [Compute Capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0 or higher (16GB+ GPU RAM is recommended).
 
@@ -315,7 +315,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 ### **WSL2 Conda Install (Preferred Method)**
 
-1. Install WSL2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL2 and the Ubuntu distribution [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
 4. Install Conda in the WSL2 Linux Instance using our [Conda instructions](#conda).
@@ -331,7 +331,7 @@ print(cudf.Series([1, 2, 3]))
 
 ### **WSL2 Docker Desktop Install**
 
-1. Install WSL2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL2 and the Ubuntu distribution [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Install latest Docker Desktop for Windows
 4. Log in to the WSL2 Linux instance.
@@ -347,7 +347,7 @@ print(cudf.Series([1, 2, 3]))
 
 ### **WSL2 pip Install**
 
-1. Install WSL2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL2 and the Ubuntu distribution [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
 4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then install the WSL-specific [CUDA 11](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} or [CUDA 12](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} Toolkit without drivers into the WSL2 instance.

--- a/install/index.md
+++ b/install/index.md
@@ -140,7 +140,6 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
   - [Rocky Linux](https://rockylinux.org/) / [Alma Linux](https://almalinux.org/) / [RHEL](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux), minimum version 8
   - [Ubuntu](https://ubuntu.com/), minimum version 20.04
 - <i class="fas fa-check-circle"></i> Windows 11 using a [WSL2 specific install](#wsl2)
-- <i class="fas fa-check-circle"></i> RHEL 7/8 support is provided through Rocky Linux 8 builds/installs
 
 <i class="fas fa-download text-purple"></i> **CUDA & NVIDIA Drivers:** One of the following supported versions:
 {: .no-tb-margins }
@@ -151,6 +150,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 - <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
 - <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive){: target="_blank"} with Driver 525.60.13 or newer **see CUDA 12 section below for notes on usage**
 - <i class="fas fa-check-circle"></i> [CUDA 12.2](https://developer.nvidia.com/cuda-12-2-2-download-archive){: target="_blank"} with Driver 535.86.10 or newer **see CUDA 12 section below for notes on usage**
+- <i class="fas fa-check-circle"></i> [CUDA 12.5](https://developer.nvidia.com/cuda-12-5-1-download-archive){: target="_blank"} with Driver 555.42.06 or newer **see CUDA 12 section below for notes on usage**
 
  **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details.
 
@@ -158,8 +158,8 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 ### **Docker and Conda**
 
-- <i class="fas fa-info-circle"></i> Stable CUDA 12 conda packages and Docker images currently support CUDA 12.0. Additionally, nightly versions now support CUDA 12.2
-- <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit
+- <i class="fas fa-info-circle"></i> conda packages and Docker images support CUDA 12 on systems with a CUDA 12 driver.
+- <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit.
 
 ### **pip**
 

--- a/install/index.md
+++ b/install/index.md
@@ -71,7 +71,7 @@ To learn more about these changes, please see the [RAPIDS Container README](http
 - `Development` images are no longer being published, in the coming releases RAPIDS will roll out [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
   - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
-  - CUDA 11.2 images are Ubuntu `20.04`
+  - CUDA 12.5+ images are Ubuntu `24.04`
   - All other images are Ubuntu `22.04`
 - All images are multiarch (x86_64 and ARM)
 - The `Base` image starts in an ipython shell
@@ -131,8 +131,14 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 <i class="fas fa-microchip"></i> **GPU:** NVIDIA Volta™ or higher with [compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0+
 - <i class="fas fa-exclamation-triangle"></i> Pascal™ GPU support was [removed in 24.02](https://docs.rapids.ai/notices/rsn0034/). Compute capability 7.0+ is required for RAPIDS 24.02 and later.
 
-<i class="fas fa-desktop"></i> **OS:** One of the following OS versions:
-- <i class="fas fa-check-circle"></i> Ubuntu 20.04/22.04 or Rocky Linux 8 with <code>gcc/++</code> 9.0+
+<i class="fas fa-desktop"></i> **OS:**
+- <i class="fas fa-check-circle"></i> Linux distributions with `glibc>=2.28` (released in August 2018), which include the following:
+  - [Arch Linux](https://archlinux.org/), minimum version 2018-08-02
+  - [Debian](https://www.debian.org/), minimum version 10.0
+  - [Fedora](https://fedoraproject.org/), minimum version 29
+  - [Linux Mint](https://linuxmint.com/), minimum version 20
+  - [Rocky Linux](https://rockylinux.org/) / [Alma Linux](https://almalinux.org/) / [RHEL](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux), minimum version 8
+  - [Ubuntu](https://ubuntu.com/), minimum version 20.04
 - <i class="fas fa-check-circle"></i> Windows 11 using a [WSL2 specific install](#wsl2)
 - <i class="fas fa-check-circle"></i> RHEL 7/8 support is provided through Rocky Linux 8 builds/installs
 

--- a/install/index.md
+++ b/install/index.md
@@ -24,7 +24,7 @@ RAPIDS has several methods for installation, depending on the preferred environm
 - [Conda](#conda)
 - [Docker](#docker)
 - [pip](#pip)
-- [Within WSL2](#wsl2)
+- [Windows WSL2](#wsl2)
   - [Conda](#wsl2-conda)
   - [Docker](#wsl2-docker)
   - [pip](#wsl2-pip)


### PR DESCRIPTION
This PR clarifies that RAPIDS is supported on Linux distributions with glibc >= 2.28. This is more inclusive than limiting to only the distributions in our CI matrix, as there are many flavors of Linux that are functionally similar for the needs of RAPIDS.
