### PR TITLE
mark CUDA 12.9 and pynvjitlink RSNs complete

### DIFF
--- a/_notices/rsn0051.md
+++ b/_notices/rsn0051.md
@@ -9,8 +9,8 @@ notice_id: 51 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "RAPIDS 25.08 replaces CUDA 12.8 with CUDA 12.9 in our Docker Images"
 notice_author: RAPIDS Ops
-notice_status: "In Progress"
-notice_status_color: yellow
+notice_status: "Completed"
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"

--- a/_notices/rsn0052.md
+++ b/_notices/rsn0052.md
@@ -9,8 +9,8 @@ notice_id: 52 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Dropping of pynvjitlink in RAPIDS Release v25.10"
 notice_author: RAPIDS Ops
-notice_status: "In Progress"
-notice_status_color: yellow
+notice_status: "Completed"
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/210 and https://github.com/rapidsai/build-planning/issues/173

Marks 2 RSNs complete:

* RSN 51: using CUDA 12.9 in container images
* RSN 52: archiving `pynvjitlink`

Those images are now up (https://github.com/rapidsai/docker/pull/767), and `pynvjitlink` was archived (https://github.com/rapidsai/build-planning/issues/210#issuecomment-3233978074)