### PR TITLE
RSN 58: add Python 3.14, change status to 'Completed'

### DIFF
--- a/_notices/rsn0058.md
+++ b/_notices/rsn0058.md
@@ -7,10 +7,10 @@ notice_type: rsn
 notice_id: 58 # should match notice number
 notice_pin: true # set to true to pin to notice page
 
-title: "Dropping Support for Python v3.10 in v26.04"
+title: "Dropping Support for Python v3.10 and Adding Support for Python v3.14 in v26.04"
 notice_author: RAPIDS TPM
-notice_status: Proposal
-notice_status_color: blue
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -21,15 +21,14 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v26.04+"
 notice_created: 2026-01-26
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-01-26
+notice_updated: 2026-04-01
 ---
 
 ## Overview
 
-RAPIDS is dropping support for Python 3.10 in the upcoming release of v26.04, scheduled for April 8, 2026.
-v26.04 will support Python 3.11, Python 3.12, and Python 3.13.
-
+RAPIDS is dropping support for Python 3.10 and adding support for Python 3.14 in the upcoming release of v26.04, scheduled for April 8, 2026.
+v26.04 will support Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Impact
 
-Users should plan to move to a supported Python version 3.11, 3.12, or 3.13 as soon as possible.
+Users should plan to move to a supported Python version (3.11, 3.12, 3.13, or 3.14) as soon as possible.


### PR DESCRIPTION
In v26.04, RAPIDS:

* dropped Python 3.10: https://github.com/rapidsai/build-planning/issues/246
* added python 3.14: https://github.com/rapidsai/build-planning/issues/205

This updates RSN 58 to indicate that, and changes that RSN's status to `Completed`.