### PR TITLE
Add redirect rule for /libucxx to /libucxx/stable

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -40,3 +40,5 @@
 /api/rmm/ /api/rmm/stable/
 /deployment /deployment/stable/
 /deployment/ /deployment/stable/
+/api/libucxx /api/libucxx/stable/
+/api/libucxx/ /api/libucxx/stable/


### PR DESCRIPTION
https://docs.rapids.ai/api/libucxx should point to https://docs.rapids.ai/api/libucxx/stable/