### PR TITLE
Mark RSN 53 as complete

### DIFF
--- a/_notices/rsn0053.md
+++ b/_notices/rsn0053.md
@@ -9,8 +9,8 @@ notice_id: 53 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "RAPIDS 25.10 consolidates Docker images to single tag per CUDA major version"
 notice_author: RAPIDS Ops
-notice_status: "In Progress"
-notice_status_color: yellow
+notice_status: "Completed"
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v25.10"
 notice_created: 2025-09-24
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-09-24
+notice_updated: 2025-12-12
 ---
 
 ## Overview


### PR DESCRIPTION
RSN 53 is complete with the release of RAPIDS 25.12.
