### PR TITLE
RSN 52: dropping pynvjitlink

### DIFF
--- a/_notices/rsn0052.md
+++ b/_notices/rsn0052.md
@@ -28,7 +28,7 @@ notice_updated: 2025-08-18
 
 Starting with RAPIDS `v25.10`, RAPIDS libraries no longer depend on `pynvjitlink`.
 
-The final release of `pynvjitlink` was `v0.7.0`. Future releases are not planned, and https://github.com/rapidsai/pynvjitlink will be archived.
+The final release of `pynvjitlink` was `v0.7.0`. Future releases are not planned, and <https://github.com/rapidsai/pynvjitlink> will be archived.
 
 ## Impact
 
@@ -40,6 +40,6 @@ All other public APIs of `pynvjitlink` are replaced by `cuda.core` and `cuda.bin
 
 Documentation:
 
-* `cuda.core`: https://nvidia.github.io/cuda-python/cuda-core/latest/
-* `cuda.bindings`: https://nvidia.github.io/cuda-python/cuda-bindings/latest/
-* `numba-cuda`: https://nvidia.github.io/numba-cuda/
+* `cuda.core`: <https://nvidia.github.io/cuda-python/cuda-core/latest/>
+* `cuda.bindings`: <https://nvidia.github.io/cuda-python/cuda-bindings/latest/>
+* `numba-cuda`: <https://nvidia.github.io/numba-cuda/>


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/210

Proposes an RSN documenting RAPIDS dropping `pynvjitlink` in its 25.10 release. See the linked issue and https://github.com/rapidsai/pynvjitlink/issues/130 for background on why we're doing this.

## Notes for Reviewers

### How I tested this

Checked the preview here: https://deploy-preview-672--docs-rapids-ai.netlify.app/notices/rsn0052/