### PR TITLE
feat: add Python 3.13 to selector and make it the new default

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -367,7 +367,7 @@
     document.addEventListener('alpine:init', () => {
         Alpine.data('rapids_selector', () => ({
             // default values
-            active_python_ver: "3.13",
+            active_python_ver: "3.12",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
             active_docker_cuda_ver: "12.8",
@@ -380,7 +380,7 @@
 
             // all possible values
             python_vers: ["3.10", "3.11", "3.12", "3.13"],
-            python_vers_stable: ["3.10", "3.11", "3.12", "3.13"],
+            python_vers_stable: ["3.10", "3.11", "3.12"],
             python_vers_nightly: ["3.10", "3.11", "3.12", "3.13"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -367,7 +367,7 @@
     document.addEventListener('alpine:init', () => {
         Alpine.data('rapids_selector', () => ({
             // default values
-            active_python_ver: "3.12",
+            active_python_ver: "3.13",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
             active_docker_cuda_ver: "12.8",
@@ -379,9 +379,9 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.10", "3.11", "3.12"],
-            python_vers_stable: ["3.10", "3.11", "3.12"],
-            python_vers_nightly: ["3.10", "3.11", "3.12"],
+            python_vers: ["3.10", "3.11", "3.12", "3.13"],
+            python_vers_stable: ["3.10", "3.11", "3.12", "3.13"],
+            python_vers_nightly: ["3.10", "3.11", "3.12", "3.13"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
             docker_cuda_vers: ["11.8", "12.0", "12.8"],


### PR DESCRIPTION
We have Python 3.13 packages now for RAPIDS -- adding those as an option and the new default in the selector.

xref rapidsai/build-planning#120
