### PR TITLE
update all GitHub Actions and pre-commit versions

### DIFF
--- a/.github/workflows/deploy-cudf-java-docs.yaml
+++ b/.github/workflows/deploy-cudf-java-docs.yaml
@@ -30,9 +30,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v5.1.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -55,7 +55,7 @@ jobs:
           echo "Updated stable value for cudf-java to $NEW_STABLE_VALUE in _data/docs.yml"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update stable value for cudf-java in docs.yml"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Build (and deploy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
           bundle install
           bundle exec jekyll build
 
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@v5.1.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -62,4 +62,5 @@ jobs:
             ARGS="--prod"
           fi
           netlify deploy "$ARGS" \
+            --debug \
             --dir=_site

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,9 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Check style
-        run: ./ci/check_style.sh
+        uses: actions/checkout@v6
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
             resources/conduct\.md
           )$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.13
     hooks:
       - id: ruff-check
         args: ["--fix"]


### PR DESCRIPTION
Fixes #738 

Updates all GitHub Actions and `pre-commit` hooks to their latest versions. This resolves a deprecation warning about the AWS SDK used, and should hopefully pull in other bugfixes, security improvements, and performance improvements.