### PR TITLE
post-processing: prevent early exit in customization

### DIFF
--- a/ci/customization/customize_docs_in_folder.sh
+++ b/ci/customization/customize_docs_in_folder.sh
@@ -14,7 +14,7 @@
 # Positional Arguments:
 #   1) FOLDER_TO_CUSTOMIZE: project root relative folder to customize (i.e. api/, api/rmm, etc.)
 #######################################
-set -e
+set -euo pipefail
 
 display_usage() {
   echo "Usage:"
@@ -51,5 +51,5 @@ grep "${JTD_SEARCH_TERM}\|${DOXYGEN_SEARCH_TERM}\|${PYDATA_SEARCH_TERM}" -rl \
 > "${MANIFEST_FILE}"
 
 echo "Customizing $(wc -l < ${MANIFEST_FILE} | tr -d ' ') HTML files"
-python ${SCRIPT_SRC_FOLDER}/customize_doc.py "${MANIFEST_FILE}"
+python -u ${SCRIPT_SRC_FOLDER}/customize_doc.py "${MANIFEST_FILE}"
 echo "Done customizing"

--- a/ci/post-process.sh
+++ b/ci/post-process.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 
 CURRENT_DIR=$(dirname $(realpath $0))
 
-pip install -r "${CURRENT_DIR}/customization/requirements.txt"
+# pip install -r "${CURRENT_DIR}/customization/requirements.txt"
 
-"${CURRENT_DIR}"/update_symlinks.sh
+# "${CURRENT_DIR}"/update_symlinks.sh
 
-"${CURRENT_DIR}"/customization/lib_map.sh
+# "${CURRENT_DIR}"/customization/lib_map.sh
 
 "${CURRENT_DIR}"/customization/customize_docs_in_folder.sh "_site/api"

--- a/ci/post-process.sh
+++ b/ci/post-process.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 
 CURRENT_DIR=$(dirname $(realpath $0))
 
-# pip install -r "${CURRENT_DIR}/customization/requirements.txt"
+pip install -r "${CURRENT_DIR}/customization/requirements.txt"
 
-# "${CURRENT_DIR}"/update_symlinks.sh
+"${CURRENT_DIR}"/update_symlinks.sh
 
-# "${CURRENT_DIR}"/customization/lib_map.sh
+"${CURRENT_DIR}"/customization/lib_map.sh
 
 "${CURRENT_DIR}"/customization/customize_docs_in_folder.sh "_site/api"


### PR DESCRIPTION
After merging #663, the post-processing "customization" process that updates things like drop-down version selectors is not processing all of the files it should be.

See https://github.com/rapidsai/docs/pull/663#issuecomment-3175192343 for details.

This fixes that.

## Notes for Reviewers

### Speed?

In #663, I said that I saw a post-processing process that's been taking around 1 hour in CI take around 4 minutes for me locally. That was an over-estimate influenced by this accidentally stopping early 😭 

Following the testing steps added in #659, with the fixes in this PR it looks like this process will now take more like 20 minutes.

So still noticably faster, even if not as fast as I'd though before 😅 

### How was this not caught in testing?

In the logs I see in the build linked from https://github.com/rapidsai/docs/pull/663#issuecomment-3175192343, `raft` is the first library processed and it immediately hits this issue.

When I run this locally, several other libraries are processed before that, and don't hit this issue.

Locally this prints thousands of lines of logs and exited with 0, so I just assumed it was working correctly and didn't carefully check those logs.

I suspect the difference in order is a result of different Python versions... no guarantees are made about the ordering of dictionary keys, and this code is driven by some YAML/JSON config files converted to Python dictionaries.