### PR TITLE
update active python version to 3.14 in selector

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -370,7 +370,7 @@
     document.addEventListener('alpine:init', () => {
         Alpine.data('rapids_selector', () => ({
             // default values
-            active_python_ver: "3.13",
+            active_python_ver: "3.14",
             active_conda_cuda_ver: "13",
             active_pip_cuda_ver: "13",
             active_docker_cuda_ver: "13",


### PR DESCRIPTION
Update active python version to 3.14 to match our recommended install default