### PR TITLE
25.12 - updated Maintainer Docs - Release Planning

### DIFF
--- a/releases/planning.md
+++ b/releases/planning.md
@@ -26,17 +26,17 @@ Project Leads
 
 ### Timing
 
-**NOTE:** The processes below use the current release of `M.A`, the next release of `M.B` and future release `M.C` (where `B=A+1`, `C=B+1`) for examples.
+**NOTE:** The processes below use the current release of `YY.MA`, the next release of `YY.MB` and future release `YY.MC` (where `MB=MA+2`, `MC=MB+2`) for examples.
 
 Releases are planned in two phases:
 1. `Fuzzy planning` from [Issue Triage]({% link releases/triage.md %}) which is ongoing.
-2. `Focus planning` which starts when release `M.B` is **frozen**.
+2. `Focus planning` which starts when release `YY.MB` is **frozen**.
 
 ### Release boards
 
 RAPIDS projects use GitHub project boards for tracking releases with a customized setup and automation that is copied from existing boards.
 
-For each project there is a Release board for each release. As an example [v0.5 Release](https://github.com/rapidsai/cudf/projects/5) tracks the progress for the v0.5 release. Release boards are closed once a release is completed, and are labeled `vM.A Release` where `M` & `A` are the major & minor release version numbers.
+For each project there is a Release board for each release. As an example [Release v25.10 RAPIDS](https://github.com/orgs/rapidsai/projects/190) tracks the progress for the `v25.10` release. Release boards are closed once a release is completed, and are labeled `Release vYY.MM` where `YY` & `MM` are the two digit year & two digit month.
 
 Each Release board has the following columns:
 
@@ -68,15 +68,15 @@ During `Fuzzy planning` issues are triaged and scheduled in their respective tra
 
 ### Focus planning
 
-Once a **freeze** has occurred for the release that is a WIP (i.e. release `M.B`), then planning for release `M.C` will start.
+Once a **freeze** has occurred for the release that is a WIP (i.e. release `YY.MB`), then planning for release `YY.MC` will start.
 
 Project Leads
 {: .label .label-blue}
 
-1. Review all issues in the current WIP release `M.B` and find issues that will slip.
-2. Move issues that will not make the release `M.B` to the release board for `M.C`.
+1. Review all issues in the current WIP release `YY.MB` and find issues that will slip.
+2. Move issues that will not make the release `YY.MB` to the release board for `YY.MC`.
 3. Review each of the tracking boards and examine all issues in the `Future release` columns.
-4. Add issues determined to be in-scope for the `M.C` release to the release board and move the issue to the `Next release` column in the tracking board.
-5. Prioritize all issues into columns `P0`, `P1`, or `P2` on the `M.C` release board with input from project leads.
+4. Add issues determined to be in-scope for the `YY.MC` release to the release board and move the issue to the `Next release` column in the tracking board.
+5. Prioritize all issues into columns `P0`, `P1`, or `P2` on the `YY.MC` release board with input from project leads.
 6. Rank issues within columns `P0`, `P1`, or `P2` to communicate priority for developers.
-7. Review with team on day after release of `M.B` for feedback and input before adopting as the initial release plan.
+7. Review with team on day after release of `YY.MB` for feedback and input before adopting as the initial release plan.

--- a/releases/planning.md
+++ b/releases/planning.md
@@ -32,36 +32,6 @@ Releases are planned in two phases:
 1. `Fuzzy planning` from [Issue Triage]({% link releases/triage.md %}) which is ongoing.
 2. `Focus planning` which starts when release `YY.MB` is **frozen**.
 
-### Release boards
-
-RAPIDS projects use GitHub project boards for tracking releases with a customized setup and automation that is copied from existing boards.
-
-For each project there is a Release board for each release. As an example [Release v25.10 RAPIDS](https://github.com/orgs/rapidsai/projects/190) tracks the progress for the `v25.10` release. Release boards are closed once a release is completed, and are labeled `Release vYY.MM` where `YY` & `MM` are the two digit year & two digit month.
-
-Each Release board has the following columns:
-
-| Column | Purpose |
-|:-------|:--------|
-| Issue-Needs prioritizing | Issues that have gone through the [Issue Triage]({% link releases/triage.md %}) process and need to be prioritized |
-| Issue-P0 | Issues that should be worked on first |
-| Issue-P1 | Issues that should be worked on only if all `P0` issues are complete or assigned |
-| Issue-P2 | Issues that should be worked on only if all `P1` issues are complete or assigned |
-| PR-WIP | Newly opened PRs and re-opened PRs |
-| PR-Needs Review | PRs move **automatically** to this column when pending approval by reviewer |
-| PR-Reviewer approved | PRs move **automatically** to this column when approved by reviewer |
-| Done | Issues and PRs that are closed will **automatically** be moved to this column |
-
-**IMPORTANT:** By leveraging the Release board for issues, Project Leads can _schedule_ issues by placing them in the appropriate column and then _prioritize_ issues by dragging & sorting the issues from highest priority at the top of the column to lowest at the bottom.  We can also use labels on the issues/PRs to filter and _prioritize_ work.
-
-#### Using the release board
-- Assigning and prioritizing work
-  - Scroll to the left to see all the columns labeled `Issue-*`
-  - Re-prioritize issues in `P0`, `P1`, `P2` by moving issues between columns
-  - Move high priority issues within a column to the top; this promotes "pop off the top of the stack" development
-- Expediting and finishing work
-  - Scroll to the right to see all columns labeled `PR-*`
-  - Identify PRs that need reviewers, input from authors, and other help
-
 ### Fuzzy planning
 
 During `Fuzzy planning` issues are triaged and scheduled in their respective tracking boards. This naturally creates a pool of issues to consider from across the tracking boards during `Focus planning` under the columns `Future release`.


### PR DESCRIPTION
This PR updates the Release Planning section 

* https://docs.rapids.ai/releases/planning/

to bring it up to the current planning/release process post RSN-47 

* https://docs.rapids.ai/notices/rsn0047/

This focuses on using `CALVER (YY.MM.PP)` instead and + an un-changing `main` development branch

xref: https://github.com/rapidsai/build-planning/issues/224