### PR TITLE
Add 26.08 nightly platform support

### DIFF
--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -1,4 +1,57 @@
 releases:
+  - version: "26.08"
+    nightly: true
+    python:
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+    glibc_min: "2.28"
+    cpu_arch:
+      - "x86_64"
+      - "aarch64"
+    os_support:
+      - "Ubuntu 22.04"
+      - "Ubuntu 24.04"
+      - "Rocky Linux 8"
+    source_build:
+      cccl: "3.4.0"
+      nvcomp: "5.2.0.13"
+      gcc: "13.3+"
+    cuda:
+      - major: 12
+        toolkit_min: "12.2"
+        toolkit_max: "12.9"
+        driver_min: "535"
+        compute_capability:
+          - name: "Volta"
+            sm: 70
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+      - major: 13
+        toolkit_min: "13.0"
+        toolkit_max: "13.2"
+        driver_min: "580"
+        compute_capability:
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+
   - version: "26.06"
     python:
       - "3.11"

--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -13,6 +13,7 @@ releases:
     os_support:
       - "Ubuntu 22.04"
       - "Ubuntu 24.04"
+      - "Ubuntu 26.04"
       - "Rocky Linux 8"
     source_build:
       cccl: "3.4.0"
@@ -38,7 +39,7 @@ releases:
             sm: [100, 120]
       - major: 13
         toolkit_min: "13.0"
-        toolkit_max: "13.2"
+        toolkit_max: "13.3"
         driver_min: "580"
         compute_capability:
           - name: "Turing"

--- a/platform-support/index.md
+++ b/platform-support/index.md
@@ -17,12 +17,12 @@ Note that for the list of supported compute capabilities below, newer GPUs are s
 
 For installation instructions, see the [Installation Guide](/install/).
 
-**Releases:** {% for release in site.data.platform_support.releases %}[{{ release.version }}](#rapids-{{ release.version | replace: ".", "" }}){% unless forloop.last %}, {% endunless %}{% endfor %}
+**Releases:** {% for release in site.data.platform_support.releases %}[{{ release.version }}{% if release.nightly %} (nightly){% endif %}](#rapids-{{ release.version | replace: ".", "" }}){% unless forloop.last %}, {% endunless %}{% endfor %}
 
 {% for release in site.data.platform_support.releases %}
 ---
 
-## RAPIDS {{ release.version }}
+## RAPIDS {{ release.version }}{% if release.nightly %} (nightly){% endif %}
 
 <div markdown="1" style="margin-left: 1.5em;">
 


### PR DESCRIPTION
This adds nightly platform support to the docs.

Closes https://github.com/rapidsai/build-planning/issues/286.