### PR TITLE
Pin cuml-cpu drop notice

### DIFF
--- a/_notices/rgn0030.md
+++ b/_notices/rgn0030.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rgn
 # Update meta-data for notice
 notice_id: 30 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "RAPIDS v23.10 Hotfix for cuDF"
 notice_author: RAPIDS TPM
 notice_status: Completed

--- a/_notices/rsn0030.md
+++ b/_notices/rsn0030.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 30 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Docker Image Changes in Release v23.08"
 notice_author: RAPIDS TPM
 notice_status: Completed

--- a/_notices/rsn0033.md
+++ b/_notices/rsn0033.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 33 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Dropping Support for Ubuntu 20.04 arm64 containers in Release v23.06"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0034.md
+++ b/_notices/rsn0034.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 34 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Deprecation announcement for Pascal GPU support in Release v23.12"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0035.md
+++ b/_notices/rsn0035.md
@@ -6,7 +6,7 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 35 # should match notice number
-notice_pin: true # set to true to pin to notice page
+notice_pin: false # set to true to pin to notice page
 title: "Deprecation Announcement Dropping CUDA 11.2 support in our Docker Images in Release v23.12"
 notice_author: RAPIDS Ops
 notice_status: Completed

--- a/_notices/rsn0043.md
+++ b/_notices/rsn0043.md
@@ -6,10 +6,11 @@ nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
 notice_id: 43 # should match notice number
-notice_pin: false # set to true to pin to notice page
+notice_pin: true # set to true to pin to notice page
+
 title: "Deprecation of cuml-cpu in favor of cuml.accel"
 notice_author: RAPIDS Ops
-notice_status: yellow
+notice_status: In Progress
 notice_status_color: yellow
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"


### PR DESCRIPTION
We usually pin notices for dropping library/platform support but didn't pin this one for cuml-cpu. This PR adds it to the pinned notices.

Also I unpinned notices for releases prior to 2024.