### PR TITLE
added label_checker: true to ops-bot.yaml

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,9 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: false
+branch_checker: false
+label_checker: true
+release_drafter: false
+recently_updated: false
+forward_merger: false


### PR DESCRIPTION
In order to enable label based functionality like `DO NOT MERGE` label. We are adding the `ops-bot.yaml` config and setting `label_checker: true` 