### PR TITLE
25.12 updated Maintainer Docs - RSN-47 - Completed

### DIFF
--- a/_notices/rsn0047.md
+++ b/_notices/rsn0047.md
@@ -10,7 +10,7 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Changes to RAPIDS branching strategy in 25.12"
 notice_author: RAPIDS Ops
-notice_status: COMPLETED
+notice_status: Completed
 notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"


### PR DESCRIPTION
This PR updates the Release Planning section 

* https://docs.rapids.ai/notices/rsn0047/

to bring it up to the current planning/release process post RSN-47 

* https://docs.rapids.ai/notices/rsn0047/

This focuses on using `CALVER (YY.MM.PP)` instead and + an un-changing `main` development branch

xref: https://github.com/rapidsai/build-planning/issues/224