### PR TITLE
Add redirects for cuml-accel docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -44,3 +44,9 @@
 /deployment/ /deployment/stable/
 /api/libucxx /api/libucxx/stable/
 /api/libucxx/ /api/libucxx/stable/
+# redirects for zero-code-change -> cuml-accel rename, can be removed after 25.10 release
+/api/cuml/stable/zero-code-change/ /api/cuml/stable/cuml-accel/
+/api/cuml/stable/zero-code-change-benchmarks/ /api/cuml/stable/cuml-accel/benchmarks/
+/api/cuml/stable/zero-code-change-limitations/ /api/cuml/stable/cuml-accel/limitations/
+/api/cuml/stable/zero-code-change-logging/ /api/cuml/stable/cuml-accel/logging-and-profiling/
+/api/cuml/stable/zero_code_change_examples/plot_kmeans_digits/ /api/cuml/stable/cuml-accel/examples/plot_kmeans_digits/


### PR DESCRIPTION
We added client-side redirects in the cuml docs, but these were done incorrectly (they assumed our docs were built using the `html` builder, not the `dirhtml` builder). I've [pushed a PR ](https://github.com/rapidsai/cuml/pull/7139)up to fix this in the docs source, but to fix the last release we'll want to (at least temporarily) add redirects here as well.