### PR TITLE
add `ci` to options for label checker categories

### DIFF
--- a/resources/label-checker.md
+++ b/resources/label-checker.md
@@ -34,6 +34,7 @@ In order for the _Label Checker_ check to pass, pull requests must include **one
 
 - `category` - categorizes the pull request
   - `bug`
+  - `ci`
   - `doc`
   - `feature request`
   - `improvement`


### PR DESCRIPTION
I opened a PR over on `dask-cuda` and didn't see a `ci` label listed as an option to pass the `label-checker`, but it seems like it does exist.

Not sure if it's universal across RAPIDS repos, but if it is, it should be added to this page.
