### PR TITLE
Update release versions for 26.04

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -66,7 +66,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 1
+      stable: 0
       nightly: 0
   cucim:
     name: cuCIM

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -165,7 +165,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 0
-      stable: 0
+      stable: 1
       nightly: 1
 
 

--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -1,4 +1,56 @@
 releases:
+  - version: "26.04"
+    python:
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+    glibc_min: "2.28"
+    cpu_arch:
+      - "x86_64"
+      - "aarch64"
+    os_support:
+      - "Ubuntu 22.04"
+      - "Ubuntu 24.04"
+      - "Rocky Linux 8"
+    source_build:
+      cccl: "3.2.0"
+      nvcomp: "5.1.0.21"
+      gcc: "13.3+"
+    cuda:
+      - major: 12
+        toolkit_min: "12.2"
+        toolkit_max: "12.9"
+        driver_min: "535"
+        compute_capability:
+          - name: "Volta"
+            sm: 70
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+      - major: 13
+        toolkit_min: "13.0"
+        toolkit_max: "13.1"
+        driver_min: "580"
+        compute_capability:
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+
   - version: "26.02"
     python:
       - "3.10"

--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -14,7 +14,7 @@ releases:
       - "Ubuntu 24.04"
       - "Rocky Linux 8"
     source_build:
-      cccl: "3.2.0"
+      cccl: "3.3.0"
       nvcomp: "5.1.0.21"
       gcc: "13.3+"
     cuda:

--- a/_data/previous_releases.json
+++ b/_data/previous_releases.json
@@ -1,5 +1,39 @@
 [
   {
+    "version": "26.04",
+    "ucxx_version": "0.49",
+    "dev": {
+      "start": "Jan 15 2026",
+      "end": "Mar 11 2026",
+      "days": "38"
+    },
+    "cudf_burndown": {
+      "start": "Mar 12 2026",
+      "end": "Mar 18 2026",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Mar 12 2026",
+      "end": "Apr 1 2026",
+      "days": "12"
+    },
+    "cudf_codefreeze": {
+      "start": "Mar 19 2026",
+      "end": "Apr 7 2026",
+      "days": "12"
+    },
+    "other_codefreeze": {
+      "start": "Apr 2 2026",
+      "end": "Apr 7 2026",
+      "days": "4"
+    },
+    "release": {
+      "start": "Apr 8 2026",
+      "end": "Apr 9 2026",
+      "days": "2"
+    }
+  },
+  {
     "version": "26.02",
     "ucxx_version": "0.48",
     "cudf_dev": {

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -57,9 +57,9 @@
       "days": "5"
     },
     "other_burndown": {
-      "start": "Jul 23 2026",
+      "start": "Jul 16 2026",
       "end": "Jul 29 2026",
-      "days": "5"
+      "days": "10"
     },
     "cudf_codefreeze": {
       "start": "Jul 23 2026",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -1,49 +1,15 @@
 {
   "legacy": {
-    "version": "25.12",
-    "ucxx_version": "0.47",
-    "date": "Dec 10 2025"
-  },
-  "stable": {
     "version": "26.02",
     "ucxx_version": "0.48",
     "date": "Feb 5 2026"
   },
-  "nightly": {
+  "stable": {
     "version": "26.04",
     "ucxx_version": "0.49",
-    "dev": {
-      "start": "Jan 15 2026",
-      "end": "Mar 11 2026",
-      "days": "38"
-    },
-    "cudf_burndown": {
-      "start": "Mar 12 2026",
-      "end": "Mar 18 2026",
-      "days": "5"
-    },
-    "other_burndown": {
-      "start": "Mar 12 2026",
-      "end": "Apr 1 2026",
-      "days": "12"
-    },
-    "cudf_codefreeze": {
-      "start": "Mar 19 2026",
-      "end": "Apr 7 2026",
-      "days": "12"
-    },
-    "other_codefreeze": {
-      "start": "Apr 2 2026",
-      "end": "Apr 7 2026",
-      "days": "4"
-    },
-    "release": {
-      "start": "Apr 8 2026",
-      "end": "Apr 9 2026",
-      "days": "2"
-    }
+    "date": "Apr 9 2026"
   },
-  "next_nightly": {
+  "nightly": {
     "version": "26.06",
     "ucxx_version": "0.50",
     "dev": {
@@ -74,6 +40,40 @@
     "release": {
       "start": "Jun 3 2026",
       "end": "Jun 4 2026",
+      "days": "2"
+    }
+  },
+  "next_nightly": {
+    "version": "26.08",
+    "ucxx_version": "0.51",
+    "dev": {
+      "start": "May 14 2026",
+      "end": "Jul 15 2026",
+      "days": "40"
+    },
+    "cudf_burndown": {
+      "start": "Jul 16 2026",
+      "end": "Jul 22 2026",
+      "days": "5"
+    },
+    "other_burndown": {
+      "start": "Jul 23 2026",
+      "end": "Jul 29 2026",
+      "days": "5"
+    },
+    "cudf_codefreeze": {
+      "start": "Jul 23 2026",
+      "end": "Aug 4 2026",
+      "days": "9"
+    },
+    "other_codefreeze": {
+      "start": "Jul 30 2026",
+      "end": "Aug 4 2026",
+      "days": "4"
+    },
+    "release": {
+      "start": "Aug 5 2026",
+      "end": "Aug 6 2026",
       "days": "2"
     }
   }

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -1,109 +1,110 @@
 {
   "cudf": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "dask-cudf": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cuml": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cugraph": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cuxfilter": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cudf-java": {
     "legacy": "25.12",
     "stable": "26.02"
   },
   "cucim": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cuvs": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "kvikio": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "raft": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "dask-cuda": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "rmm": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "rapidsmpf": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "ucxx": {
-    "stable": "0.48",
-    "nightly": "0.49"
+    "stable": "0.49",
+    "nightly": "0.50"
   },
   "nvforest": {
-    "nightly": "26.04"
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "librmm": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "libcudf": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "libcuml": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "libkvikio": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "librapidsmpf": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "libucxx": {
-    "legacy": "0.47",
-    "stable": "0.48",
-    "nightly": "0.49"
+    "legacy": "0.48",
+    "stable": "0.49",
+    "nightly": "0.50"
   },
   "rapids-cmake": {
-    "legacy": "25.12",
-    "stable": "26.02",
-    "nightly": "26.04"
+    "legacy": "26.02",
+    "stable": "26.04",
+    "nightly": "26.06"
   },
   "cuproj": {
     "legacy": "25.02",

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -25,8 +25,7 @@
     "nightly": "26.06"
   },
   "cudf-java": {
-    "legacy": "25.12",
-    "stable": "26.02"
+    "legacy": "26.02"
   },
   "cucim": {
     "legacy": "26.02",


### PR DESCRIPTION
Roll version labels for 26.04 release:
- legacy: 25.12 -> 26.02
- stable: 26.02 -> 26.04
- nightly: 26.04 -> 26.06
- next_nightly: 26.06 -> 26.08

Also enables stable docs for nvforest (first release).