### PR TITLE
post-processing: fix version map, use pre-commit to regenerate it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ files-to-customize.txt
 .netlify
 __pycache__/
 node_modules
-projects-to-versions.json
 rapids-docs-env/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,13 @@ repos:
             .devcontainer/devcontainer.json
           )
       - id: check-yaml
+  - repo: local
+    hooks:
+      - id: generate-projects-to-versions
+        name: generate-projects-to-versions
+        entry: ./ci/generate-projects-to-versions.sh
+        language: system
+        pass_filenames: false
   - repo: https://github.com/sirosen/texthooks
     rev: 0.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@ ci:
   autoupdate_branch: ""
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: quarterly
+  skip:
+    # requires 'jq' and 'yq', which dont' come pre-installed in the pre-commit.ci image
+    - generate-projects-to-versions
   submodules: false
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: quarterly
   skip:
-    # requires 'jq' and 'yq', which dont' come pre-installed in the pre-commit.ci image
+    # requires 'jq' and 'yq', which don't come pre-installed in the pre-commit.ci image
     - generate-projects-to-versions
   submodules: false
 

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -142,7 +142,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
-      stable: 0
+      stable: 1
       nightly: 1
 
 

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -35,6 +35,28 @@ apis:
       legacy: 1
       stable: 1
       nightly: 1
+  cugraph:
+    name: cuGraph
+    path: cugraph
+    desc: 'cuGraph is a GPU accelerated graph analytics library, with functionality like NetworkX, which is seamlessly integrated into the RAPIDS data science platform. cuGraph supports GNNs with PyG, DGL packages, cugraph-service for analytics on a remote graph, and WHOLEGRAPH for memory management.'
+    ghlink: https://github.com/rapidsai/cugraph
+    cllink: https://github.com/rapidsai/cugraph/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  cuxfilter:
+    name: cuxfilter
+    path: cuxfilter
+    desc: 'cuxfilter acts as a connector library, which provides the connections between different visualization libraries and a GPU dataframe without much hassle. This also allows the user to use charts from different libraries in a single dashboard, while also providing the interaction.'
+    ghlink: https://github.com/rapidsai/cuxfilter
+    cllink: https://github.com/rapidsai/cuxfilter/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
   cudf-java:
     name: 'Java + cuDF'
     path: cudf-java
@@ -46,6 +68,83 @@ apis:
       legacy: 1
       stable: 1
       nightly: 0
+  cucim:
+    name: cuCIM
+    path: cucim
+    desc: 'The RAPIDS cuCIM is an extensible toolkit designed to provide GPU accelerated I/O, computer vision & image processing primitives for N-Dimensional images with a focus on biomedical imaging.'
+    ghlink: https://github.com/rapidsai/cucim
+    cllink: https://github.com/rapidsai/cucim/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  cuvs:
+    name: cuVS
+    path: cuvs
+    desc: 'cuVS is a library for GPU-accelerated vector search and clustering.'
+    ghlink: https://github.com/rapidsai/cuvs
+    cllink: https://github.com/rapidsai/cuvs/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  kvikio:
+    name: KvikIO
+    path: kvikio
+    desc: "KvikIO is a Python and C++ library for high performance file IO using GPUDirect Storage (GDS)."
+    ghlink: https://github.com/rapidsai/kvikio
+    cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  raft:
+    name: RAFT
+    path: raft
+    desc: "RAFT contains fundamental widely-used algorithms and primitives for vector search, machine learning, and information retrieval."
+    ghlink: https://github.com/rapidsai/raft
+    cllink: https://github.com/rapidsai/raft/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  dask-cuda:
+    name: Dask-CUDA
+    path: dask-cuda
+    desc: "Various utilities to improve deployment and management of Dask workers on CUDA-enabled systems."
+    ghlink: https://github.com/rapidsai/dask-cuda
+    cllink: https://github.com/rapidsai/dask-cuda/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  rmm:
+    name: RMM
+    path: rmm
+    desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
+    ghlink: https://github.com/rapidsai/rmm
+    cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  rapidsmpf:
+    name: RapidsMPF
+    path: rapidsmpf
+    desc: 'RAPIDS Multi-Process Foundation (rapidsmpf) is a collection of multi-GPU, distributed memory algorithms written in C++ and exposed to Python.'
+    ghlink: https://github.com/rapidsai/rapidsmpf
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1
+
 
 # RAPIDS "Libs" - lower-level libraries that are building blocks for creating
 #                 custom tools and integrate with other libraries
