### PR TITLE
Update CUDA requirements in 25.08 installation guide

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -265,7 +265,7 @@
                 </div>
                 <div class="options-section" x-show="active_method === 'Docker'">
                     <div class="option-label">Image CUDA</div>
-                    <template x-for="version in docker_cuda_vers">
+                    <template x-for="version in getSupportedDockerCudaVersions()">
                         <div x-on:click="(e) => dockerCUDAClickHandler(e, version)"
                             x-bind:class="{'active': version === active_docker_cuda_ver, 'disabled': disableUnsupportedDockerCuda(version)}"
                             class="option" x-text="'CUDA ' + version"></div>
@@ -273,7 +273,7 @@
                 </div>
                 <div class="options-section" x-show="active_method !== 'pip'">
                     <div class="option-label">Python</div>
-                    <template x-for="version in python_vers">
+                    <template x-for="version in getSupportedPythonVersions()">
                         <div x-on:click="(e) => pythonClickHandler(e, version)"
                             x-bind:class="{'active': version === active_python_ver, 'disabled': disableUnsupportedPython(version)}"
                             class="option" x-text="'Python ' + version"></div>
@@ -373,7 +373,7 @@
             active_python_ver: "3.13",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
-            active_docker_cuda_ver: "12.8",
+            active_docker_cuda_ver: "12.9",
             active_method: "Conda",
             active_release: "Stable",
             active_img_type: "Base",
@@ -382,17 +382,13 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.10", "3.11", "3.12", "3.13"],
             python_vers_stable: ["3.10", "3.11", "3.12", "3.13"],
             python_vers_nightly: ["3.10", "3.11", "3.12", "3.13"],
-            conda_cuda_vers: ["11", "12"],
-            conda_cuda_vers_stable: ["11", "12"],
+            conda_cuda_vers_stable: ["12"],
             conda_cuda_vers_nightly: ["12"],
-            pip_cuda_vers: ["11.4 - 11.8", "12"],
-            pip_cuda_vers_stable: ["11.4 - 11.8", "12"],
+            pip_cuda_vers_stable: ["12"],
             pip_cuda_vers_nightly: ["12"],
-            docker_cuda_vers: ["11.8", "12.0", "12.8", "12.9"],
-            docker_cuda_vers_stable: ["11.8", "12.0", "12.8"],
+            docker_cuda_vers_stable: ["12.0", "12.9"],
             docker_cuda_vers_nightly: ["12.0", "12.9"],
             methods: ["Conda", "pip", "Docker"],
             releases: ["Stable", "Nightly"],
