### PR TITLE
Fix typo in releases.json

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -48,7 +48,7 @@
       "days": "2"
     }
   },
-  "next-nightly": {
+  "next_nightly": {
     "version": "26.04",
     "ucxx_version": "0.49",
     "cudf_dev": {


### PR DESCRIPTION
It should be `next_nightly`, not `next-nightly`. Missed in https://github.com/rapidsai/docs/pull/718