### PR TITLE
cugraph: explicitly mention libraries by name on API docs page

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -38,7 +38,7 @@ apis:
   cugraph:
     name: cuGraph
     path: cugraph
-    desc: 'cuGraph is a GPU accelerated graph analytics library, with functionality like NetworkX, which is seamlessly integrated into the RAPIDS data science platform. cuGraph supports GNNs with PyG, DGL packages, cugraph-service for analytics on a remote graph, and WHOLEGRAPH for memory management.'
+    desc: 'cuGraph is a GPU accelerated graph analytics library, the core part of an ecosystem of libraries supporting graph-processing workloads like NetworkX integration (nx-cugraph), GNNs with PyG (cugraph-pyg), analytics on a remote graph (cugraph-service), and more efficient memory management for large graphs (pylibwholegraph).'
     ghlink: https://github.com/rapidsai/cugraph
     cllink: https://github.com/rapidsai/cugraph/blob/main/CHANGELOG.md
     versions:


### PR DESCRIPTION
Follow-up to https://github.com/rapidsai/docs/pull/669#discussion_r2274421865

@bdice's comment there highlights that the API docs for cuGraph and its ecosystem of related libraries can be a bit hard to find right now. At https://docs.rapids.ai/api/, you see individual entries for `cudf`, `dask-cudf`, `Java + cudf`, and `libcudf`, but only a single `cuGraph` entry.

<img width="1309" height="841" alt="image" src="https://github.com/user-attachments/assets/e31c406c-d100-43da-9474-212925484e27" />

I believe this is intentional (@acostadon please correct me), and it's related to the fact that `cugraph`-related libraries have all their docs built and combined together in a dedicated repo: https://github.com/rapidsai/cugraph-docs

When you click the `Stable (25.08)` link on that API docs page, you're directed to https://docs.rapids.ai/api/cugraph/stable/, which mentions all of the libraries by name:

<img width="1413" height="854" alt="Screenshot 2025-08-13 at 4 45 42 PM" src="https://github.com/user-attachments/assets/411eaa3b-21ea-47ea-9a64-310163a019e5" />

Here, I'm proposing updating the language about `cuGraph` on that main API docs page, to clarify that all those libraries are documented in there.

* mentions all the cuGraph libraries by name
* removes references to DGL (https://docs.rapids.ai/notices/rsn0046/)