### PR TITLE
add CUDA 13.1 support to install selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -449,7 +449,7 @@
                     },
                     "Nightly": {
                         "12": ["12.2", "12.9"],
-                        "13": ["13.0"]
+                        "13": ["13.0", "13.1"]
                     }
                 };
                 var bounds = cuda_version_info[this.active_release][version];


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/236

Adds CUDA 13.1 to the release selector for nightly packages. RAPIDS 26.02 nightlies almost all now support CUDA 13.1 (just cuGraph is left, see https://github.com/rapidsai/cugraph/pull/5383).