### PR TITLE
Updated SDK manager parts in the RAPIDS Installation Guide

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -245,9 +245,9 @@ RAPIDS pip packages are available on the NVIDIA Python Package Index.
 <br/>
 <div id="sdkm"></div>
 
-## **SDK Manager (Ubuntu Only)**
-[NVIDIA SDK Manager](https://developer.nvidia.com/sdk-manager) gives a users a Graphical User Interface (GUI) option to install RAPIDS.  It also attempts to fix any environment issues before installing RAPIDS or updating RAPIDS, making it ideal for new Linux users.
-1. Download [SDK Manager's Ubuntu version from their website](https://developer.nvidia.com/sdk-manager){: target="_blank"} (requires sign up or login to NVIDIA's Developer community).  Do not install yet.  It is assumed that your home directory's `Downloads` folder is where the `.deb` file will be stored.  If not, please move `sdkmanager_[version]-[build#]_amd64.deb` file to your current Download folder.
+## **SDK Manager**
+[NVIDIA SDK Manager](https://developer.nvidia.com/sdk-manager) gives users a Graphical User Interface (GUI) option to install RAPIDS.  It also attempts to fix any environment issues before installing RAPIDS or updating RAPIDS, making it ideal for new users.
+1. Download [SDK Manager from its website](https://developer.nvidia.com/sdk-manager){: target="_blank"} (requires sign up or login to NVIDIA's Developer community).  
 2. Install and run SDK Manager [using the installation guide here](https://docs.nvidia.com/sdk-manager/download-run-sdkm/index.html){: target="_blank"}. For Ubuntu, use the following commands:
 ```bash
 sudo apt install ./sdkmanager_[version]-[build#]_amd64.deb
@@ -283,26 +283,6 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 <i class="fas fa-info-circle text-white"></i> When installing with Conda or pip, if an `WSL2 Jitify fatal error: libcuda.so: cannot open shared object file` error occurs, follow suggestions in [this WSL issue](https://github.com/microsoft/WSL/issues/8587) to resolve.
 
-<br/>
-<div id="wsl2-sdkm"></div>
-
-### **WSL2 SDK Manager Install**
-[NVIDIA's SDK Manager](https://developer.nvidia.com/sdk-manager){: target="_blank"} gives Windows users a Graphical User Interface (GUI) option to install RAPIDS. It also attempts to fix any environment issues before installing RAPIDS or updating RAPIDS, making it ideal for new WSL users.
-1. Install the [latest NVIDIA Drivers](https://www.nvidia.com/en-us/drivers/){: target="_blank"} on the Windows host.
-2. Download [SDK Manager's Ubuntu version from their website](https://developer.nvidia.com/sdk-manager){: target="_blank"} (requires sign up or login to NVIDIA's Developer community).  Do not install yet.  The rest of the instructions assume that your home directory's `Downloads` folder is where the `.deb` file will be stored.  If this is not the case, please change the directory, as needed, for your system.
-3. Install or update WSL2 and the Ubuntu 22.04 or Ubuntu 24.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}. To install Ubuntu 24.04 from the command line, use this command:
-```bash
-wsl --install -d Ubuntu-24.04
-```
-This will install and start Ubuntu in your Windows host system using WSL2.  Make your **sudo** password memorable as you will need it in the next two steps.
-4. Install and run SDK Manager inside Ubuntu by pasting this into your command line.  This command will navigate to your Windows users's `Downloads` folder, from your WSL2 instance, and install the latest SDK Manager `.deb` file that you had downloaded. You will have to enter the sudo password you created when you installed Ubuntu.
-```bash
-sudo apt update && sudo apt install wslu -y
-cd "$(wslpath -au "$(cmd.exe /c 'echo %USERPROFILE%' | tr -d '\r')")/Downloads"
-sudo apt install "$(ls -t ./sdkmanager_*_amd64.deb | head -n 1)" -y
-sdkmanager
-```
-5. Sign in when asked, and [follow SDK Manager's RAPIDS installation instructions here](https://docs.nvidia.com/sdk-manager/install-with-sdkm-rapids/index.html){: target="_blank"}.
 
 <br/>
 <div id="wsl2-conda"></div>

--- a/install/index.md
+++ b/install/index.md
@@ -26,7 +26,6 @@ RAPIDS has several methods for installation, depending on the preferred environm
 - [pip](#pip)
 - [SDK Manager](#sdkm)
 - [Windows WSL2](#wsl2)
-  - [SDK Manager](#wsl2-sdkm)
   - [Conda](#wsl2-conda)
   - [Docker](#wsl2-docker)
   - [pip](#wsl2-pip)
@@ -247,13 +246,28 @@ RAPIDS pip packages are available on the NVIDIA Python Package Index.
 
 ## **SDK Manager**
 [NVIDIA SDK Manager](https://developer.nvidia.com/sdk-manager) gives users a Graphical User Interface (GUI) option to install RAPIDS.  It also attempts to fix any environment issues before installing RAPIDS or updating RAPIDS, making it ideal for new users.
-1. Download [SDK Manager from its website](https://developer.nvidia.com/sdk-manager){: target="_blank"} (requires sign up or login to NVIDIA's Developer community).  
-2. Install and run SDK Manager [using the installation guide here](https://docs.nvidia.com/sdk-manager/download-run-sdkm/index.html){: target="_blank"}. For Ubuntu, use the following commands:
-```bash
+1. Download [SDK Manager from its website](https://developer.nvidia.com/sdk-manager) (requires sign up or login to NVIDIA's Developer community).
+2. Install SDK Manager client
+- For Ubuntu, use the following command:
+```sh
 sudo apt install ./sdkmanager_[version]-[build#]_amd64.deb
+```
+
+   - For Windows, follow the step-by-step instructions in the NVIDIA_SDK_Manager_[version]-[build#].exe
+
+3. Run SDK Manager client
+- For Ubuntu, use the following command:
+```sh
 sdkmanager
 ```
-3. Sign in when asked, and follow SDK Manager's [RAPIDS installation instructions](https://docs.nvidia.com/sdk-manager/install-with-sdkm-rapids/index.html){: target="_blank"}.
+
+- For Windows,
+```sh
+Use the Start menu shortcut "NVIDIA SDK Manager" or
+Open a terminal window, go to the installation directory if not added to the path during installation, and run NvSDKManager.exe
+```
+
+4. To install RAPIDS, log in to your NVIDIA Developer account via the SDK Manager client (“NVIDIA Developer” tab) using the [provided login instructions](https://docs.nvidia.com/sdk-manager/download-run-sdkm/index.html#log-in-and-run-sdk-manager). Once logged in, proceed with the RAPIDS installation using the SDK Manager's instructions, which can be found [here](https://docs.nvidia.com/sdk-manager/install-with-sdkm-rapids/index.html).
 
 
 <br/>


### PR DESCRIPTION
Updated SDK manager parts in the RAPIDS Installation Guide. (per Edward's guidance)

1. Updated SDK Manager (Ubuntu Only) section
2. Removed WSL2 SDK Manager Install section. It is obsolete and user is recommended with SDK Manager Windows version install.