### PR TITLE
expand docs on testing locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib_map.json
 .netlify
 __pycache__/
 node_modules
+rapids-docs-env/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
       uri
     nokogiri (1.18.8-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -276,6 +278,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ exclude:
   - package-lock.json
   - Gemfile
   - Gemfile.lock
+  - .ruff_cache/
 include:
   - _sources
   - _static


### PR DESCRIPTION
I relied on some miminal local testing + the PR docs preview to test the changes in #654 

Those changes did not interact well with the 25.08 release, and had to be reverted: #658

On #657, I'm touching the same code paths (the downloads from S3 and post-processing) and this time found myself wanting much more thorough testing.

I've found a pattern that's working well for me. This proposes adding it to `CONTRIBUTING.md`, so others can repeat that testing in the future.

## Notes for Reviewers

### How I tested this

Locally, on my arm64 (M2) Mac.