### PR TITLE
enable cudf-java docs

### DIFF
--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -25,7 +25,8 @@
     "nightly": "26.02"
   },
   "cudf-java": {
-    "legacy": "25.10"
+    "legacy": "25.10",
+    "stable": "25.12"
   },
   "cucim": {
     "legacy": "25.10",


### PR DESCRIPTION
`cudf-java` docs have been uploaded to `s3`. This change enables its publication to https://docs.rapids.ai/api