### PR TITLE
disable cudf java docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -66,7 +66,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM


### PR DESCRIPTION
Disables cudf-java docs temporarily until the cudf-java package is released in a few days from now

Missed in https://github.com/rapidsai/docs/pull/655