### PR TITLE
Update release version to 26.04 for cudf-java

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -66,7 +66,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -25,7 +25,8 @@
     "nightly": "26.06"
   },
   "cudf-java": {
-    "legacy": "26.02"
+    "legacy": "26.02",
+    "stable": "26.04"
   },
   "cucim": {
     "legacy": "26.02",


### PR DESCRIPTION
Roll version labels for `cudf-java` to  26.04 release:

stable: 26.02 -> 26.04
