### PR TITLE
enable cudf-java stable

### DIFF
--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -25,7 +25,8 @@
     "nightly": "25.12"
   },
   "cudf-java": {
-    "legacy": "25.08"
+    "legacy": "25.08",
+    "stable": "25.10"
   },
   "cucim": {
     "legacy": "25.08",


### PR DESCRIPTION
`cudf-java` docs have been uploaded to `s3`. This change enables its publication to https://docs.rapids.ai/api