### PR TITLE
Fix git commands for RSN 47

### DIFF
--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -36,7 +36,7 @@ release branch.
 Releases and hot fixes will be tagged from the release branch.
 
 The transition to this new strategy will commence for all RAPIDS repositories
-after the 25.08 release is completed.
+during the 25.10 development cycle, after the 25.08 release is completed.
 
 ## Impact
 
@@ -48,7 +48,7 @@ you can update your local clone with the following commands:
 
 ```bash
 git branch -m main legacy-main
-git branch -m branch-25.08 main # Use branch-25.08 for the 3 pilot repositories otherwise use branch-25.10
+git branch -m branch-25.10 main
 git fetch upstream
 git branch -u upstream/main main
 git remote set-head upstream -a


### PR DESCRIPTION
This is a small fix for #639. Changes were merged from #619 but not updated accordingly.
