### PR TITLE
RSN 55: dropping cuGraph service (mark completed)

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -38,7 +38,7 @@ apis:
   cugraph:
     name: cuGraph
     path: cugraph
-    desc: 'cuGraph is a GPU accelerated graph analytics library, the core part of an ecosystem of libraries supporting graph-processing workloads like NetworkX integration (nx-cugraph), GNNs with PyG (cugraph-pyg), analytics on a remote graph (cugraph-service), and more efficient memory management for large graphs (pylibwholegraph).'
+    desc: 'cuGraph is a GPU accelerated graph analytics library, the core part of an ecosystem of libraries supporting graph-processing workloads like NetworkX integration (nx-cugraph), GNNs with PyG (cugraph-pyg), and more efficient memory management for large graphs (pylibwholegraph).'
     ghlink: https://github.com/rapidsai/cugraph
     cllink: https://github.com/rapidsai/cugraph/blob/main/CHANGELOG.md
     versions:

--- a/_notices/rsn0055.md
+++ b/_notices/rsn0055.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Dropping of Publishing cuGraph-Service Packages in RAPIDS Release v25.12"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,7 +22,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v25.12+"
 notice_created: 2025-10-17
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-10-17
+notice_updated: 2025-11-25
 ---
 
 ## Overview


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/220

Now that we've stopped publishing `cugraph-service-{client,server}` packages (https://github.com/rapidsai/cugraph/pull/5325), marks the corresponding RSN as "completed".