### PR TITLE
docs: selector shows channel priority warning for CUDA 11 installs

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -657,7 +657,10 @@
             },
             getCondaNotes() {
                 var notes = [];
-                notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
+                if (this.active_conda_cuda_ver.startsWith("11")) {
+                    notes = [...notes, "RAPIDS on CUDA 11 currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
+                }
+
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -658,7 +658,7 @@
             getCondaNotes() {
                 var notes = [];
                 if (this.active_conda_cuda_ver.startsWith("11")) {
-                    notes = [...notes, "RAPIDS on CUDA 11 currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
+                    notes = [...notes, "RAPIDS on CUDA 11 doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 }
 
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {

--- a/install/index.md
+++ b/install/index.md
@@ -215,7 +215,13 @@ bash Miniforge3-$(uname)-$(uname -m).sh
 
 **3. Start Conda.** Open a new terminal window, which should now show Conda initialized.
 
-**4. Check Conda Configuration.** Installing RAPIDS requires you to use `channel_priority: flexible`. You can check this and change it, if required, by doing:
+**4. Check Conda Configuration.** Installing RAPIDS may require you to use `channel_priority: flexible`.
+
+If you are installing RAPIDS with CUDA 12 or greater, then you can use either strict or flexible channel priority.
+
+If you are install RAPIDS with CUDA 11, then you must set `channel_priority: flexible`.
+
+You can check this and change it, if required, by doing:
 ```sh
 conda config --show channel_priority
 conda config --set channel_priority flexible

--- a/install/index.md
+++ b/install/index.md
@@ -217,7 +217,7 @@ bash Miniforge3-$(uname)-$(uname -m).sh
 
 **4. Check Conda Configuration.** Installing RAPIDS may require you to use `channel_priority: flexible`.
 
-If you are installing RAPIDS with CUDA 12 or greater, then you can use either strict or flexible channel priority.
+If you are installing RAPIDS with CUDA 12 or greater, then you can use either `strict` or `flexible` channel priority.
 
 If you are install RAPIDS with CUDA 11, then you must set `channel_priority: flexible`.
 


### PR DESCRIPTION
Strict channel priority now works with RAPIDS installs on CUDA 12.  This PR changes the warning about channel priority to only appear if a user clicks the `CUDA 11` button.

Here's a local version of the Selector with these changes:

![image](https://github.com/user-attachments/assets/ac54b2c4-5ff7-4b11-8492-34292b5c1eda)

![image](https://github.com/user-attachments/assets/4499fcd0-b47d-4bfe-93c3-8e4712a92bd2)
