### PR TITLE
RAPIDS Wheels Missing from pypi.nvidia.com

### DIFF
--- a/_notices/rsn0049.md
+++ b/_notices/rsn0049.md
@@ -1,0 +1,33 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 49 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Importandt Installation Notice : RAPIDS Wheels are missiing from pypi.nvidia.com"
+notice_author: RAPIDS Ops
+notice_status: "In Progress"
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "All RAPIDS Versions"
+notice_created: 2025-06-27
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-06-27
+---
+
+## Overview
+
+RAPIDS is aware pypi.nvidia.com is down and users are unable to insall PIP wheels via `pip install`, and are working to get it back up & working ASAP.
+
+## Impact
+
+Users will not be unable to download RAPIDS wheels via `pip install`.


### PR DESCRIPTION
RAPIDS Wheels are missing from pypi.nvidia.com