### PR TITLE
Add CUDA 12.9 to nightlies

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -384,9 +384,9 @@
             python_vers_nightly: ["3.10", "3.11", "3.12", "3.13"],
             conda_cuda_vers: ["11", "12"],
             pip_cuda_vers: ["11.4 - 11.8", "12"],
-            docker_cuda_vers: ["11.8", "12.0", "12.8"],
+            docker_cuda_vers: ["11.8", "12.0", "12.8", "12.9"],
             docker_cuda_vers_stable: ["11.8", "12.0", "12.8"],
-            docker_cuda_vers_nightly: ["11.8", "12.0", "12.8"],
+            docker_cuda_vers_nightly: ["11.8", "12.0", "12.9"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
             img_loc: ["NGC", "Docker Hub"],
@@ -446,7 +446,7 @@
                     },
                     "Nightly": {
                         "11": ["11.4", "11.8"],
-                        "12": ["12.0", "12.8"]
+                        "12": ["12.0", "12.9"]
                     }
                 };
                 var bounds = cuda_version_info[this.active_release][version];


### PR DESCRIPTION
Now that RAPIDS is building and testing with CUDA 12.9, add it to the selector matrix under nightlies.

References:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173