### PR TITLE
updated RSN 47 to target release 25.12 instead of 25.10

### DIFF
--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -22,7 +22,7 @@ notice_topic: Development Process Change
 notice_rapids_version: "v25.12+"
 notice_created: 2025-05-05
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-07-10
+notice_updated: 2025-10-15
 ---
 
 ## Overview


### PR DESCRIPTION
This is an update to RSN 47 updating the release target from 25.10 to 24.12. 