### PR TITLE
Update forward merger instructions

### DIFF
--- a/maintainers/forward-merger.md
+++ b/maintainers/forward-merger.md
@@ -48,6 +48,8 @@ git push <personal fork> branch-{{ site.data.releases.nightly.version }}-merge-b
 
 Once this is done, open a PR that targets the new default branch (`branch-{{ site.data.releases.nightly.version }}` in this example) with your changes.
 
-**IMPORTANT**: When merging this PR, do not use the [auto-merger]({% link resources/auto-merger.md %}) (i.e. the `/merge` comment). Instead, an admin must manually merge by changing the merging strategy to `Create a Merge Commit`. Otherwise, history will be lost and the branches become incompatible.
+**IMPORTANT**:
+- The PR's branch should be named in the `<target_branch>-merge-<source_branch>` format as shown in the snippet above.
+- When merging this PR, do not use the [auto-merger]({% link resources/auto-merger.md %}) (i.e. the `/merge` comment). Instead, an admin must manually merge by changing the merging strategy to `Create a Merge Commit`. Otherwise, history will be lost and the branches become incompatible.
 
 Once this PR is approved and merged, the original forward-merger PR should automatically be merged since it will contain the same commit hashes.

--- a/maintainers/forward-merger.md
+++ b/maintainers/forward-merger.md
@@ -39,11 +39,11 @@ git checkout branch-{{ site.data.releases.stable.version }}
 git pull <rapidsai remote>
 git checkout branch-{{ site.data.releases.nightly.version }}
 git pull <rapidsai remote>
-git checkout -b branch-{{ site.data.releases.nightly.version }}-merge-{{ site.data.releases.stable.version }}
+git checkout -b branch-{{ site.data.releases.nightly.version }}-merge-branch-{{ site.data.releases.stable.version }}
 git merge --no-squash branch-{{ site.data.releases.stable.version }}
 # Fix any merge conflicts caused by this merge
 git commit -am "Merge branch-{{ site.data.releases.stable.version }} into branch-{{ site.data.releases.nightly.version }}"
-git push <personal fork> branch-{{ site.data.releases.nightly.version }}-merge-{{ site.data.releases.stable.version }}
+git push <personal fork> branch-{{ site.data.releases.nightly.version }}-merge-branch-{{ site.data.releases.stable.version }}
 ```
 
 Once this is done, open a PR that targets the new default branch (`branch-{{ site.data.releases.nightly.version }}` in this example) with your changes.

--- a/maintainers/forward-merger.md
+++ b/maintainers/forward-merger.md
@@ -49,7 +49,6 @@ git push <personal fork> branch-{{ site.data.releases.nightly.version }}-merge-b
 Once this is done, open a PR that targets the new default branch (`branch-{{ site.data.releases.nightly.version }}` in this example) with your changes.
 
 **IMPORTANT**:
-- The PR's branch should be named in the `<target_branch>-merge-<source_branch>` format as shown in the snippet above.
-- When merging this PR, do not use the [auto-merger]({% link resources/auto-merger.md %}) (i.e. the `/merge` comment). Instead, an admin must manually merge by changing the merging strategy to `Create a Merge Commit`. Otherwise, history will be lost and the branches become incompatible.
+- When merging this PR, do not use the [auto-merger]({% link resources/auto-merger.md %}) (i.e. the `/merge` comment). Instead, use the `/merge nosquash` comment. This ensures that branch history is preserved and branches remain compatible.
 
-Once this PR is approved and merged, the original forward-merger PR should automatically be merged since it will contain the same commit hashes.
+Once this PR is merged, the original forward-merger PR should automatically be merged since it will contain the same commit hashes.


### PR DESCRIPTION
Depends on https://github.com/rapidsai/ops-bot/pull/209 first getting merged.

Updates the forward-merger instructions based on the changes introduced by the PR linked above.