### PR TITLE
Temporarily disable 25.06 cugraph docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -45,7 +45,7 @@ apis:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
-      nightly: 1
+      nightly: 0
   cuxfilter:
     name: cuxfilter
     path: cuxfilter


### PR DESCRIPTION
`cugraph` `25.06` are not building quite yet, so just temporarily disabling them so we can publish all of the other repo docs.
