### PR TITLE
Quote packages so shells don't get unhappy

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -586,6 +586,8 @@
                     pkgs.push(["\"dask-cuda" + cuda_suffix.slice(5)])
                 }
 
+                pkgs = pkgs.flatMap(pkg => '"' + pkg + '"');
+
                 // For every n packages add a new line with a "\" character
                 // We need i += n + 1 since the splice adds a new element to the array
                 if (this.active_release === "Stable") {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -556,14 +556,14 @@
                 else {
                     index_url = `--${this.highlightFlag("extra-index-url")}=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple`;
                     var version = this.removeLeadingZeros("{{ site.data.releases.nightly.version }}")
-                    cuda_suffix = cuda_suffix + `>=${version}.0a0,<=${version}"`;
+                    cuda_suffix = cuda_suffix + `>=${version}.0a0,<=${version}`;
                     var libraryToPkg = (pkg) => {
                         pkg = pkg.toLowerCase();
-                        if (pkg === "cuspatial/cuproj") return ["\"cuspatial" + cuda_suffix, "\"cuproj" + cuda_suffix];
-                        if (pkg === "raft") return ["\"pylibraft" + cuda_suffix, "\"raft-dask" + cuda_suffix];
-                        if (pkg === "cuvs") return ["\"cuvs" + cuda_suffix, "\"pylibraft" + cuda_suffix];
-                        if (pkg === "cugraph/nx-cugraph") return ["\"cugraph" + cuda_suffix, "\"nx-cugraph" + cuda_suffix];
-                        return ["\"" + pkg + cuda_suffix];
+                        if (pkg === "cuspatial/cuproj") return ["cuspatial" + cuda_suffix, "cuproj" + cuda_suffix];
+                        if (pkg === "raft") return ["pylibraft" + cuda_suffix, "raft-dask" + cuda_suffix];
+                        if (pkg === "cuvs") return ["cuvs" + cuda_suffix, "pylibraft" + cuda_suffix];
+                        if (pkg === "cugraph/nx-cugraph") return ["cugraph" + cuda_suffix, "nx-cugraph" + cuda_suffix];
+                        return ["" + pkg + cuda_suffix];
                     }
                 }
 
@@ -583,9 +583,10 @@
 
                 // pkgs.length == 2 because it includes the "Choose Specific Packages" option
                 if (this.active_release === "Nightly" && !(pkgs.length === 2 && pkgs[0] === "cucim")) {
-                    pkgs.push(["\"dask-cuda" + cuda_suffix.slice(5)])
+                    pkgs.push(["dask-cuda" + cuda_suffix.slice(5)])
                 }
 
+                // Make sure all packages (and version selectors) are quoted
                 pkgs = pkgs.flatMap(pkg => '"' + pkg + '"');
 
                 // For every n packages add a new line with a "\" character

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -563,7 +563,7 @@
                         if (pkg === "raft") return ["pylibraft" + cuda_suffix, "raft-dask" + cuda_suffix];
                         if (pkg === "cuvs") return ["cuvs" + cuda_suffix, "pylibraft" + cuda_suffix];
                         if (pkg === "cugraph/nx-cugraph") return ["cugraph" + cuda_suffix, "nx-cugraph" + cuda_suffix];
-                        return ["" + pkg + cuda_suffix];
+                        return [pkg + cuda_suffix];
                     }
                 }
 


### PR DESCRIPTION
This attempts to fix #560

This moves the quoting to the end of `getpipCmdHtml` and always applies it. Previously only the nightly version got quoted. but it required a leading `"` in each package name and a closing `"` in the CUDA suffix.

I clicked through a few combinations of things for the `pip` option. As far as I can tell it works for all of them