### PR TITLE
RSN 56: moving cumlprims_mg into cuml

### DIFF
--- a/_notices/rsn0056.md
+++ b/_notices/rsn0056.md
@@ -7,7 +7,7 @@ notice_type: rsn
 # Update meta-data for notice
 notice_id: 56 # should match notice number
 notice_pin: true # set to true to pin to notice page
-title: "Dropping of cumlprims_mg packages in RAPIDS Release v26.02"
+title: "Moving cumlprims_mg into cuML in RAPIDS Release v26.02"
 notice_author: RAPIDS Ops
 notice_status: "In Progress"
 notice_status_color: yellow


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/239

Adds an RSN about `libcumlprims` packages not being published for RAPIDS 26.02 and beyond.