### PR TITLE
Add git instructions for new branching strategy

### DIFF
--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -45,11 +45,11 @@ the new strategy will be implemented across all RAPIDS libraries.
 After a repository has switched to the new strategy, existing local clones of
 repository may need to be updated to use the new `main` branch.
 
-Assuming you have a remote called `upstream` that points to `rapidai/<repo>`,
+Assuming you have a remote called `upstream` that points to `rapidsai/<repo>`,
 you can update your local clone with the following commands:
 
 ```bash
-git branch -d main
+git branch -m main legacy-main
 git branch -m branch-25.08 main # Use branch-25.08 for the 3 pilot repositories otherwise use branch-25.10
 git fetch upstream
 git branch -u upstream/main main

--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -42,6 +42,24 @@ the new strategy will be implemented across all RAPIDS libraries.
 
 ## Impact
 
+After a repository has switched to the new strategy, existing local clones of
+repository may need to be updated to use the new `main` branch.
+
+Assuming you have a remote called `upstream` that points to `rapidai/<repo>`,
+you can update your local clone with the following commands:
+
+```bash
+git branch -d main
+git branch -m branch-25.08 main # Use branch-25.08 for the 3 pilot repositories otherwise use branch-25.10
+git fetch origin
+git branch -u upstream/main main
+git remote set-head upstream -a
+```
+
+The original `main` branch is still available as `legacy-main` if needed.
+
+## Comparison
+
 Below is a table comparing the current and new branching strategies. Here, the current release is `YY.MM` (e.g. 25.06) and we denote the next release as `<YY.MM-next>` (e.g. 25.08).
 
 Aspect | Current (25.06) | New Branching Strategy (25.08+)

--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -56,6 +56,15 @@ git branch -u upstream/main main
 git remote set-head upstream -a
 ```
 
+After completing the above steps, if you want to update your fork with the new
+`main` branch, you can do so with (assuming your fork is called `origin`):
+
+```bash
+git push origin legacy-main:legacy-main
+git push origin main:main --force
+gh repo edit $USERNAME/$REPO --default-branch main
+```
+
 The original `main` branch is still available as `legacy-main` if needed.
 
 ## Comparison

--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -51,7 +51,7 @@ you can update your local clone with the following commands:
 ```bash
 git branch -d main
 git branch -m branch-25.08 main # Use branch-25.08 for the 3 pilot repositories otherwise use branch-25.10
-git fetch origin
+git fetch upstream
 git branch -u upstream/main main
 git remote set-head upstream -a
 ```


### PR DESCRIPTION
The new branching strategy effectively renames `branch-25.08` (for the pilot repositories) or `branch-25.10` (for all other RAPIDS libraries) to `main`. This means existing local clones will need to be updated to sync with the new `main` branch. This PR details instructions for doing that.
