### PR TITLE
Fix default Docker CUDA version

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -373,7 +373,7 @@
             active_python_ver: "3.13",
             active_conda_cuda_ver: "12",
             active_pip_cuda_ver: "12",
-            active_docker_cuda_ver: "12",
+            active_docker_cuda_ver: "12.9",
             active_method: "Conda",
             active_release: "Stable",
             active_img_type: "Base",


### PR DESCRIPTION
This fixes a bug in #687. The default value for `active_docker_cuda_version` should be one of the stable values.
