### PR TITLE
Fix 26.06 cudf_burndown end date (off-by-one)

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -19,8 +19,8 @@
     },
     "cudf_burndown": {
       "start": "May 14 2026",
-      "end": "May 19 2026",
-      "days": "4"
+      "end": "May 20 2026",
+      "days": "5"
     },
     "other_burndown": {
       "start": "May 14 2026",


### PR DESCRIPTION
Fix off-by-one in 26.06 cudf burndown end date so it matches the standard 5-day pattern from prior releases and is consecutive with the codefreeze start.

- `cudf_burndown.end`: `May 19 2026` -> `May 20 2026`
- `cudf_burndown.days`: `4` -> `5`