### PR TITLE
Add NVIDIA docs selector styling

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -438,7 +438,7 @@ legend {
 
 .rapids-selector__selected {
   cursor: pointer;
-  padding: 0.5em 0;
+  padding: 0.5em 2em 0.5em 0;
 }
 
 .rapids-selector__selected::after {
@@ -463,7 +463,7 @@ legend {
 #rapids-jtd-container .rapids-selector__selected::after,
 #rapids-pydata-container .rapids-selector__selected::after {
   position: absolute;
-  right: 0;
+  right: 0.75em;
 }
 
 .rapids-selector__menu {
@@ -504,6 +504,39 @@ a.rapids-selector__menu-item--selected:visited {
 
 a.rapids-selector__menu-item--selected {
   cursor: default;
+}
+
+/* PyData pages load Font Awesome through JS/SVG handling, so selector
+ * pseudo-elements should not depend on icon webfonts being available.
+ */
+#rapids-pydata-container .rapids-home-container__home-btn::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.25em;
+  vertical-align: -0.125em;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.2 1.5 6.4l.9 1.1L3.5 6.6v6.9h3.4V9.8h2.2v3.7h3.4V6.6l1.1.9.9-1.1L8 1.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.2 1.5 6.4l.9 1.1L3.5 6.6v6.9h3.4V9.8h2.2v3.7h3.4V6.6l1.1.9.9-1.1L8 1.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
+#rapids-pydata-container .rapids-selector__selected::after {
+  content: "";
+  display: inline-block;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  position: absolute;
+  top: 0.85em;
+  right: 0.75em;
+  transform: rotate(225deg);
+  transform-origin: 65% 65%;
+}
+
+#rapids-pydata-container .rapids-selector--hidden .rapids-selector__selected::after {
+  transform: rotate(45deg);
 }
 
 .label-title {

--- a/assets/css/custom_nvidia.css
+++ b/assets/css/custom_nvidia.css
@@ -1,0 +1,162 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 */
+
+/* Selector CSS for NVIDIA-themed API docs.
+ * Keep this limited to the post-processing elements injected by customize_doc.py.
+ */
+
+:root {
+  --nvidia-selector-green: #76b900;
+  --nvidia-selector-text: #1a1a1a;
+  --nvidia-selector-surface: #f7f7f7;
+  --nvidia-selector-underline: #d9d9d9;
+  --nvidia-selector-shadow: rgba(0, 0, 0, 0.2);
+}
+
+html[data-theme="dark"] {
+  --nvidia-selector-text: #eee;
+  --nvidia-selector-surface: #1a1a1a;
+  --nvidia-selector-underline: #444;
+  --nvidia-selector-shadow: rgba(0, 0, 0, 0.45);
+}
+
+.rapids-home-container__home-btn {
+  position: relative;
+  display: block;
+  padding: 0.5em 0;
+}
+
+.rapids-home-container__home-btn::before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.25em;
+  vertical-align: -0.125em;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.2 1.5 6.4l.9 1.1L3.5 6.6v6.9h3.4V9.8h2.2v3.7h3.4V6.6l1.1.9.9-1.1L8 1.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.2 1.5 6.4l.9 1.1L3.5 6.6v6.9h3.4V9.8h2.2v3.7h3.4V6.6l1.1.9.9-1.1L8 1.2z'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
+.rapids-selector__container,
+.rapids-home-container {
+  text-align: left;
+}
+
+.rapids-selector__container {
+  position: relative;
+}
+
+.rapids-selector__container * {
+  box-sizing: border-box;
+}
+
+.rapids-home-container__home-btn,
+.rapids-home-container__home-btn:visited,
+.rapids-home-container__home-btn:hover,
+.rapids-selector__selected {
+  color: var(--nvidia-selector-green);
+  font-weight: 700;
+  text-decoration: none;
+  background-image: linear-gradient(
+    var(--nvidia-selector-underline) 0%,
+    var(--nvidia-selector-underline) 100%
+  );
+  background-repeat: repeat-x;
+  background-position: 0 100%;
+  background-size: 1px 1px;
+}
+
+.rapids-selector__selected:hover,
+.rapids-home-container__home-btn:hover {
+  background-image: linear-gradient(
+    rgba(118, 185, 0, 0.45) 0%,
+    rgba(118, 185, 0, 0.45) 100%
+  );
+  background-size: 1px 1px;
+}
+
+.rapids-selector__selected {
+  cursor: pointer;
+  padding: 0.5em 2em 0.5em 0;
+}
+
+.rapids-selector__selected::after {
+  content: "";
+  display: inline-block;
+  width: 0.5em;
+  height: 0.5em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transition: transform 250ms ease-in-out;
+  transform: rotate(225deg);
+  transform-origin: 65% 65%;
+}
+
+.rapids-selector--hidden .rapids-selector__selected::after {
+  transform: rotate(45deg);
+}
+
+#rapids-pydata-container .rapids-selector__selected::after {
+  position: absolute;
+  top: 0.85em;
+  right: 0.75em;
+}
+
+.rapids-selector__menu {
+  position: absolute;
+  z-index: 10000;
+  background-color: var(--nvidia-selector-surface);
+  min-width: 100%;
+  left: 0;
+  box-shadow: 0 5px 5px -3px var(--nvidia-selector-shadow),
+    0 8px 10px 1px var(--nvidia-selector-shadow),
+    0 3px 14px 2px var(--nvidia-selector-shadow);
+  overflow: hidden;
+  transition: all 250ms ease-in-out;
+}
+
+.rapids-selector--hidden .rapids-selector__menu {
+  height: 0 !important;
+  visibility: hidden;
+}
+
+.rapids-selector__menu-item {
+  display: block;
+  padding: 0.5em;
+  white-space: nowrap;
+}
+
+a.rapids-selector__menu-item,
+a.rapids-selector__menu-item:visited {
+  color: var(--nvidia-selector-text);
+}
+
+a.rapids-selector__menu-item:hover,
+a.rapids-selector__menu-item--selected,
+a.rapids-selector__menu-item--selected:visited {
+  text-decoration: none;
+  background-color: var(--nvidia-selector-green);
+  color: #000;
+}
+
+a.rapids-selector__menu-item--selected {
+  cursor: default;
+}
+
+.label-title {
+  margin: 0;
+  font-size: inherit !important;
+  vertical-align: inherit !important;
+  font-weight: bold;
+}
+
+/* Account for the post-processed selector block above the PyData sidebar links. */
+@media (min-width: 720px) {
+  @supports (position: -webkit-sticky) or (position: sticky) {
+    .bd-links {
+      max-height: calc(100vh - 18rem);
+    }
+  }
+}

--- a/ci/customization/README.md
+++ b/ci/customization/README.md
@@ -137,6 +137,7 @@ It adds the following elements to each documentation page:
 
 - A _Home_ button that links to https://docs.rapids.ai/api
 - A _library_ selector that enables navigation to different RAPIDS libraries
+  - The library selector excludes inactive projects, hidden projects, and projects without stable or nightly docs.
 - A _version_ selector that enables navigation to the different versions of each RAPIDS library
 - A `link` tag that points to [custom.css](/assets/css/custom.css) in the file's `head`
   - Pages using NVIDIA Sphinx Theme receive [custom_nvidia.css](/assets/css/custom_nvidia.css) instead, limited to the injected selector styles.

--- a/ci/customization/README.md
+++ b/ci/customization/README.md
@@ -139,6 +139,7 @@ It adds the following elements to each documentation page:
 - A _library_ selector that enables navigation to different RAPIDS libraries
 - A _version_ selector that enables navigation to the different versions of each RAPIDS library
 - A `link` tag that points to [custom.css](/assets/css/custom.css) in the file's `head`
+  - Pages using NVIDIA Sphinx Theme receive [custom_nvidia.css](/assets/css/custom_nvidia.css) instead, limited to the injected selector styles.
 - A `script` tag that points to [custom.js](/assets/js/custom.js) at the end the file's `body`
 - A `link` tag enabling [FontAwesome](https://fontawesome.com/) in the file's `head` (only for Doxygen files)
 

--- a/ci/customization/customize_doc.py
+++ b/ci/customization/customize_doc.py
@@ -18,6 +18,7 @@ SCRIPT_TAG_ID = "rapids-selector-js"
 PIXEL_SRC_TAG_ID = "rapids-selector-pixel-src"
 PIXEL_INVOCATION_TAG_ID = "rapids-selector-pixel-invocation"
 STYLE_TAG_ID = "rapids-selector-css"
+NVIDIA_STYLE_TAG_ID = "nvidia-selector-css"
 FA_TAG_ID = "rapids-fa-tag"
 
 
@@ -196,10 +197,28 @@ def create_pixel_tags(soup):
     return [head_tag, body_tag]
 
 
+def uses_nvidia_sphinx_theme(soup) -> bool:
+    """
+    Returns whether the document already uses the NVIDIA Sphinx Theme.
+    """
+    return any(
+        "nvidia-sphinx-theme" in link.get("href", "")
+        for link in soup.find_all("link", href=True)
+    )
+
+
 def create_css_link_tag(soup):
     """
-    Creates and returns a link tag that points to custom.css
+    Creates and returns the stylesheet tag for the injected selectors.
     """
+    if uses_nvidia_sphinx_theme(soup):
+        return soup.new_tag(
+            "link",
+            id=NVIDIA_STYLE_TAG_ID,
+            rel="stylesheet",
+            href="/assets/css/custom_nvidia.css",
+        )
+
     script_tag = soup.new_tag(
         "link", id=STYLE_TAG_ID, rel="stylesheet", href="/assets/css/custom.css"
     )
@@ -214,6 +233,15 @@ def delete_element(soup, selector):
         soup.select(f"{selector}")[0].extract()
     except Exception:
         pass
+
+
+def delete_rapids_custom_css_links(soup):
+    """
+    Deletes global RAPIDS custom CSS links from NVIDIA-themed pages.
+    """
+    for link in soup.find_all("link", href=True):
+        if link["href"].endswith("/assets/css/custom.css"):
+            link.extract()
 
 
 def delete_existing_elements(soup):
@@ -236,6 +264,7 @@ def delete_existing_elements(soup):
         doxygen_title_area,
         f"#{SCRIPT_TAG_ID}",
         f"#{STYLE_TAG_ID}",
+        f"#{NVIDIA_STYLE_TAG_ID}",
         f"#{FA_TAG_ID}",
         f"#{PIXEL_SRC_TAG_ID}",
         f"#{PIXEL_INVOCATION_TAG_ID}",
@@ -304,6 +333,8 @@ def main(
 
     # Delete any existing added/unnecessary elements
     delete_existing_elements(soup)
+    if uses_nvidia_sphinx_theme(soup):
+        delete_rapids_custom_css_links(soup)
 
     # Add Font Awesome to Doxygen for icons
     if doc_type == "doxygen":

--- a/ci/customization/customize_doc.py
+++ b/ci/customization/customize_doc.py
@@ -12,6 +12,8 @@ import re
 import sys
 from copy import deepcopy
 
+import yaml
+
 from bs4 import BeautifulSoup
 
 SCRIPT_TAG_ID = "rapids-selector-js"
@@ -50,6 +52,26 @@ def get_lib_from_fp(*, filepath: str, lib_path_dict: dict) -> str:
         if re.search(f"(^{lib}/|/{lib}/)", filepath):
             return lib
     raise ValueError(f"Couldn't find valid library name in '{filepath}'.")
+
+
+def get_selector_project_names(*, docs_yml_path: str) -> set[str]:
+    """
+    Returns projects that should be shown in the library selector.
+    """
+    with open(docs_yml_path) as fp:
+        docs_config = yaml.safe_load(fp)
+
+    selector_projects = set()
+    for docs_key in ["apis", "libs"]:
+        for project_name, project_details in docs_config[docs_key].items():
+            versions = project_details["versions"]
+            if project_details.get("hidden", False):
+                continue
+            if not (versions.get("stable") == 1 or versions.get("nightly") == 1):
+                continue
+            selector_projects.add(project_name)
+
+    return selector_projects
 
 
 def create_home_container(soup):
@@ -117,19 +139,22 @@ def create_version_options(
     return options
 
 
-def create_library_options(*, project_name: str, lib_path_dict: dict):
+def create_library_options(
+    *, project_name: str, lib_path_dict: dict, selector_project_names: set[str]
+):
     """
     Creates options for library selector
     """
     options = []
 
     for lib, lib_versions in lib_path_dict.items():
+        if lib not in selector_project_names:
+            continue
+
         if lib_versions["stable"]:
             option_href = lib_versions["stable"]
         elif lib_versions["nightly"]:
             option_href = lib_versions["nightly"]
-        elif lib_versions["legacy"]:
-            option_href = lib_versions["legacy"]
         else:
             continue
         is_selected = False
@@ -141,7 +166,7 @@ def create_library_options(*, project_name: str, lib_path_dict: dict):
     return options
 
 
-def create_selector(soup, options):
+def create_selector(soup, options, *, fallback_selected_text=None):
     """
     Creates a dropdown selector
     """
@@ -150,7 +175,10 @@ def create_selector(soup, options):
         attrs={"class": ["rapids-selector__container", "rapids-selector--hidden"]},
     )
     selected = soup.new_tag("div", attrs={"class": "rapids-selector__selected"})
-    selected.string = next(option["text"] for option in options if option["selected"])
+    selected.string = next(
+        (option["text"] for option in options if option["selected"]),
+        fallback_selected_text,
+    )
     container.append(selected)
     drop_down_menu = soup.new_tag("div", attrs={"class": ["rapids-selector__menu"]})
 
@@ -314,6 +342,7 @@ def main(
     lib_path_dict: dict,
     project_name: str,
     versions_dict: dict[str, str],
+    selector_project_names: set[str],
 ) -> None:
     """
     Given the path to a documentation HTML file, this function will
@@ -347,7 +376,9 @@ def main(
         create_library_options(
             project_name=project_name,
             lib_path_dict=lib_path_dict,
+            selector_project_names=selector_project_names,
         ),
+        fallback_selected_text=project_name,
     )
     version_selector = create_selector(
         soup,
@@ -383,6 +414,9 @@ if __name__ == "__main__":
     MANIFEST_FILEPATH = sys.argv[1]
     PROJECT_TO_VERSIONS_PATH = sys.argv[2]
     LIB_MAP_PATH = os.path.join(os.path.dirname(__file__), "lib_map.json")
+    DOCS_YML_PATH = os.path.join(
+        os.path.dirname(__file__), "..", "..", "_data", "docs.yml"
+    )
 
     # read in config files (doing this here so it only happens once)
     with open(LIB_MAP_PATH) as fp:
@@ -390,6 +424,8 @@ if __name__ == "__main__":
 
     with open(PROJECT_TO_VERSIONS_PATH) as fp:
         PROJECT_TO_VERSIONS_DICT = json.load(fp)
+
+    SELECTOR_PROJECT_NAMES = get_selector_project_names(docs_yml_path=DOCS_YML_PATH)
 
     with open(MANIFEST_FILEPATH) as manifest_file:
         for line in manifest_file:
@@ -408,4 +444,5 @@ if __name__ == "__main__":
                 lib_path_dict=lib_path_dict,
                 project_name=project_name,
                 versions_dict=deepcopy(PROJECT_TO_VERSIONS_DICT[project_name]),
+                selector_project_names=SELECTOR_PROJECT_NAMES,
             )

--- a/ci/customization/requirements.txt
+++ b/ci/customization/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 html5lib
+PyYAML


### PR DESCRIPTION
## Summary
- Add a NVIDIA-themed selector stylesheet and use it when rendered docs load NVIDIA Sphinx Theme.
- Keep RAPIDS custom.css for non-NVIDIA pages, including stable docs that should remain RAPIDS purple.
- Fix selector icons without relying on Font Awesome pseudo-glyphs.
- Filter selector project entries to exclude inactive, hidden, and legacy-only projects.

## Validation
- Pre-commit hooks passed while creating each commit.
- python -m py_compile ci/customization/customize_doc.py
- Verified selector metadata includes active projects such as cudf, cuvs, and rmm, while excluding inactive/hidden projects such as cuproj, cusignal, cuspatial, libcuproj, libcuspatial, and librmm.
- Rendered local docs for RMM nightly/stable plus cuVS/cuDF pages and verified NVIDIA-themed nightly docs use custom_nvidia.css while RMM stable retains RAPIDS custom.css.