@@ -448,8 +444,7 @@
             getCondaVersionSupport(version) {
                 var cuda_version_info = {
                     "Stable": {
-                        "11": ["11.4", "11.8"],
-                        "12": ["12.0", "12.8"]
+                        "12": ["12.0", "12.9"]
                     },
                     "Nightly": {
                         "12": ["12.0", "12.9"]
@@ -533,12 +528,8 @@
             },
             getpipCmdHtml() {
                 var pip_install = `${this.highlightCmd("pip")} install`;
-                var cuda_suffix = "-cu12";
+                var cuda_suffix = `-cu${this.active_pip_cuda_ver}`;
                 var indentation = "    ";
-
-                if (this.active_pip_cuda_ver.startsWith("11")) {
-                    cuda_suffix = "-cu11";
-                }
 
                 // Change index depending on stable vs nightly for pip
                 // Also add versioning commands for nightly installs so that --pre is unnecessary
@@ -654,10 +645,6 @@
             },
             getCondaNotes() {
                 var notes = [];
-                if (this.active_conda_cuda_ver.startsWith("11")) {
-                    notes = [...notes, "RAPIDS on CUDA 11 doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
-                }
-
                 var pkgs_to_show = this.rapids_meta_pkgs;
 
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {

--- a/install/index.md
+++ b/install/index.md
@@ -102,7 +102,6 @@ ERROR: No matching distribution found for cudf-cu12
 ```
 Check the suggestions below for possible resolutions:
 
-- The pip index has moved from the initial experimental release! Ensure the correct `--extra-index-url=https://pypi.nvidia.com`
 - Ensure you're using a Python version that RAPIDS supports (compare the values in the [the install selector](#selector) to the Python version reported by `python --version`).
 
 <br/>

--- a/install/index.md
+++ b/install/index.md
@@ -358,7 +358,7 @@ print(cudf.Series([1, 2, 3]))
 <div id="source"></div>
 
 ## **Build from Source**
-To build from source, check each [RAPIDS GitHub](https://github.com/rapidsai){: target="_blank"} README, such as the [cuDF's](https://github.com/rapidsai/cudf#buildinstall-from-source){: target="_blank"} source environment set up and build instructions. Further links are provided in the [selector tool](#selector). If additional help is needed reach out on our [Slack Channel]({{ site.social.slack.url }}).
+To build from source, find the library on the [RAPIDS GitHub](https://github.com/rapidsai){: target="_blank"}. Libraries provide guidance on building from source in `README.md` or `CONTRIBUTING.md`. If additional help is needed, file an issue on GitHub or reach out on our [Slack Channel]({{ site.social.slack.url }}).
 
 
 <hr/>

--- a/install/index.md
+++ b/install/index.md
@@ -59,9 +59,9 @@ To resolve this error please follow one of these steps:
 You may see something like:
 ```
 LibMambaUnsatisfiableError: Encountered problems while solving:
- - package cuda-version-12.0-hffde075_0 has constraint __cuda >=12 conflicting with __cuda-11.4-0
+ - package cuda-version-12.0-hffde075_0 has constraint __cuda >=12 conflicting with __cuda-11.8-0
 ```
-This means the CUDA driver currently installed on your machine (e.g. `__cuda`: 11.4.0) is
+This means the CUDA driver currently installed on your machine (e.g. `__cuda`: 11.8.0) is
 incompatible with the `cuda-version` (12.0) you are trying to install. You will have to ensure the [CUDA
 driver on your machine supports the CUDA version](#system-req) you are trying to install with conda.
 
@@ -92,13 +92,9 @@ To learn more about these changes, please see the [RAPIDS Container README](http
 
 
 ### **pip Issues**
-<i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For CUDA 11 toolkits, install the `-cu11` wheels, and for CUDA 12 toolkits install the `-cu12` wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the `-cu11` wheels. <br/>
+<i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For example, if you have the CUDA 12 toolkit, install the `-cu12` wheels.<br/>
 <i class="fas fa-info-circle"></i> Infiniband is not supported yet. <br/>
 <i class="fas fa-info-circle"></i> These packages are not compatible with Tensorflow pip packages. Please use the [NGC containers](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow){: target="_blank"} or conda packages instead. <br/>
-<i class="fas fa-info-circle"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install `cupy-cuda11x`. For example:
-```sh
-pip uninstall cupy-cuda115; pip install cupy-cuda11x
-```
 <br/>
 
 <i class="fas fa-info-circle"></i> The following error message indicates a problem with your environment:
@@ -155,28 +151,18 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 <i class="fas fa-download text-purple"></i> **CUDA & NVIDIA Drivers:** One of the following supported versions:
 {: .no-tb-margins }
 
-- <i class="fas fa-check-circle"></i> [CUDA 11.2](https://developer.nvidia.com/cuda-11.2.0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
-- <i class="fas fa-check-circle"></i> [CUDA 12.0](https://developer.nvidia.com/cuda-12-0-1-download-archive){: target="_blank"} with Driver 525.60.13 or newer **see CUDA 12 section below for notes on usage**
-- <i class="fas fa-check-circle"></i> [CUDA 12.2](https://developer.nvidia.com/cuda-12-2-2-download-archive){: target="_blank"} with Driver 535.86.10 or newer **see CUDA 12 section below for notes on usage**
-- <i class="fas fa-check-circle"></i> [CUDA 12.5](https://developer.nvidia.com/cuda-12-5-1-download-archive){: target="_blank"} with Driver 555.42.06 or newer **see CUDA 12 section below for notes on usage**
+- <i class="fas fa-check-circle"></i> CUDA 12 with Driver 525.60.13 or newer
+- <i class="fas fa-info-circle"></i> Compatibility with CUDA 13 is coming soon
 
- **Note**: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details.
+See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) for details.
 
-## **CUDA Support**
-
-### **Docker and Conda**
-
-- <i class="fas fa-info-circle"></i> conda packages and Docker images support CUDA 12 on systems with a CUDA 12 driver.
-- <i class="fas fa-info-circle"></i> CUDA 11 conda packages and Docker images can be used on a system with a CUDA 12 driver because they include their own CUDA toolkit.
+## **CUDA Support Notes**
 
 ### **pip**
 
 - <i class="fas fa-info-circle"></i> pip installations require using a wheel matching the system's installed CUDA toolkit.
 - <i class="fas fa-info-circle"></i> RAPIDS pip packages require NVRTC for Numba to function properly. For Docker users, this means that RAPIDS wheels require the `devel` flavor of `nvidia/cuda` images for full functionality. The `base` and `runtime` flavors of `nvidia/cuda` Docker images are currently not sufficient.
-- <i class="fas fa-info-circle"></i> For CUDA 11 toolkits, install the <code>-cu11</code> wheels, and for CUDA 12 toolkits install the <code>-cu12</code> wheels. If your installation has a CUDA 12 driver but a CUDA 11 toolkit, use the <code>-cu11</code> wheels.
+- <i class="fas fa-info-circle"></i> pip installations require using the matching wheel to the system's installed CUDA toolkit. For example, if you have the CUDA 12 toolkit, install the `-cu12` wheels.<br/>
 
 <br/>
 <div id="system-recommendations"></div>
@@ -224,11 +210,7 @@ bash Miniforge3-$(uname)-$(uname -m).sh
 
 **3. Start Conda.** Open a new terminal window, which should now show Conda initialized.
 
-**4. Check Conda Configuration.** Installing RAPIDS may require you to use `channel_priority: flexible`.
-
-If you are installing RAPIDS with CUDA 12 or greater, then you can use either `strict` or `flexible` channel priority.
-
-If you are installing RAPIDS with CUDA 11, then you must set `channel_priority: flexible`.
+**4. Check Conda Configuration.** RAPIDS supports either `flexible` or `strict` channel priority.
 
 You can check this and change it, if required, by doing:
 ```sh
@@ -290,12 +272,7 @@ The standard docker command may be sufficient, but the additional arguments ensu
 <div id="pip"></div>
 
 ## **pip**
-RAPIDS pip packages are available for CUDA 11 and CUDA 12 on the NVIDIA Python Package Index.
-
-### **pip Additional Prerequisites**
-<i class="fas fa-info-circle"></i> The CUDA toolkit version on your system must match the pip CUDA version you install (`-cu11` or `-cu12`). <br/>
-<i class="fas fa-info-circle"></i> **glibc version:** x86_64 wheels require glibc >= 2.17. <br/>
-<i class="fas fa-info-circle"></i> **glibc version:** ARM architecture (aarch64) wheels require glibc >= 2.32 (only ARM Server Base System Architecture is supported).
+RAPIDS pip packages are available on the NVIDIA Python Package Index.
 
 <br/>
 <div id="sdkm"></div>
@@ -401,9 +378,8 @@ print(cudf.Series([1, 2, 3]))
 1. Install WSL2 and the Ubuntu distribution [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL2 Linux instance.
-4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then install the WSL-specific [CUDA 11](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} or [CUDA 12](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} Toolkit without drivers into the WSL2 instance.
-  - The installed CUDA Toolkit version must match the pip wheel version (`-cu11` or `-cu12`)
-  - Any CUDA 12 CTK will work with RAPIDS `-cu12` pip packages
+4. Follow [this helpful developer guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"} and then install the WSL-specific [CUDA 12](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local){: target="_blank"} Toolkit without drivers into the WSL2 instance.
+  - The installed CUDA Toolkit major version must match the package suffix (e.g. `-cu12`)
 5. Install RAPIDS pip packages on the WSL2 Linux Instance using the [release selector](#selector) commands.
 6. Run this code to check that the RAPIDS installation is working:
 ```python


### PR DESCRIPTION
In 25.08, there were a few significant changes in CUDA support.

- CUDA 11 was dropped
- CUDA 12.9 support was added
- CUDA 12.8 containers were removed in favor of CUDA 12.9 containers

This PR updates those and also thoroughly revises the installation notes and troubleshooting info. In many places, we had outdated information that is no longer relevant with CUDA 12+.

I also removed notes pertaining to CUDA 11, updated a lot of links, fixed installation instructions for `nvidia-container-toolkit`, and removed workarounds for non-RAPIDS software older than 2023.