### PR TITLE
fix(dates): burndown starts on the same day everywhere

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -23,9 +23,9 @@
       "days": "6"
     },
     "other_burndown": {
-      "start": "Jul 23 2026",
+      "start": "Jul 16 2026",
       "end": "Jul 29 2026",
-      "days": "5"
+      "days": "10"
     },
     "cudf_codefreeze": {
       "start": "Jul 23 2026",
@@ -57,9 +57,9 @@
       "days": "5"
     },
     "other_burndown": {
-      "start": "Sep 17 2026",
+      "start": "Sep 10 2026",
       "end": "Sep 30 2026",
-      "days": "8"
+      "days": "15"
     },
     "cudf_codefreeze": {
       "start": "Sep 17 2026",


### PR DESCRIPTION
We updated the docs to indicate that the start of burndown is no longer staggered in #758 -- those changes were accidentally reverted as part of #790.

I've corrected the dates -- the `days` variable here is _way_ too manual and inconsistent, so no promises.

I _think_ it's inclusive of start- and end-date, but doesn't count weekends, holidays, or NVIDIA free days, but there are some existing counts that don't include the end-date.

That can be rectified later (or we can remove the "days" column).
