### PR TITLE
fix API docs versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,12 @@ cp -avR "${BACKUP_DIR}/api" _site
 
 In a browser, navigate to the URL shown in the `jekyll serve` output (probably something like `http://127.0.0.1:4000/`) to see the rendered docs.
 
+If the hot reloading in `jekyll serve` again deletes all the files in `api/`, just copy them in again.
+
+```shell
+cp -avR "${BACKUP_DIR}/api" _site
+```
+
 ## PR submissions
 
 Once you have code changes, submit a PR to the docs site. Netlify will generate

--- a/_includes/api-docs.html
+++ b/_includes/api-docs.html
@@ -11,7 +11,7 @@
 #### DOCS {% for version_name in versions -%}
     {%- if api.version-overrides -%}
         **[{{ version_name }} ({{ api.version-overrides[version_name] }})](/api/{{ api.path }}/{{ version_name }})**
-    {%- elsif api.name | downcase contains "ucxx" -%}
+    {%- elsif api.name == "libucxx" or api.name == "UCXX" -%}
         **[{{ version_name }} ({{ site.data.releases[version_name].ucxx_version }})](/api/{{ api.path }}/{{ version_name }})**
     {%- else -%}
         **[{{ version_name }} ({{ site.data.releases[version_name].version }})](/api/{{ api.path }}/{{ version_name }})**


### PR DESCRIPTION
Fixes #684

In https://github.com/rapidsai/docs/pull/679#discussion_r2349193446 I'd tried to push us towards using the `downcase` filter from Liquid (https://shopify.dev/docs/api/liquid/filters/downcase) for a "use a different version for UCXX" projects, to deal with:

* casing differences, e.g. `"libucxx"` (lowercase) vs. `"UCXX"` (uppercase)
* the possibility of adding `distributed-ucxx` in the future

But that seems to have broken the versioning of all the other API docs (cuDF, cuML, etc.).

This fixes that.

## Notes for Reviewers

### How I tested this

Tested locally, following the docs in `CONTRIBUTING.md`. Saw the expected versions for all libraries on the API docs page.