### PR TITLE
post-processing: update and expand docs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,66 @@
+# ci
+
+## API docs
+
+The site's `/api` page links to API documentation for many RAPIDS projects.
+
+Those API docs are built in CI of the individual projects, published to object storage,
+then pulled into builds here and integrated into the rest of the docs site.
+
+The steps are roughly as follows.
+
+### Step 1: determine libraries and versions to build
+
+`get-projects-to-versions.sh` is responsible for holding all the logic relevant to the question "projects' API docs should be hosted? what versions?".
+
+Run it from the root of the repo to see for yourself.
+
+```shell
+./ci/get-projects-to-versions.sh
+```
+
+That script is re-used by other automation to determine which projects and versions to build.
+
+### Step 2: download API docs
+
+All of the API docs for RAPIDS projects are uploaded to an S3 bucket from those projects' CI.
+
+To integrate them into the docs site, they need to be downloaded and placed in `_site/api/` locally.
+
+```shell
+./ci/download_from_s3.sh
+```
+
+### Step 3: post-processing
+
+After downloading the API docs, they'll all be arranged locally in directories named with version numbers, like this:
+
+```text
+_site/api/
+├── cudf
+│   ├── 25.06
+│   ├── 25.08
+│   ├── 25.10
+├── cudf-java
+│   ├── 25.06
+│   ├── 25.08
+├── cuml
+│   ├── 25.06
+│   ├── 25.08
+│   ├── 25.10
+```
+
+Further processing is then needed to integrate them into the docs site, including:
+
+* mapping version numbers like `25.10` to version identifies like `"stable"` (to populate links like https://docs.rapids.ai/api/cudf/stable/)
+* adding version selectors on all the docs pages
+* other formatting and visual consistency changes
+
+That is handled by the code in the `ci/customization` directory.
+You can invoke it all like this:
+
+```shell
+./ci/post-process.sh
+```
+
+See the docs in `ci/customization` for more details ([customization/README.md](./customization/README.md)).

--- a/ci/README.md
+++ b/ci/README.md
@@ -19,7 +19,7 @@ Run it from the root of the repo to see for yourself.
 ./ci/get-projects-to-versions.sh
 ```
 
-That script is re-used by other automation to determine which projects and versions to build.
+That script is reused by other automation to determine which projects and versions to build.
 
 ### Step 2: download API docs
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ The steps are roughly as follows.
 
 ### Step 1: determine libraries and versions to build
 
-`get-projects-to-versions.sh` is responsible for holding all the logic relevant to the question "projects' API docs should be hosted? what versions?".
+`get-projects-to-versions.sh` is responsible for holding all the logic relevant to the questions "What projects' API docs should be hosted? What versions?".
 
 Run it from the root of the repo to see for yourself.
 


### PR DESCRIPTION
API documentation for RAPIDS projects are built in those projects' CI and uploaded to an S3 bucket.

CI in this repo then downloads those files and does some post-processing to integrate them into the rest of the docs site, resulting in this page: https://docs.rapids.ai/api/

I've been making some changes to the process recently, and @AyodeAwe asked if I could update / expand the docs on how everything fits together: https://github.com/rapidsai/docs/pull/664#issuecomment-3175643344

This PR has those docs updates.