### PR TITLE
Dropping CUDA 11 Support in v25.08

### DIFF
--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -1,0 +1,36 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 48 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Deprecation announcement for CUDA 11.8 in v25.08 in our Docker Images"
+notice_author: RAPIDS Ops
+notice_status: "In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v25.08"
+notice_created: 2025-05-21
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-05-21
+---
+
+## Overview
+
+RAPIDS is removing support for CUDA 11.8 Docker containers in Release `v25.08`, scheduled for August 7, 2025, and will cease publishing CUDA 11.8 Docker containers.
+We are continuing support for CUDA 12.8 and 12.9 containers.
+
+## Impact
+
+Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11.8 Docker containers.
+RAPIDS will support CUDA 12.8 and 12.9 Docker containers.
+Users who still wish to use CUDA 11.8 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -26,7 +26,7 @@ notice_updated: 2025-05-21
 
 ## Overview
 
-RAPIDS is dropping all CUDA 11 support, including containers and all published packages (wheels and conda) in Release `v25.08`, scheduled for August 7, 2025. `v25.06` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.0 and 12.9 containers.
+RAPIDS is dropping all CUDA 11 support, including containers, all published packages (wheels and conda), and compilation from source in Release `v25.08`, scheduled for August 7, 2025. `v25.06` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.0 and 12.9 containers.
 
 ## Impact
 

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -32,4 +32,4 @@ RAPIDS is dropping all CUDA 11 support, including containers and all published p
 
 Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11, including containers and all our published packages (wheels and conda).
 RAPIDS will support CUDA 12.8 and 12.9 Docker containers.
-Users who still wish to use CUDA 11 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.
+Users who still wish to use CUDA 11 may pin to RAPIDS `v25.06`.

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -30,6 +30,6 @@ RAPIDS is dropping all CUDA 11 support, including containers, all published pack
 
 ## Impact
 
-Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11 release artifacts, including containers and all our published packages (wheels and conda).
+Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11 release artifacts, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 11.
 RAPIDS will support CUDA 12.0 and 12.9 Docker containers.
 Users who still wish to use CUDA 11 may pin to RAPIDS `v25.06`.

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -19,9 +19,9 @@ notice_status_color: yellow
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v25.08"
-notice_created: 2025-05-21
+notice_created: 2025-05-29
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-05-21
+notice_updated: 2025-05-29
 ---
 
 ## Overview

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -9,7 +9,7 @@ notice_id: 48 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation announcement for CUDA 11 in v25.08"
 notice_author: RAPIDS Ops
-notice_status: "In Progress
+notice_status: "In Progress"
 notice_status_color: yellow
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -31,5 +31,5 @@ RAPIDS is dropping all CUDA 11 support, including containers and all published p
 ## Impact
 
 Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11 release artifacts, including containers and all our published packages (wheels and conda).
-RAPIDS will support CUDA 12.8 and 12.9 Docker containers.
+RAPIDS will support CUDA 12.0 and 12.9 Docker containers.
 Users who still wish to use CUDA 11 may pin to RAPIDS `v25.06`.

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -26,7 +26,7 @@ notice_updated: 2025-05-21
 
 ## Overview
 
-RAPIDS is dropping all CUDA 11 support, including containers and all our published packages (wheels and conda)in Release `v25.08`, scheduled for August 7, 2025. `25.06` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.8 and 12.9 containers.
+RAPIDS is dropping all CUDA 11 support, including containers and all published packages (wheels and conda) in Release `v25.08`, scheduled for August 7, 2025. `v25.06` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.0 and 12.9 containers.
 
 ## Impact
 

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -30,6 +30,6 @@ RAPIDS is dropping all CUDA 11 support, including containers and all published p
 
 ## Impact
 
-Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11, including containers and all our published packages (wheels and conda).
+Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11 release artifacts, including containers and all our published packages (wheels and conda).
 RAPIDS will support CUDA 12.8 and 12.9 Docker containers.
 Users who still wish to use CUDA 11 may pin to RAPIDS `v25.06`.

--- a/_notices/rsn0048.md
+++ b/_notices/rsn0048.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 48 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Deprecation announcement for CUDA 11.8 in v25.08 in our Docker Images"
+title: "Deprecation announcement for CUDA 11 in v25.08"
 notice_author: RAPIDS Ops
 notice_status: "In Progress
 notice_status_color: yellow
@@ -26,11 +26,10 @@ notice_updated: 2025-05-21
 
 ## Overview
 
-RAPIDS is removing support for CUDA 11.8 Docker containers in Release `v25.08`, scheduled for August 7, 2025, and will cease publishing CUDA 11.8 Docker containers.
-We are continuing support for CUDA 12.8 and 12.9 containers.
+RAPIDS is dropping all CUDA 11 support, including containers and all our published packages (wheels and conda)in Release `v25.08`, scheduled for August 7, 2025. `25.06` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.8 and 12.9 containers.
 
 ## Impact
 
-Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11.8 Docker containers.
+Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 11, including containers and all our published packages (wheels and conda).
 RAPIDS will support CUDA 12.8 and 12.9 Docker containers.
-Users who still wish to use CUDA 11.8 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.
+Users who still wish to use CUDA 11 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.


### PR DESCRIPTION
RAPIDS is removing support of CUDA 11.8 Docker containers in Release `v25.08`, scheduled for August 7, 2025, and will cease publishing CUDA 11.8 Docker containers.