### PR TITLE
Update versions.md with cleanup instructions for Anaconda

### DIFF
--- a/resources/versions.md
+++ b/resources/versions.md
@@ -38,3 +38,29 @@ Using CalVer for versioning, RAPIDS projects use the notation `YY.MM.PP` for rel
 A hotfix/patch release occurs for the current release, incrementing the hotfix/patch version number by 1.
 
 There is no limit or time constraint of these releases as they are governed by the need to fix critical issues in the current release. Generally, hotfix/patch releases contain only one change and are typically bug fixes; new features should not be introduced in this way.
+
+## Cleaning up accidental publications on anaconda.org
+
+These commands require that the logged-in user (`anaconda login`) is in the owner group for the involved channels. More information on how to manage groups and channels ("organizations") is on [Anaconda's documentation](https://www.anaconda.com/docs/tools/anaconda-org/user-guide/work-with-groups).
+
+### Remove all files for a given package name with a specific version
+
+When release procedures are not well-established or some other accident has resulted in packages that may cause problems, we need to remove packages.
+
+`anaconda remove <channel>/<package>/<version>`
+
+A real example of this would be removing an accidentally published package for rapids-logger, with a version that doesn't make sense:
+
+`anaconda remove rapidsai-nightly/rapids-logger/0.2.27`
+
+### Copy files from one channel to another
+
+ The recommended install command right now is `conda create -n rapids-25.10 -c rapidsai-nightly -c conda-forge -c nvidia rapids=25.10 python=3.13 'cuda-version>=12.0,<=12.9'`. If a release is uploaded to the rapidsai channel and not the rapidsai-nightly channel, our install command will not see the packages on the `rapidsai`. If both channels were added, we would have to be very careful about strict channel priority, which could easily pick up older or alpha releases.
+
+ One solution to this is to just copy the published packages to both `rapidsai` and `rapidsai-nightly`.
+
+`anaconda copy <source channel>/<package>/<version> --to-owner <destination channel>`
+
+and a real example:
+
+`anaconda copy rapidsai/rapids-logger/0.2.2 --to-owner rapidsai-nightly`

--- a/resources/versions.md
+++ b/resources/versions.md
@@ -55,9 +55,9 @@ A real example of this would be removing an accidentally published package for r
 
 ### Copy files from one channel to another
 
- The recommended install command right now is `conda create -n rapids-25.10 -c rapidsai-nightly -c conda-forge -c nvidia rapids=25.10 python=3.13 'cuda-version>=12.0,<=12.9'`. If a release is uploaded to the rapidsai channel and not the rapidsai-nightly channel, our install command will not see the packages on the `rapidsai`. If both channels were added, we would have to be very careful about strict channel priority, which could easily pick up older or alpha releases.
+The recommended install command at time of writing is `conda create -n rapids-25.10 -c rapidsai-nightly -c conda-forge -c nvidia rapids=25.10 python=3.13 'cuda-version>=12.0,<=12.9'`. If a release is uploaded to the rapidsai channel and not the rapidsai-nightly channel, our install command will not see the packages on the `rapidsai` channel. It's just not in the channel list. If both channels were added, we would have to be very careful about strict channel priority, which could easily pick up older or alpha releases.
 
- One solution to this is to just copy the published packages to both `rapidsai` and `rapidsai-nightly`.
+One solution to this is to just copy the published packages to both `rapidsai` and `rapidsai-nightly`.
 
 `anaconda copy <source channel>/<package>/<version> --to-owner <destination channel>`
 


### PR DESCRIPTION
Added instructions for cleaning up accidental publications on anaconda.org, including commands for removing and copying packages between channels.