### PR TITLE
Show installation path from pypi.org for some packages

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -538,7 +538,7 @@
             },
             areOnlyPypiAvailablePackagesSelected() {
                 var selected_packages = this.active_packages.filter(pkg => pkg !== "Choose Specific Packages" && pkg !== "Standard");
-                var pypi_available_packages = ["cudf", "cuml", "dask-cudf"];
+                var pypi_available_packages = ["cudf", "cuml", "dask-cudf", "raft"];
                 return selected_packages.length > 0 &&
                     selected_packages.every(pkg => pypi_available_packages.includes(pkg.toLowerCase()));
             },


### PR DESCRIPTION
Updates the RAPIDS install selector to show PyPI installation paths for packages available on PyPI (cuDF, cuML, and dask-cuDF).

When users select only packages available on PyPI, the install command now:
- Omits the `--extra-index-url` flag (installs directly from PyPI)
- Updates the install notes to mention PyPI availability

For all other package selections, behavior remains unchanged (NVIDIA-hosted packages with `--extra-index-url`).

Closes https://github.com/rapidsai/docs/issues/702