@@ -68,6 +167,28 @@ libs:
     desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  libcuml:
+    name: libcuml
+    path: libcuml
+    desc: 'libcuml is a C/C++ CUDA library for cuML.'
+    ghlink: https://github.com/rapidsai/cuml
+    cllink: https://github.com/rapidsai/cuml/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 1
+      stable: 1
+      nightly: 1
+  libkvikio:
+    name: libkvikio
+    path: libkvikio
+    desc: "libkvikio is a C++ header-only library providing bindings to cuFile, which enables GPUDirect Storage (GDS)."
+    ghlink: https://github.com/rapidsai/kvikio
+    cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -1,0 +1,58 @@
+{
+  "cudf": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "cudf-java": {
+    "legacy": "25.06",
+    "stable": "25.08"
+  },
+  "cuml": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "cuproj": {
+    "legacy": "25.02",
+    "stable": "25.04"
+  },
+  "cusignal": {},
+  "cuspatial": {
+    "legacy": "25.02",
+    "stable": "25.04"
+  },
+  "dask-cudf": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "libcudf": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "libcuproj": {
+    "legacy": "25.02",
+    "stable": "25.04"
+  },
+  "libcuspatial": {
+    "legacy": "25.02",
+    "stable": "25.04"
+  },
+  "librmm": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "libucxx": {
+    "legacy": "0.44",
+    "nightly": "0.46",
+    "stable": "0.45"
+  },
+  "rapids-cmake": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  }
+}

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -101,7 +101,8 @@
     "stable": "25.08"
   },
   "rapidsmpf": {
-    "nightly": "25.10"
+    "nightly": "25.10",
+    "stable": "25.08"
   },
   "rmm": {
     "legacy": "25.06",

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -1,4 +1,9 @@
 {
+  "cucim": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
   "cudf": {
     "legacy": "25.06",
     "nightly": "25.10",
@@ -6,6 +11,11 @@
   },
   "cudf-java": {
     "legacy": "25.06",
+    "stable": "25.08"
+  },
+  "cugraph": {
+    "legacy": "25.06",
+    "nightly": "25.10",
     "stable": "25.08"
   },
   "cuml": {
@@ -22,12 +32,37 @@
     "legacy": "25.02",
     "stable": "25.04"
   },
+  "cuvs": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "cuxfilter": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "dask-cuda": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
   "dask-cudf": {
     "legacy": "25.06",
     "nightly": "25.10",
     "stable": "25.08"
   },
+  "kvikio": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
   "libcudf": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "libcuml": {
     "legacy": "25.06",
     "nightly": "25.10",
     "stable": "25.08"
@@ -40,6 +75,11 @@
     "legacy": "25.02",
     "stable": "25.04"
   },
+  "libkvikio": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
   "librmm": {
     "legacy": "25.06",
     "nightly": "25.10",
@@ -50,7 +90,20 @@
     "nightly": "0.46",
     "stable": "0.45"
   },
+  "raft": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
   "rapids-cmake": {
+    "legacy": "25.06",
+    "nightly": "25.10",
+    "stable": "25.08"
+  },
+  "rapidsmpf": {
+    "nightly": "25.10"
+  },
+  "rmm": {
     "legacy": "25.06",
     "nightly": "25.10",
     "stable": "25.08"

--- a/ci/download_from_s3.sh
+++ b/ci/download_from_s3.sh
@@ -71,7 +71,7 @@ download_lib_docs() {
     SRC VERSION_NAME VERSION_NUMBER
 
   echo "--- processing RAPIDS libraries ---"
-  PROJECTS_TO_VERSIONS_JSON=$(./ci/get-projects-to-versions.sh)
+  PROJECTS_TO_VERSIONS_JSON=$(cat "./ci/customization/projects-to-versions.json")
   for PROJECT in $(jq -r 'keys | .[]' <<< "${PROJECTS_TO_VERSIONS_JSON}"); do
 
     # extract the map of versions to download for this project, which will look something like:

--- a/ci/generate-projects-to-versions.sh
+++ b/ci/generate-projects-to-versions.sh
@@ -35,7 +35,7 @@
 #
 # Only that mapping is written to stdout, so this is safe to use inline like this:
 #
-#     PROJECTS_TO_VERSIONS=$(./ci/get-projects-to-versions.sh)
+#     PROJECTS_TO_VERSIONS=$(./ci/generate-projects-to-versions.sh)
 #
 # WARNING: no guarantees are made about the ordering of output in this mapping.
 #
@@ -58,6 +58,7 @@ VERSION_MAP=$(jq '{
 PROJECTS_TO_VERSIONS='{}'
 
 for PROJECT in $(yq -r 'keys | .[]' <<< "$PROJECT_MAP"); do
+    log-stderr "active: ${PROJECT}"
     THIS_PROJECT_MAP="{\"${PROJECT}\":{}}"
     for VERSION_NAME in $(jq -r 'keys | .[]' <<< "$VERSION_MAP"); do
         VERSION_NUMBER=$(jq -r --arg vn "$VERSION_NAME" --arg pr "$PROJECT" '
@@ -130,4 +131,4 @@ for PROJECT in $(yq -r 'keys | .[]' <<< "$INACTIVE_PROJECT_MAP"); do
     )
 done
 
-echo -n "${PROJECTS_TO_VERSIONS}"
+echo "${PROJECTS_TO_VERSIONS}" > ./ci/customization/projects-to-versions.json

--- a/ci/generate-projects-to-versions.sh
+++ b/ci/generate-projects-to-versions.sh
@@ -46,24 +46,6 @@ log-stderr() {
     echo "${1}" >&2
 }
 
-# no way to pre-install tools on pre-commit.ci, so ensure they
-# get installed at runtime as needed here
-if type -f jq && type -f yq ; then
-    log-stderr "detected 'jq' and 'yq' already installed"
-else
-    DETECTED_OS="$(uname)"
-    if [[ "${DETECTED_OS}" != "Linux" ]] || ! type -f apt-get; then
-        log-stderr "'jq' and/or 'yq' not found, and not sure how to automatically them'. Install those tools."
-        exit 1
-    else
-        log-stderr "'jq' and/or 'yq' not found, installing them with 'apt'"
-        apt-get update
-        apt-get install -y --no-install-recommends \
-            jq \
-            yq
-    fi
-fi
-
 PROJECT_MAP=$(yq '.apis + .libs'  _data/docs.yml)
 INACTIVE_PROJECT_MAP=$(yq '.inactive-projects' _data/docs.yml)
 

--- a/ci/generate-projects-to-versions.sh
+++ b/ci/generate-projects-to-versions.sh
@@ -52,7 +52,7 @@ if type -f jq && type -f yq ; then
     log-stderr "detected 'jq' and 'yq' already installed"
 else
     DETECTED_OS="$(uname)"
-    if [[ "${DETECTED_OS}" != "Linux" ]] || ! type -f apt; then
+    if [[ "${DETECTED_OS}" != "Linux" ]] || ! type -f apt-get; then
         log-stderr "'jq' and/or 'yq' not found, and not sure how to automatically them'. Install those tools."
         exit 1
     else

--- a/ci/generate-projects-to-versions.sh
+++ b/ci/generate-projects-to-versions.sh
@@ -58,7 +58,6 @@ VERSION_MAP=$(jq '{
 PROJECTS_TO_VERSIONS='{}'
 
 for PROJECT in $(yq -r 'keys | .[]' <<< "$PROJECT_MAP"); do
-    log-stderr "active: ${PROJECT}"
     THIS_PROJECT_MAP="{\"${PROJECT}\":{}}"
     for VERSION_NAME in $(jq -r 'keys | .[]' <<< "$VERSION_MAP"); do
         VERSION_NUMBER=$(jq -r --arg vn "$VERSION_NAME" --arg pr "$PROJECT" '

--- a/ci/generate-projects-to-versions.sh
+++ b/ci/generate-projects-to-versions.sh
@@ -46,6 +46,24 @@ log-stderr() {
     echo "${1}" >&2
 }
 
+# no way to pre-install tools on pre-commit.ci, so ensure they
+# get installed at runtime as needed here
+if type -f jq && type -f yq ; then
+    log-stderr "detected 'jq' and 'yq' already installed"
+else
+    DETECTED_OS="$(uname)"
+    if [[ "${DETECTED_OS}" != "Linux" ]] || ! type -f apt; then
+        log-stderr "'jq' and/or 'yq' not found, and not sure how to automatically them'. Install those tools."
+        exit 1
+    else
+        log-stderr "'jq' and/or 'yq' not found, installing them with 'apt'"
+        apt-get update
+        apt-get install -y --no-install-recommends \
+            jq \
+            yq
+    fi
+fi
+
 PROJECT_MAP=$(yq '.apis + .libs'  _data/docs.yml)
 INACTIVE_PROJECT_MAP=$(yq '.inactive-projects' _data/docs.yml)
 

--- a/ci/post-process.sh
+++ b/ci/post-process.sh
@@ -10,7 +10,6 @@ CURRENT_DIR=$(dirname $(realpath $0))
 pip install -r "${CURRENT_DIR}/customization/requirements.txt"
 
 PROJECTS_TO_VERSIONS_PATH="${CURRENT_DIR}"/customization/projects-to-versions.json
-"${CURRENT_DIR}"/get-projects-to-versions.sh > "${PROJECTS_TO_VERSIONS_PATH}"
 
 "${CURRENT_DIR}"/update_symlinks.sh "${PROJECTS_TO_VERSIONS_PATH}"
 


### PR DESCRIPTION
Follow-up to fix the issues noted in https://github.com/rapidsai/docs/pull/657#issuecomment-3184788441

In #657, I accidentally removed some projects (like `cucim`, `cuxfilter`, and `rmm`) from https://docs.rapids.ai/api/, via a mix of a bad merge conflict resolution and mistakes made reading the diff.

This fixes that, by restoring the dropped entries in `_data/docs.yml`.

It also proposes changes to prevent this type of thing from slipping through in the future:

* checking `projects-to-versions.json` into source control
* using a `pre-commit` hook to regenerate it
  - *@KyleFromNVIDIA set up something similar for `rapids-medata` and it's been very helpful there* ([code link](https://github.com/rapidsai/rapids-metadata/blob/883506afa46f28406a7b693f81c6a8834c9ed68c/.pre-commit-config.yaml#L54-L69))

## Notes for Reviewers

### How I tested this

Re-generated the docs site locally, following the docs at https://github.com/rapidsai/docs/blob/b04146f73554cf799cae3143ddc164c9326ae8ed/CONTRIBUTING.md#L37

Confirmed that every expected library was downloaded, the processing worked for all of them, and the API docs pages rendered correctly.

I also tried manually changing entries in `releases.json`, `docs.yml`, and `projects-to-versions.json`, then running

```shell
pre-commit run --all-files
```

In all cases, I saw the hook correctly update that file.