### PR TITLE
fix: update Python support range in install selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -382,7 +382,7 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers_stable: ["3.10", "3.11", "3.12", "3.13"],
+            python_vers_stable: ["3.11", "3.12", "3.13", "3.14"],
             python_vers_nightly: ["3.11", "3.12", "3.13", "3.14"],
             conda_cuda_vers_stable: ["12", "13"],
             conda_cuda_vers_nightly: ["12", "13"],


### PR DESCRIPTION
Noticed the install selector still offers Python 3.10 as an option and omits Python 3.14.  Platform support page is already updated.
