### PR TITLE
Add RSN for cuml.tsa deprecation

### DIFF
--- a/_notices/rsn0062.md
+++ b/_notices/rsn0062.md
@@ -1,0 +1,67 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 62 # should match notice number
+notice_pin: true # set to true to pin to notice page
+
+title: "Deprecation and planned removal of cuml.tsa"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Library Deprecation
+notice_rapids_version: "v26.08+"
+notice_created: 2026-07-07
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2026-07-07
+---
+
+## Overview
+
+Starting with RAPIDS `v26.08`, `cuml.tsa` is deprecated and planned for removal
+in RAPIDS `v26.12`.
+
+Deprecation warnings, documentation updates, and release-note coverage for the
+affected APIs will begin in RAPIDS `v26.08`.
+
+## Affected APIs
+
+The deprecation includes the following `cuml.tsa` APIs:
+
+- `cuml.tsa.ARIMA`
+- `cuml.tsa.auto_arima.AutoARIMA`
+- `cuml.tsa.ExponentialSmoothing`
+
+The deprecation also includes top-level exports for these APIs:
+
+- `cuml.ARIMA`
+- `cuml.AutoARIMA`
+- `cuml.ExponentialSmoothing`
+
+## Impact
+
+Users of the affected APIs will receive deprecation warnings beginning in
+RAPIDS `v26.08`.
+
+After removal, the `cuml.tsa` module, top-level exports, documentation, tests,
+and build targets will no longer be present in RAPIDS releases.
+
+## Migration guidance
+
+Users should plan to migrate workloads away from `cuml.tsa` before RAPIDS
+`v26.12`.
+
+RAPIDS does not currently designate a direct replacement for these APIs. Users
+should evaluate maintained time-series libraries or application-specific
+forecasting workflows that fit their requirements.
+
+For tracking details, see <https://github.com/rapidsai/cuml/issues/8343>.


### PR DESCRIPTION
Adds RSN 62 for the `cuml.tsa` deprecation, including the `26.08` deprecation notice, affected APIs, `26.12` removal timeline, and migration guidance.

Part of https://github.com/rapidsai/cuml/issues/8343
