### PR TITLE
Add CUDA 13.2 to nightly support

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -449,7 +449,7 @@
                     },
                     "Nightly": {
                         "12": ["12.2", "12.9"],
-                        "13": ["13.0", "13.1"]
+                        "13": ["13.0", "13.2"]
                     }
                 };
                 var bounds = cuda_version_info[this.active_release][version];


### PR DESCRIPTION
Adds CUDA 13.2 to nightly version support. Part of https://github.com/rapidsai/build-planning/issues/265.
