### PR TITLE
RSN 45: move to completed

### DIFF
--- a/_notices/rsn0045.md
+++ b/_notices/rsn0045.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Dropping of Publishing cuSpatial Packages in RAPIDS Release v25.06"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,10 +22,12 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v25.06+"
 notice_created: 2025-04-09
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-04-09
+notice_updated: 2025-07-16
 ---
 
 ## Overview
+
+**UPDATE (July 16, 2025):** RAPIDS 25.04 was the final release to include cuSpatial packages.
 
 RAPIDS will stop publishing cuSpatial packages in RAPIDS Release v25.06, scheduled for June 05, 2025. Development for the cuSpatial repository will be paused and no new packages will be published.
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/197

Follow-up to #588

Proposes marking the RSN about stopping `cuspatial` complete. There is still a bit of cleanup to do (see the linked issue), but none that directly affects this RSN... the last `cuspatial` and `cuproj` packages were published in 25.04, and as of now the plan is to not publish any more packages.