### PR TITLE
Dropping UCX-Py project in v25.10

### DIFF
--- a/_notices/rsn0050.md
+++ b/_notices/rsn0050.md
@@ -38,9 +38,13 @@ Development for the UCX-Py repository will cease and no new packages will be pub
 
 Dask-CUDA and Dask/Distributed users may continue to benefit from UCX support through the new UCXX project. Python developers will continue to be supported as well. Additionally, UCXX now provides a C++ library to interface with UCX.
 
-### Dask-CUDA and Dask/Distributed
+### Dask-CUDA
 
-Dask-CUDA users have been automatically migrated. Beginning with RAPIDS v25.08, if the `distributed-ucxx` package is installed, setting `protocol="ucx"` will now automatically use UCXX instead of UCX-Py, if `distributed-ucxx` is not installed the old UCX-Py will still be be used and a warning will be emitted to advise updating. Setting `protocol="ucxx"` always uses UCXX and will continue to work. In RAPIDS v25.08 users can still continue to use UCX-Py by setting `protocol="ucx-old"`, but this option will be removed in RAPIDS v25.10.
+Dask-CUDA users have been automatically migrated. Beginning with RAPIDS v25.08, if the `distributed-ucxx` package is installed, setting `protocol="ucx"` will now automatically use UCXX instead of UCX-Py.
+If `distributed-ucxx` is not installed the old UCX-Py will still be be used and a warning will be emitted to advise updating.
+Setting `protocol="ucxx"` always uses UCXX and will continue to work. In RAPIDS v25.08 users can still continue to use UCX-Py by setting `protocol="ucx-old"`, but this option will be removed in RAPIDS v25.10.
+
+### Dask/Distributed
 
 Dask/Distributed will require installing the `distributed-ucxx` package and set `protocol="ucxx"`. After the migration is completed, `protocol="ucx"` will also use UCXX, provided the `distributed-ucxx` package is installed.
 

--- a/_notices/rsn0050.md
+++ b/_notices/rsn0050.md
@@ -1,0 +1,53 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 50 # should match notice number
+notice_pin: true # set to true to pin to notice page
+
+title: "Dropping of UCX-Py project in RAPIDS Release v25.10"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v25.06+"
+notice_created: 2025-07-10
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-08-10
+---
+
+## Overview
+
+RAPIDS will stop publishing UCX-Py packages in RAPIDS Release v25.10, scheduled for October 09, 2025. UCX-Py 0.45 in RAPIDS Release v25.08 will be its last. Development for the UCX-Py repository will stop, the repository will be archived and no new packages will be published. Users are advised to switch to the new [UCXX](https://github.com/rapidsai/ucxx/) project.
+
+## Impact
+
+Development for the UCX-Py repository will cease and no new packages will be published. UCX-Py will be dropped from the `rapids` conda metapackage and RAPIDS Docker containers.
+
+
+## Continued accelerated communication support
+
+Dask-CUDA and Dask/Distributed users may continue to benefit from UCX support through the new UCXX project. Python developers will continue to be supported as well. Additionally, UCXX now provides a C++ library to interface with UCX.
+
+### Dask-CUDA and Dask/Distributed
+
+Dask-CUDA users have been automatically migrated. Beginning with RAPIDS v25.08, if the `distributed-ucxx` package is installed, setting `protocol="ucx"` will now automatically use UCXX instead of UCX-Py, if `distributed-ucxx` is not installed the old UCX-Py will still be be used and a warning will be emitted to advise updating. Setting `protocol="ucxx"` always uses UCXX and will continue to work. In RAPIDS v25.08 users can still continue to use UCX-Py by setting `protocol="ucx-old"`, but this option will be removed in RAPIDS v25.10.
+
+Dask/Distributed will require installing the `distributed-ucxx` package and set `protocol="ucxx"`. After the migration is completed, `protocol="ucx"` will also use UCXX, provided the `distributed-ucxx` package is installed.
+
+### Python developers
+
+Python developers who directly used UCX-Py via `import ucp` will continue to be supported via `import ucxx`, this requires the `ucxx` package to be installed. There may be minor changes, users are advised to consult the API documentation.
+
+### C++
+
+With the introduction of UCXX, C++ developers can also benefit of a proper C++ library to interface with UCX via the new `libucxx` package, providing RAII interface along with additional features.


### PR DESCRIPTION
UCX-Py will be dropped and the project will be archived in v25.10, continued accelerated communication support will be maintained via its successor UCXX.