### PR TITLE
Enable librmm download and publishing

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -172,6 +172,17 @@ apis:
 # RAPIDS "Libs" - lower-level libraries that are building blocks for creating
 #                 custom tools and integrate with other libraries
 libs:
+  librmm:
+    name: librmm
+    path: librmm
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
+    ghlink: https://github.com/rapidsai/rmm
+    cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
   libcudf:
     name: libcudf
     path: libcudf

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -178,6 +178,7 @@ libs:
     desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
+    hidden: true
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -1,5 +1,6 @@
 {% for lib in include.data %}
 {% assign api = lib[1] %}
+{% if api.name != "librmm" %}
 {% comment %} HACK: below operation returns an array of stable/nightly/legacy values only if they're enabled in docs.yml. see issue #97 {% endcomment %}
 {% assign versions = api.versions | sort | where_exp: "item", "item[1] == 1" | join: "" | split: "1" | reverse %}
 ### {{ api.name }}
@@ -7,4 +8,5 @@
 #### DOCS {% for version_name in versions %} {% if api.name == "libucxx" %} **[{{ version_name }} ({{ site.data.releases[version_name].ucxx_version }})](/api/{{ api.path }}/{{ version_name }})** {% else %} **[{{ version_name }} ({{ site.data.releases[version_name].version }})](/api/{{ api.path }}/{{ version_name }})** {% endif %} {% unless forloop.last %}|{% endunless %} {% endfor %}
 #### LINKS {% if api.cllink %} **[changelog]({{ api.cllink }}){:target="_blank"}** | {% endif %} **[github]({{ api.ghlink }}){:target="_blank"}**
 {: .mb-7 }
+{% endif %}
 {% endfor %}

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -1,6 +1,6 @@
 {% for lib in include.data %}
 {% assign api = lib[1] %}
-{% if api.name != "librmm" %}
+{% if api.hidden != true %}
 {% comment %} HACK: below operation returns an array of stable/nightly/legacy values only if they're enabled in docs.yml. see issue #97 {% endcomment %}
 {% assign versions = api.versions | sort | where_exp: "item", "item[1] == 1" | join: "" | split: "1" | reverse %}
 ### {{ api.name }}


### PR DESCRIPTION
`librmm` docs were previously [removed](https://github.com/rapidsai/docs/pull/517) but now need to be added back because crosslinks from `libcudf` currently `404`. See [here](https://github.com/rapidsai/docs/pull/517#issuecomment-2221045326).

The `librmm` entry will not be listed in https://docs.rapids.ai/api/ but will continue to be deployed to the website so that crosslinks from `libcudf` can continue to function.