### PR TITLE
RSN 50: dropping ucx-py (mark completed)

### DIFF
--- a/_notices/rsn0050.md
+++ b/_notices/rsn0050.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Dropping of UCX-Py project in RAPIDS Release v25.10"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,7 +22,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v25.10+"
 notice_created: 2025-07-10
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-07-10
+notice_updated: 2025-09-18
 ---
 
 ## Overview


### PR DESCRIPTION
https://github.com/rapidsai/ucx-py has now been archived

* https://github.com/rapidsai/ucx-py/issues/1160
* https://github.com/rapidsai/build-planning/issues/198

This marks the relevant RSN "completed".