### PR TITLE
Remove nvidia channel from install selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -485,8 +485,8 @@
                 var cuda_version_pinning = this.getCondaVersionSupport(this.active_conda_cuda_ver)["pinning"];
                 var py_cuda_pkgs = [this.highlightPkgOrImg("python") + "=" + python_version, "'" + this.highlightPkgOrImg("cuda-version") + cuda_version_pinning + "'"].join(" ");
                 var conda_channels = [rapids_channel, "conda-forge"]
-                    .map(ch => "-" + this.highlightFlag("c") + " " + ch + " ")
-                    .join("");
+                    .map(ch => this.highlightFlag("-c") + " " + ch)
+                    .join(" ");
                 var indentation = "    ";
 
                 // sort active_packages to appear in the same order as the additional_rapids_packages list


### PR DESCRIPTION
The `nvidia` channel is no longer needed, so we can remove it from the install selector.