### PR TITLE
Disable cuSpatial nightly packages and docs.

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -67,7 +67,7 @@ apis:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
-      nightly: 1
+      nightly: 0
   cuproj:
     name: cuProj
     path: cuProj
@@ -78,7 +78,7 @@ apis:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
-      nightly: 1
+      nightly: 0
   cusignal:
     name: cusignal
     path: cusignal
@@ -205,7 +205,7 @@ libs:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
-      nightly: 1
+      nightly: 0
   libcuproj:
     name: libcuproj
     path: libcuproj

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -803,6 +803,11 @@
                if (!supported_docker_cuda_versions.includes(this.active_docker_cuda_ver)) {
                    this.active_docker_cuda_ver = supported_docker_cuda_versions[supported_docker_cuda_versions.length - 1];
                }
+
+               /* Remove cuSpatial/cuProj from active packages if in Nightly */
+               if (this.active_release === "Nightly") {
+                   this.active_packages = this.active_packages.filter(pkg => pkg !== "cuSpatial/cuProj");
+               }
             },
             imgTypeClickHandler(e, type) {
                 if (this.isDisabled(e.target)) return;

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -756,6 +756,9 @@
             },
             disableUnsupportedPackage(package) {
                 var isDisabled = false;
+                if (this.active_release === "Nightly" && package === "cuSpatial/cuProj") {
+                    isDisabled = true;
+                }
                 return isDisabled;
             },
             isDisabled(e) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -317,7 +317,7 @@
                         <div class="option-label"><!-- Second row of packages --></div>
                         <template x-for="package in additional_pip_packages">
                             <div x-on:click="(e) => packagesClickHandler(e, package)"
-                                x-bind:class="{'active': active_packages.includes(package)}" class="option"
+                                x-bind:class="{'active': active_packages.includes(package), 'disabled': disableUnsupportedPackage(package)}" class="option"
                                 x-text="package"></div>
                         </template>
                     </div>

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -572,7 +572,15 @@
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Choose Specific Packages") {
                     return "Select at least one package.";
                 } else if (this.active_packages[0] === 'Standard') {
-                    var pkgs = this.additional_pip_packages.flatMap(libraryToPkg);
+                    var pkgs_to_show = this.additional_pip_packages;
+
+                    // Hide cuSpatial and cuProj for Nightly
+                    if (this.active_release === "Nightly") {
+                        pkgs_to_show = pkgs_to_show.filter(pkg => pkg !== "cuSpatial" && pkg !== "cuProj");
+                    }
+
+                    var pkgs = pkgs_to_show.flatMap(libraryToPkg);
+
                     var additional_pip_commands = libraryToPkg("nx-cugraph");
                     pkgs = pkgs.concat(additional_pip_commands);
                 } else {
@@ -644,16 +652,16 @@
             },
             getDockerNotes() {
                 var notes = [];
-                if (this.active_docker_cuda_ver.startsWith("12") && this.active_release === "Stable") {
-                    var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    notes = [...notes]
-                } else {
-                    var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
+                var pkgs_to_show = this.rapids_meta_pkgs;
+
+                // Hide cuSpatial and cuProj for Nightly
+                if (this.active_release === "Nightly") {
+                    pkgs_to_show = pkgs_to_show.filter(pkg => pkg !== "cuSpatial" && pkg !== "cuProj");
                 }
 
+                var pkgs_html = pkgs_to_show.map(pkg => "<code>" + pkg + "</code>").join(", ");
                 notes = [...notes, "The selected image contains the following packages:<br>" + pkgs_html];
                 return notes.map(note => this.note_prefix + " " + note);
-
             },
             getCondaNotes() {
                 var notes = [];
@@ -661,8 +669,15 @@
                     notes = [...notes, "RAPIDS on CUDA 11 doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 }
 
+                var pkgs_to_show = this.rapids_meta_pkgs;
+
+                // Hide cuSpatial and cuProj for Nightly
+                if (this.active_release === "Nightly") {
+                    pkgs_to_show = pkgs_to_show.filter(pkg => pkg !== "cuSpatial" && pkg !== "cuProj");
+                }
+
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
-                    var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
+                    var pkgs_html = pkgs_to_show.map(pkg => "<code>" + pkg + "</code>").join(", ");
                     notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
                 }
 

--- a/install/index.md
+++ b/install/index.md
@@ -71,7 +71,7 @@ If conda has incorrectly identified the CUDA driver, you can [override by settin
 <i class="fas fa-exclamation-triangle"></i> RAPIDS `23.08` brought significant Docker changes. <br/>
 To learn more about these changes, please see the [RAPIDS Container README](https://hub.docker.com/r/rapidsai/base){: target="_blank"}. Some key notes below:
 - `Development` images are no longer being published, RAPIDS now uses [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers){: target="_blank"} for development
-  - See cuSpatial for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cuspatial/tree/main/.devcontainer){: target="_blank"}
+  - See cuDF for an example and information on [RAPIDS' usage of Dev Containers](https://github.com/rapidsai/cudf/tree/main/.devcontainer){: target="_blank"}
 - All images are Ubuntu-based
   - CUDA 12.5+ images use Ubuntu 24.04
   - All other images use Ubuntu 22.04


### PR DESCRIPTION
cuSpatial will not be published in 25.06: https://docs.rapids.ai/notices/rsn0045/

This PR drops cuSpatial from the nightly package selector and nightly docs.
