### PR TITLE
25.12 updated Maintainer Docs - RSN-54 - status color green

### DIFF
--- a/_notices/rsn0054.md
+++ b/_notices/rsn0054.md
@@ -10,7 +10,7 @@ notice_pin: true # set to true to pin to notice page
 title: "Increasing CUDA minimum requirement from 12.0 to 12.2 in v25.12"
 notice_author: RAPIDS Ops
 notice_status: "Completed"
-notice_status_color: yellow
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v25.12"
 notice_created: 2025-09-29
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2025-09-29
+notice_updated: 2025-12-12
 ---
 
 ## Overview


### PR DESCRIPTION
This PR updates the Release Planning section 

* https://docs.rapids.ai/notices/rsn0054

This focuses on using `CALVER (YY.MM.PP)` instead and + an un-changing `main` development branch

xref: https://github.com/rapidsai/build-planning/issues/224