### PR TITLE
Add RSN for CuPy 14 and NumPy 2

### DIFF
--- a/_notices/rsn0061.md
+++ b/_notices/rsn0061.md
@@ -29,15 +29,14 @@ notice_updated: 2026-06-30
 
 RAPIDS will require CuPy version 14.0.1 or newer in the 26.08 release.
 
+As a consequence, RAPIDS will require NumPy 2 as CuPy 14 requires it.
+
 This simplifies RAPIDS installation, because CuPy 14 can now be used without
 installing a system-wide CUDA Toolkit. Users can rely on
 [CUDA components provided via PyPI](https://pypi.org/project/cuda-toolkit/).
 Only the CUDA driver needs to be pre-installed. See the
 [CuPy 14 release blog](https://medium.com/cupy-team/announcing-cupy-v14-e8515ec05fca)
 for more information.
-
-This requirement also means that RAPIDS will require NumPy 2, because of CuPy
-14's requirements.
 
 ## Impact
 

--- a/_notices/rsn0061.md
+++ b/_notices/rsn0061.md
@@ -1,0 +1,45 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 61 # should match notice number
+notice_pin: true # set to true to pin to notice page
+
+title: "RAPIDS 26.08 will require CuPy 14 and NumPy 2"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v26.08+"
+notice_created: 2026-06-30
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2026-06-30
+---
+
+## Overview
+
+RAPIDS will require CuPy version 14.0.1 or newer in the 26.08 release.
+
+This simplifies RAPIDS installation, because CuPy 14 can now be used without
+installing a system-wide CUDA Toolkit. Users can rely on
+[CUDA components provided via PyPI](https://pypi.org/project/cuda-toolkit/).
+Only the CUDA driver needs to be pre-installed. See the
+[CuPy 14 release blog](https://medium.com/cupy-team/announcing-cupy-v14-e8515ec05fca)
+for more information.
+
+This requirement also means that RAPIDS will require NumPy 2, because of CuPy
+14's requirements.
+
+## Impact
+
+User environments will need to be compatible with NumPy 2 and CuPy 14 for
+RAPIDS 26.08 and later.


### PR DESCRIPTION
Adds RSN 61 for the RAPIDS 26.08 CuPy 14.0.1+ and NumPy 2 requirement, based on https://github.com/rapidsai/build-planning/issues/279#issuecomment-4783280020.

The notice keeps the recommended title, overview, and impact from the planning comment, with RAPIDS docs notice metadata for an in-progress v26.08+ platform support change.

Closes https://github.com/rapidsai/build-planning/issues/279.