### PR TITLE
Mark RSN 43 as completed

### DIFF
--- a/_notices/rsn0043.md
+++ b/_notices/rsn0043.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Deprecation of cuml-cpu in favor of cuml.accel"
 notice_author: RAPIDS Ops
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"


### PR DESCRIPTION
Updates RSN 43 status to completed now that cuml-cpu deprecation is complete.