### PR TITLE
Require minimum of CUDA 12.2 in RAPIDS 25.12

### DIFF
--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -1,0 +1,35 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 48 # should match notice number
+notice_pin: true # set to true to pin to notice page
+title: "Deprecation announcement for Dropping CUDA minimum version from 12.0 to 12.2 in v25.12"
+notice_author: RAPIDS Ops
+notice_status: "Yellow"
+notice_status_color: green
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v25.12"
+notice_created: 2025-09-29
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2025-09-29
+---
+
+## Overview
+
+RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 to 12.1 starting with the v25.12 release.  All of RAPIDS will require a minimum of CUDA 12.2 including containers, all published packages (wheels and conda), and compilation from source in Release `v25.12`, scheduled for December 11, 2025. `v25.12` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.1, 12.9 and 12.13 containers.
+
+## Impact
+
+Effective RAPIDS `v25.12` release, RAPIDS will cease distribution of CUDA 12.0 release artifacts, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 12.0.
+RAPIDS will support CUDA 12.2 12.9 and 12.3 Docker containers.
+Users who still wish to use CUDA 11 may pin to RAPIDS `v25.10`.

--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -26,7 +26,10 @@ notice_updated: 2025-09-29
 
 ## Overview
 
-RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 and 12.1 to 12.2 starting with the v25.12 release.  All of RAPIDS will require a minimum of CUDA 12.2 including containers, all published packages (wheels and conda), and compilation from source in Release `v25.12`, scheduled for December 11, 2025. `v25.12` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.1, 12.9 and 13.0 containers.
+RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 to 12.2 starting with the v25.12 release.
+All of RAPIDS will require a minimum of CUDA 12.2 including containers, all published packages (wheels and conda), and compilation from source in Release `v25.12`, scheduled for December 11, 2025.
+`v25.10` will be the last RAPIDS release to support CUDA 12.0 and 12.1 runtimes in any format.
+We are continuing support for CUDA 12 and 13 containers, with CUDA major version tags. See [RSN 53](https://docs.rapids.ai/notices/rsn0053/) for more information.
 
 ## Impact
 

--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -5,7 +5,7 @@ grand_parent: RAPIDS Notices
 nav_exclude: true
 notice_type: rsn
 # Update meta-data for notice
-notice_id: 48 # should match notice number
+notice_id: 54 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation announcement for Dropping CUDA minimum version from 12.0 to 12.2 in v25.12"
 notice_author: RAPIDS Ops
@@ -26,10 +26,10 @@ notice_updated: 2025-09-29
 
 ## Overview
 
-RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 to 12.1 starting with the v25.12 release.  All of RAPIDS will require a minimum of CUDA 12.2 including containers, all published packages (wheels and conda), and compilation from source in Release `v25.12`, scheduled for December 11, 2025. `v25.12` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.1, 12.9 and 12.13 containers.
+RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 and 12.1 to 12.2 starting with the v25.12 release.  All of RAPIDS will require a minimum of CUDA 12.2 including containers, all published packages (wheels and conda), and compilation from source in Release `v25.12`, scheduled for December 11, 2025. `v25.12` will be the last RAPIDS release to support CUDA 11 runtimes in any format. We are continuing support for CUDA 12.1, 12.9 and 13.0 containers.
 
 ## Impact
 
-Effective RAPIDS `v25.12` release, RAPIDS will cease distribution of CUDA 12.0 release artifacts, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 12.0.
-RAPIDS will support CUDA 12.2 12.9 and 12.3 Docker containers.
+Effective RAPIDS `v25.12` release, RAPIDS will cease distribution of CUDA 12.0 and 12.1 to 12.2 release artifacts, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 12.0.
+RAPIDS will support CUDA 12.2 12.9 and 13.0 Docker containers.
 Users who still wish to use CUDA 11 may pin to RAPIDS `v25.10`.

--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -9,8 +9,8 @@ notice_id: 54 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Deprecation announcement for Dropping CUDA minimum version from 12.0 to 12.2 in v25.12"
 notice_author: RAPIDS Ops
-notice_status: "Yellow"
-notice_status_color: green
+notice_status: "In Progress"
+notice_status_color: yellow
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"

--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -30,6 +30,5 @@ RAPIDS is raising the minimum required CUDA version for the entire software suit
 
 ## Impact
 
-Effective RAPIDS `v25.12` release, RAPIDS will cease distribution of CUDA 12.0 and 12.1 to 12.2 release artifacts, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 12.0.
-RAPIDS will support CUDA 12.2 12.9 and 13.0 Docker containers.
-Users who still wish to use CUDA 11 may pin to RAPIDS `v25.10`.
+Effective RAPIDS `v25.12` release, RAPIDS will require CUDA 12.2, including containers and all our published packages (wheels and conda), and will not support compilation from source with CUDA 12.0.
+Users who still wish to use CUDA 12.0 may pin to RAPIDS `v25.10`.

--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 54 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Deprecation announcement for Dropping CUDA minimum version from 12.0 to 12.2 in v25.12"
+title: "Increasing CUDA minimum requirement from 12.0 to 12.2 in v25.12"
 notice_author: RAPIDS Ops
 notice_status: "In Progress"
 notice_status_color: yellow


### PR DESCRIPTION
RAPIDS is raising the minimum required CUDA version for the entire software suite from 12.0 to 12.2 starting with the v25.12