### PR TITLE
Fix next nightly version names

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -49,8 +49,8 @@
     }
   },
   "next_nightly": {
-    "version": "25.08",
-    "ucxx_version": "0.45",
+    "version": "25.10",
+    "ucxx_version": "0.46",
     "cudf_dev": {
       "start": "Jul 17 2025",
       "end": "Sep 17 2025",


### PR DESCRIPTION
Fixes a copy-paste error in #616

The dates are correct, just the version numbers were wrong.
