### PR TITLE
Remove TensorFlow and enable PyTorch with CUDA 13

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -397,7 +397,7 @@
             packages: ["Standard", "Choose Specific Packages"],
             additional_pip_packages: ["cuDF", "dask-cuDF", "cuML", "cuGraph/nx-cugraph", "cuCIM", "RAFT", "cuVS", "nvForest"],
             additional_rapids_packages: ["cuDF", "cuML", "cuGraph", "cuCIM", "RAFT", "cuVS", "nvForest"],
-            additional_packages: ["Graphistry", "JupyterLab", "NetworkX + nx-cugraph", "Plotly Dash", "PyTorch", "TensorFlow", "Xarray-Spatial"],
+            additional_packages: ["Graphistry", "JupyterLab", "NetworkX + nx-cugraph", "Plotly Dash", "PyTorch", "Xarray-Spatial"],
             note_prefix: "<i class='fas fa-info-circle text-blue'></i>",
             rapids_meta_pkgs: ["cuDF", "cuML", "cuGraph", "nx-cugraph", "cuCIM", "RAFT", "cuVS"],
             getStableVersion() {
@@ -681,9 +681,6 @@
                     if (this.active_additional_packages.includes("PyTorch")) {
                         notes = [...notes, "PyTorch requires CUDA 12."];
                     }
-                    if (this.active_additional_packages.includes("TensorFlow")) {
-                        notes = [...notes, "TensorFlow requires CUDA 12."];
-                    }
                 }
 
                 return notes.map(note => this.note_prefix + " " + note);
@@ -761,9 +758,8 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                // PyTorch and TensorFlow do not support CUDA 13 yet
+                // PyTorch does not support CUDA 13 yet
                 if (this.active_additional_packages.includes("PyTorch") && (!cuda_version.startsWith("12"))) isDisabled = true;
-                if (this.active_additional_packages.includes("TensorFlow") && (!cuda_version.startsWith("12"))) isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -925,7 +921,6 @@
                 }
                 this.active_additional_packages = [...this.active_additional_packages, package];
                 if (this.active_additional_packages.includes("PyTorch") && this.active_conda_cuda_ver !== "12") this.active_conda_cuda_ver = "12";
-                if (this.active_additional_packages.includes("TensorFlow") && this.active_conda_cuda_ver !== "12") this.active_conda_cuda_ver = "12";
             },
             copyToClipboard() {
                 let range = document.createRange();

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -677,10 +677,6 @@
 
                 if (this.active_additional_packages.length) {
                     notes = [...notes, "Third-party packages are not tested."];
-
-                    if (this.active_additional_packages.includes("PyTorch")) {
-                        notes = [...notes, "PyTorch requires CUDA 12."];
-                    }
                 }
 
                 return notes.map(note => this.note_prefix + " " + note);
@@ -758,8 +754,6 @@
             },
             disableUnsupportedCuda(cuda_version) {
                 var isDisabled = false;
-                // PyTorch does not support CUDA 13 yet
-                if (this.active_additional_packages.includes("PyTorch") && (!cuda_version.startsWith("12"))) isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -920,7 +914,6 @@
                     return;
                 }
                 this.active_additional_packages = [...this.active_additional_packages, package];
-                if (this.active_additional_packages.includes("PyTorch") && this.active_conda_cuda_ver !== "12") this.active_conda_cuda_ver = "12";
             },
             copyToClipboard() {
                 let range = document.createRange();


### PR DESCRIPTION
## Summary

- Removes TensorFlow from the install selector's **Additional Packages** options and deletes obsolete compatibility notes.
- Allows PyTorch to be selected with CUDA 13. I validated that current official PyTorch wheels and conda-forge packages support CUDA 13.
