### PR TITLE
RSN 56: mark complete

### DIFF
--- a/_notices/rsn0056.md
+++ b/_notices/rsn0056.md
@@ -9,8 +9,8 @@ notice_id: 56 # should match notice number
 notice_pin: true # set to true to pin to notice page
 title: "Moving cumlprims_mg into cuML in RAPIDS Release v26.02"
 notice_author: RAPIDS Ops
-notice_status: "In Progress"
-notice_status_color: yellow
+notice_status: "Completed"
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,7 +21,7 @@ notice_topic: Library Deprecation
 notice_rapids_version: "v26.02"
 notice_created: 2026-01-02
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-01-02
+notice_updated: 2026-01-05
 ---
 
 ## Overview


### PR DESCRIPTION
Followup to #730 

Contributes to https://github.com/rapidsai/build-planning/issues/239

https://github.com/rapidsai/cumlprims_mg has been archived, nightly packages for it have been removed, and nothing in RAPIDS depends on it any more. The RSN about its removal can be marked `Completed`.