### PR TITLE
Remove cuda 12.8 Docker Images in Release v25.08

### DIFF
--- a/_notices/rsn0050.md
+++ b/_notices/rsn0050.md
@@ -32,4 +32,4 @@ The CUDA 12.8 containers will be replaced by CUDA 12.9 containers.  We are conti
 ## Impact
 
 Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 12.8 Docker containers.  RAPIDS will support CUDA 12.0 and 12.9 Docker containers.
-Users who still wish to use CUDA 12.8 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.
+Users who still wish to use CUDA 12.8 (or other versions in the CUDA 12.x series) may continue to use RAPIDS via conda or pip.

--- a/_notices/rsn0050.md
+++ b/_notices/rsn0050.md
@@ -1,0 +1,35 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 50 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "RAPIDS 25.08 replaces CUDA 12.8 with CUDA 12.9 in our Docker Images"
+notice_author: RAPIDS Ops
+notice_status: "In Progress"
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v25.08"
+notice_created: 2025-07-02
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-07-02
+---
+
+## Overview
+
+RAPIDS is removing support for CUDA 12.8 Docker containers in Release `v25.08`, and will cease publishing CUDA 12.8 Docker containers before the `v25.08` release.
+The CUDA 12.8 containers will be replaced by CUDA 12.9 containers.  We are continuing support for CUDA 12.0 containers.
+
+## Impact
+
+Effective RAPIDS `v25.08` release, RAPIDS will cease distribution of CUDA 12.8 Docker containers.  RAPIDS will support CUDA 12.0 and 12.9 Docker containers.
+Users who still wish to use CUDA 12.8 (or other versions in the CUDA 11.x or 12.x series) may continue to use RAPIDS via conda or pip.

--- a/_notices/rsn0051.md
+++ b/_notices/rsn0051.md
@@ -5,7 +5,7 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
-notice_id: 50 # should match notice number
+notice_id: 51 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "RAPIDS 25.08 replaces CUDA 12.8 with CUDA 12.9 in our Docker Images"
 notice_author: RAPIDS Ops


### PR DESCRIPTION
Closes #632

RAPIDS is removing support for CUDA 12.8 Docker containers in Release `v25.08`, and will cease publishing CUDA 12.8 Docker containers before the `v25.08` release.  The CUDA 12.8 containers will be replaced by CUDA 12.9 containers.  We are continuing support for CUDA 12.0 containers.
