### PR TITLE
RSN 60: mark complete

### DIFF
--- a/_notices/rsn0060.md
+++ b/_notices/rsn0060.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "Sunsetting cuxfilter after RAPIDS Release v26.06"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,7 +22,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v26.06+"
 notice_created: 2026-05-22
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-05-22
+notice_updated: 2026-07-07
 ---
 
 ## Overview


### PR DESCRIPTION
https://github.com/rapidsai/cuxfilter is now archived and the 26.06 release is done. The RSN about archiving `cuxfilter` can be marked complete.