### PR TITLE
update analytics handling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,14 +32,46 @@
   <link rel="stylesheet" href="{{ "/assets/css/custom.css" | relative_url }}">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-DLJNCEWKZD"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
 
-    gtag('config', 'G-DLJNCEWKZD');
+    function hasAnalyticsConsent() {
+      return typeof OnetrustActiveGroups === 'string' &&
+            OnetrustActiveGroups.split(',').includes('C0002');
+    }
+
+    function loadGA4() {
+      if (window._ga4Loaded) return;
+      window._ga4Loaded = true;
+      var gtagScript = document.createElement('script');
+      gtagScript.async = true;
+      gtagScript.src = 'https://www.googletagmanager.com/gtag/js?id=G-DLJNCEWKZD';
+      document.head.appendChild(gtagScript);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      window.gtag = window.gtag || gtag;
+      gtag('js', new Date());
+      gtag('config', 'G-DLJNCEWKZD');
+    }
+
+    function initAnalyticsIfConsented() {
+      if (hasAnalyticsConsent()) {
+        loadGA4();
+      }
+    }
+
+    if (document.readyState === 'complete') {
+      initAnalyticsIfConsented();
+    } else {
+      window.addEventListener('load', initAnalyticsIfConsented);
+    }
+
+    if (window.OneTrust && typeof window.OneTrust.OnConsentChanged === 'function') {
+      window.OneTrust.OnConsentChanged(function () {
+        initAnalyticsIfConsented();
+      });
+    }
   </script>
+
   <script src="https://assets.adobedtm.com/5d4962a43b79/814eb6e9b4e1/launch-4bc07f1e0b0b.min.js"></script>
 
   {% if site.search_enabled != nil %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,6 +31,18 @@
   <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/css/custom.css" | relative_url }}">
 
+  <!-- OneTrust Cookies Consent Notice start for rapids.ai -->
+  <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="018e2d71-40f3-7e89-90b8-e10ec6012ab0-test" ></script>
+  <script type="text/javascript">
+      function OptanonWrapper() {
+          var event = new Event('bannerLoaded');
+          window.dispatchEvent(event);
+      }
+  </script>
+
+  <!-- OneTrust Cookies Consent Notice end for rapids.ai -->
+  <script type="text/javascript" src="https://images.nvidia.com/aem-dam/Solutions/ot-js/ot-custom.js"></script>
+
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>
 


### PR DESCRIPTION
Some changes to how consent for analytics cookies is handled on `rapids.ai` pages. I'll give more details privately.

## Notes for Reviewers

### How I tested this

Honestly, I'm very unsure how to test this. The deployment preview renders fine but:

* will our Google Analytics stuff still work?
* is this interacting with OneTrust correclty?

I'll need some help testing this (have asked privately).