### PR TITLE
Add license + DCO + headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,45 @@ docker run --rm \
 
 Once you have code changes, submit a PR to the docs site. Netlify will generate
 a preview of your changes and the team will review.
+
+## Developer Certificate of Origin
+
+All contributions to this project must be accompanied by a sign-off indicating that the contribution is made pursuant to the Developer Certificate of Origin (DCO). This is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+
+The DCO is a simple statement that you, as a contributor, have the legal right to make the contribution. To certify your adherence to the DCO, you must sign off on your commits. This is done by adding a `Signed-off-by` line to your commit messages:
+
+```
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+You can do this automatically with `git commit -s`.
+
+Here is the full text of the DCO, which you can also find at <https://developercertificate.org/>:
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 NVIDIA Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 {% for lib in include.data %}
 {% assign api = lib[1] %}
 {% if api.hidden != true %}

--- a/_includes/bokeh.html
+++ b/_includes/bokeh.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="1bd788b2-2761-45b2-ae08-2caece4b658e" data-root-id="9175"></div>

--- a/_includes/datashader.html
+++ b/_includes/datashader.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="cf6d710b-1908-4b9d-9787-ff5f9bb4ad79" data-root-id="8756"></div>

--- a/_includes/gpu-labels-table-row.html
+++ b/_includes/gpu-labels-table-row.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <tr>
   <td>
     <code

--- a/_includes/gpu-labels-table.html
+++ b/_includes/gpu-labels-table.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <table>
   <thead>
     <tr>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">

--- a/_includes/holoviews.html
+++ b/_includes/holoviews.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="b48c307e-9b2d-4ab7-9c71-fbce2a52bf4d" data-root-id="1002"></div>

--- a/_includes/hvplot.html
+++ b/_includes/hvplot.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="b1afe886-1efe-473f-b5b3-b36a7f08c990" data-root-id="4809"></div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <nav role="navigation" aria-label="Main navigation">
   <ul class="navigation-list">
     {% assign pages_list = site.html_pages | sort:"nav_order" %}

--- a/_includes/plotly.html
+++ b/_includes/plotly.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="ec437eae-b74d-4042-8f47-2da685fda62f" data-root-id="8789"></div>

--- a/_includes/seaborn.html
+++ b/_includes/seaborn.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <section>
 
   <div class="bk-root" id="97a50a14-c50a-4103-8735-b007cde7a0fe" data-root-id="12281"></div>

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <style>
     /* install options selector */
     /* new selector */

--- a/_includes/viz-cdn-js-css.html
+++ b/_includes/viz-cdn-js-css.html
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 -->
 <link rel="stylesheet"
   href="https://cdn.holoviz.org/panel/0.14.3/dist/bundled/deckglplot/mapbox-gl-js/v2.6.1/mapbox-gl.css"
   type="text/css" />

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
 /* Custom API layout CSS */
 .api-left-header {
   max-height: 60px;

--- a/assets/css/just-the-docs.css
+++ b/assets/css/just-the-docs.css
@@ -1,4 +1,8 @@
 @charset "UTF-8";
+/* SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+ 
 /*! normalize.scss v0.1.0 | MIT License | based on git.io/normalize */
 /**
  * 1. Set default font family to sans-serif.

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // temporary flag to prevent JS from being loaded twice
 // while we move around some of this JS to the libraries
 window.customJSLoaded = window.customJSLoaded || false;

--- a/assets/js/just-the-docs.js
+++ b/assets/js/just-the-docs.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 ---
 ---
 (function (jtd, undefined) {

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 

--- a/ci/customization/customize_doc.py
+++ b/ci/customization/customize_doc.py
@@ -1,4 +1,7 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Script to customize doxygen/sphinx generated HTML for RAPIDS
 """

--- a/ci/customization/customize_docs_in_folder.sh
+++ b/ci/customization/customize_docs_in_folder.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #######################################
 # Recursively customizes all docs in a specified folder relative
 # to the project's root. Intended to be run from the project's

--- a/ci/customization/lib_map.sh
+++ b/ci/customization/lib_map.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
-#
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script generates a lib_map.json file that maps each RAPIDS library
 # to its default documentation page for each version (legacy, stable, nightly).
 # i.e.

--- a/ci/customization/util.py
+++ b/ci/customization/util.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+
 class r_versions(str):
     def compare(self, other: str) -> int:
         yearA, monthA = map(int, self.split("."))

--- a/ci/customization/util.py
+++ b/ci/customization/util.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 class r_versions(str):
     def compare(self, other: str) -> int:
         yearA, monthA = map(int, self.split("."))

--- a/ci/download_from_s3.sh
+++ b/ci/download_from_s3.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Copies the RAPIDS libraries' HTML files from S3 into the "_site" directory of
 # the Jekyll build.
 set -euo pipefail

--- a/ci/post-process.sh
+++ b/ci/post-process.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 CURRENT_DIR=$(dirname $(realpath $0))

--- a/ci/update_symlinks.sh
+++ b/ci/update_symlinks.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #######################################
 # Updates or removes all symlinked folders based on the given positional parameter
 #######################################

--- a/ci/upload_cudf_java_docs.sh
+++ b/ci/upload_cudf_java_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 


### PR DESCRIPTION
This pull request introduces the addition of a Developer Certificate of Origin (DCO), an Apache 2.0 license file, and SPDX copyright and license headers across multiple files. These changes aim to ensure compliance with open-source licensing standards and clarify contribution requirements.

### Licensing and Contribution Compliance:

* Added a Developer Certificate of Origin (DCO) section to `CONTRIBUTING.md`, requiring contributors to sign off on commits to certify their legal right to contribute.
* Introduced an `Apache License, Version 2.0` file to define the terms and conditions for using, reproducing, and distributing the project.

### SPDX Headers for Copyright and Licensing:

* Added SPDX headers to all HTML files in the `_includes` directory (e.g., `_includes/api-docs.html`, `_includes/bokeh.html`, `_includes/datashader.html`, etc.), ensuring proper attribution and license compliance. [[1]](diffhunk://#diff-a07c50780e126a38017183fb1ab721b8d6aee4dc3355f2b4e152818fa066c3acR1-R3) [[2]](diffhunk://#diff-51b8ca9e30eddf1a2fd59af8d8f5f0df93957b8faf8165a10c535c3d00f9949cR1-R3) [[3]](diffhunk://#diff-347a09a18374f8f1136bdef285534cb046b9d9207f252b4bf0db806f066a38d5R1-R3) [[4]](diffhunk://#diff-60d18ba3408efc0dcc472aafa42d47918b3c0c4b949b1cd3ebcd29990cbe5e3aR1-R3) [[5]](diffhunk://#diff-4ccc902e3f35e121ecf20b81a0c954bf7cee16086bf1ccf705f6bddedca29162R1-R3) [[6]](diffhunk://#diff-e241bda4e3c3c6dc1c0b00185b61f6ce19b5eb16e294dd955ca9fa6d01befb0eR1-R3) [[7]](diffhunk://#diff-ca492e468e0dc2d5751cc764172f0c0f74580870b92b4099fb0e4f5f159a4c56R1-R3) [[8]](diffhunk://#diff-fb8ad7a52ca7e548499582a72c9987b1d9a7b4db22f9ecb35a2b83c50ee3523eR1-R3) [[9]](diffhunk://#diff-9c4a34e464067c958759c74541311573208a3b6d4f48ed862e188d7d912c91ffR1-R3) [[10]](diffhunk://#diff-5f5db4d3d732bcb457b700dfedd836d4245782c13d4ff802785ca131e8699a6fR1-R3) [[11]](diffhunk://#diff-204397201926429011c4bc95304794b6e4ed917899a3f695469873b8d9df7525R1-R3) [[12]](diffhunk://#diff-395138901913dbcb12c6504c460d16462b17ad056b0ddaca459af85680d250beR1-R3) [[13]](diffhunk://#diff-78a250711e3db5382132ffd62866bbf54413184ac774595be7999e431027fdabR1-R3)
* Added SPDX headers to CSS files (`assets/css/custom.css`, `assets/css/just-the-docs.css`) and JavaScript files (`assets/js/custom.js`, `assets/js/just-the-docs.js`) for consistent licensing metadata. [[1]](diffhunk://#diff-54a66f9a42172ece239b80abd6538c28c80c25375a2ef411908be80fac1ef58fR1-R4) [[2]](diffhunk://#diff-e7af556c82f8f57ad37c2891af58e55a7bd5c3351556dbf7138675f6eba45c53R2-R5) [[3]](diffhunk://#diff-af1b0d0d7c968935aa63bba9e56562139791c575b78fb492a791b047325ff360R1-R4) [[4]](diffhunk://#diff-b0f8bf5565a5065e28a5158923dc657703997e3133f5a0cb72bdf956a214ffc1R1-R4)
* Updated the `ci/check_style.sh` script with an SPDX header to reflect updated copyright and license information.

These updates improve transparency, ensure legal compliance, and align the project with best practices for open-source contributions.