### PR TITLE
Highlight additional Conda package names separately

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -513,7 +513,7 @@
                 }
 
                 var channel_pkg_separator = "::";
-                var version_start = pkg.search(/[=<>!~]/);
+                var version_start = pkg.search(/\s*[=<>!~]/);
                 var version_pinning = version_start === -1 ? "" : pkg.slice(version_start);
                 var pkg_without_version = version_start === -1 ? pkg : pkg.slice(0, version_start);
                 var pkg_components = pkg_without_version.split(channel_pkg_separator);
@@ -523,7 +523,7 @@
                 return quote + channel + this.highlightPkgOrImg(pkg_name) + version_pinning + quote;
             },
             highlightCondaPkgs(pkgs) {
-                return pkgs.split(/\s+/).map(pkg => this.highlightCondaPkg(pkg)).join(" ");
+                return pkgs.match(/'[^']*'|"[^"]*"|\S+/g).map(pkg => this.highlightCondaPkg(pkg)).join(" ");
             },
             getCondaVersionSupport(version) {
                 var cuda_version_info = {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -506,12 +506,24 @@
                 return "<span class='nv'>" + str + "</span>"
             },
             highlightCondaPkg(pkg) {
-                var channel_pkg_separator = "::";
-                var pkg_components = pkg.split(channel_pkg_separator);
-                if (pkg_components.length === 1) {
-                    return this.highlightPkgOrImg(pkg);
+                var quote = "";
+                if ((pkg.startsWith("'") && pkg.endsWith("'")) || (pkg.startsWith('"') && pkg.endsWith('"'))) {
+                    quote = pkg[0];
+                    pkg = pkg.slice(1, -1);
                 }
-                return pkg_components[0] + channel_pkg_separator + this.highlightPkgOrImg(pkg_components[1]);
+
+                var channel_pkg_separator = "::";
+                var version_start = pkg.search(/[=<>!~]/);
+                var version_pinning = version_start === -1 ? "" : pkg.slice(version_start);
+                var pkg_without_version = version_start === -1 ? pkg : pkg.slice(0, version_start);
+                var pkg_components = pkg_without_version.split(channel_pkg_separator);
+                var pkg_name = pkg_components.pop();
+                var channel = pkg_components.length ? pkg_components.join(channel_pkg_separator) + channel_pkg_separator : "";
+
+                return quote + channel + this.highlightPkgOrImg(pkg_name) + version_pinning + quote;
+            },
+            highlightCondaPkgs(pkgs) {
+                return pkgs.split(/\s+/).map(pkg => this.highlightCondaPkg(pkg)).join(" ");
             },
             getCondaVersionSupport(version) {
                 var cuda_version_info = {
@@ -593,7 +605,7 @@
 
                 if (this.active_additional_packages.length) {
                     add_pkgs_ln = indentation + this.active_additional_packages
-                        .map(pkg => this.highlightCondaPkg(this.getAdditionalPkgName(pkg)))
+                        .map(pkg => this.highlightCondaPkgs(this.getAdditionalPkgName(pkg)))
                         .join(" ");
                 }
 

--- a/index.md
+++ b/index.md
@@ -11,27 +11,27 @@ you. Visit [RAPIDS.ai](https://rapids.ai) for more information on the overall pr
 :class-container: rapids-section-grid
 
 :::{grid-item-card} <i class="fa-solid fa-download" aria-hidden="true"></i> Installation Guide
-:link: /install/
+:link: install/
 :link-type: url
 :::
 
 :::{grid-item-card} <i class="fa-solid fa-list-check" aria-hidden="true"></i> Platform Support
-:link: /platform-support/
+:link: platform-support/
 :link-type: url
 :::
 
 :::{grid-item-card} <i class="fa-solid fa-book" aria-hidden="true"></i> User Guides
-:link: /user-guide/
+:link: user-guide/
 :link-type: url
 :::
 
 :::{grid-item-card} <i class="fa-solid fa-code" aria-hidden="true"></i> API Documentation
-:link: /api/
+:link: api/
 :link-type: url
 :::
 
 :::{grid-item-card} <i class="fa-solid fa-chart-bar" aria-hidden="true"></i> Visualization Guide
-:link: /visualization/
+:link: visualization/
 :link-type: url
 :::
 
@@ -41,12 +41,12 @@ you. Visit [RAPIDS.ai](https://rapids.ai) for more information on the overall pr
 :::
 
 :::{grid-item-card} <i class="fa-solid fa-wrench" aria-hidden="true"></i> Maintainer Documentation
-:link: /maintainers/
+:link: maintainers/
 :link-type: url
 :::
 
 :::{grid-item-card} <i class="fas fa-bullhorn" aria-hidden="true"></i> RAPIDS Notices
-:link: /notices/
+:link: notices/
 :link-type: url
 :::
 


### PR DESCRIPTION
## Summary

- highlight only package names in additional Conda package specifications
- leave channel prefixes, quotes, and version constraints unhighlighted
- handle mappings that expand to multiple packages, such as `networkx nx-cugraph=<version>`

## Impact

Additional packages now use the same package-name-only syntax highlighting as the rest of the generated Conda command.

The previous formatter wrapped the entire additional package specification in the package-name span. It also treated the NetworkX/nx-cugraph mapping as one package even though it expands to two specifications.

Closes #544.

## Validation

- exercised the selector's actual JavaScript with Node assertions covering plain, pinned, channel-qualified, quoted, and multi-package specifications
- verified the generated Conda command for NetworkX/nx-cugraph and PyTorch
- ran `pre-commit run --all-files`
