### PR TITLE
Replace `conda-mambabuild`with `conda-build`

### DIFF
--- a/resources/github-actions.md
+++ b/resources/github-actions.md
@@ -187,7 +187,7 @@ LIBCUMLPRIMS_CHANNEL=$(rapids-get-pr-conda-artifact cumlprims_mg 129 cpp)
 
 # Build library packages with the CI artifact channels providing the updated dependencies
 
-rapids-mamba-retry mambabuild \
+rapids-conda-retry build \
     --channel "${LIBRMM_CHANNEL}" \
     --channel "${LIBRAFT_CHANNEL}" \
     --channel "${LIBCUMLPRIMS_CHANNEL}" \


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149