### PR TITLE
DOC-792 update cudf-java to support stable 26.06 release

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -66,7 +66,7 @@ apis:
     versions:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
-      stable: 0
+      stable: 1
       nightly: 0
   cucim:
     name: cuCIM

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -25,7 +25,8 @@
     "nightly": "26.08"
   },
   "cudf-java": {
-    "legacy": "26.04"
+    "legacy": "26.04",
+    "stable": "26.06"
   },
   "cucim": {
     "legacy": "26.04",


### PR DESCRIPTION
This PR adds the configuration necissary for the `cudf-java` project to show `STABLE (26.06)` subsection on the api docs: 

* https://docs.rapids.ai/api/

closes: https://github.com/rapidsai/docs/issues/792