### PR TITLE
Stop publishing cuspatial packages - v25.06

### DIFF
--- a/_notices/rsn0043.md
+++ b/_notices/rsn0043.md
@@ -1,0 +1,35 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 43 # should match notice number
+notice_pin: true # set to true to pin to notice page
+
+title: "Dropping of Publishing cuSpatial Packages in RAPIDS Release v25.06 "
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v24.10+"
+notice_created: 2025-04-09
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-04-09
+---
+
+## Overview
+
+RAPIDS is will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuspatial repository will be paused and no new packages will be published. 
+
+
+## Impact
+
+Development for the cuspatial repository will be paused and no new packages will be published.

--- a/_notices/rsn0045.md
+++ b/_notices/rsn0045.md
@@ -27,9 +27,9 @@ notice_updated: 2025-04-09
 
 ## Overview
 
-RAPIDS will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuspatial repository will be paused and no new packages will be published.
+RAPIDS will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuSpatial repository will be paused and no new packages will be published.
 
 ## Impact
 
-Development for the cuspatial repository will be paused and no new packages will be published.
+Development for the cuSpatial repository will be paused and no new packages will be published.
 cuSpatial will be dropped from the `rapids` conda metapackage and RAPIDS Docker containers.

--- a/_notices/rsn0045.md
+++ b/_notices/rsn0045.md
@@ -19,7 +19,7 @@ notice_status_color: yellow
 #   "In Progress" - "yellow"
 #   "Closed" - "red"
 notice_topic: Platform Support Change
-notice_rapids_version: "v24.10+"
+notice_rapids_version: "v25.06+"
 notice_created: 2025-04-09
 # 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2025-04-09

--- a/_notices/rsn0045.md
+++ b/_notices/rsn0045.md
@@ -27,9 +27,9 @@ notice_updated: 2025-04-09
 
 ## Overview
 
-RAPIDS is will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuspatial repository will be paused and no new packages will be published. 
-
+RAPIDS will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuspatial repository will be paused and no new packages will be published.
 
 ## Impact
 
 Development for the cuspatial repository will be paused and no new packages will be published.
+cuSpatial will be dropped from the `rapids` conda metapackage and RAPIDS Docker containers.

--- a/_notices/rsn0045.md
+++ b/_notices/rsn0045.md
@@ -5,10 +5,10 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
-notice_id: 43 # should match notice number
+notice_id: 45 # should match notice number
 notice_pin: true # set to true to pin to notice page
 
-title: "Dropping of Publishing cuSpatial Packages in RAPIDS Release v25.06 "
+title: "Dropping of Publishing cuSpatial Packages in RAPIDS Release v25.06"
 notice_author: RAPIDS TPM
 notice_status: In Progress
 notice_status_color: yellow


### PR DESCRIPTION
RAPIDS is will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025