### PR TITLE
Add RSN for `rapids-xgboost` removal

### DIFF
--- a/extensions/rapids_docs/lifecycle.py
+++ b/extensions/rapids_docs/lifecycle.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Manage Sphinx lifecycle events and source rendering."""
@@ -25,14 +25,14 @@ def _jinja_environment(app) -> Environment:
     )
 
 
-def _context(app) -> dict:
+def _context(app, docname: str = "index") -> dict:
     data = app.rapids_portal_data
     return {
         **data,
         "api_docs": lambda section: _api_docs(data, section),
         "current_schedules": lambda: _current_schedules(data),
         "notice_table": lambda notice_type=None, pinned=False: _notice_table(
-            data, notice_type, pinned
+            data, notice_type, pinned, docname
         ),
         "platform_support_content": lambda: _platform_support(data),
         "previous_schedules": lambda: _previous_schedules(data),
@@ -70,4 +70,4 @@ def _source_read(app, docname: str, source: list[str]) -> None:
     elif docname == "SECURITY":
         raw = "---\norphan: true\n---\n\n" + _convert_github_alerts(raw)
     template = app.rapids_portal_jinja.from_string(raw)
-    source[0] = template.render(_context(app))
+    source[0] = template.render(_context(app, docname))

--- a/extensions/rapids_docs/notices.py
+++ b/extensions/rapids_docs/notices.py
@@ -1,10 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Render notices and generate their RSS feed."""
 
 import email.utils
 import html
+import posixpath
 from datetime import UTC, datetime
 from pathlib import Path
 from xml.etree import ElementTree
@@ -28,7 +29,9 @@ def _notice_status_label(notice: dict) -> str:
     return f'<span class="notice-status-label notice-status-{color}">{status}</span>'
 
 
-def _notice_table(data: dict, notice_type: str | None = None, pinned: bool = False) -> str:
+def _notice_table(
+    data: dict, notice_type: str | None = None, pinned: bool = False, source_docname: str = "index"
+) -> str:
     notices = data["notices"]
     if notice_type:
         notices = [notice for notice in notices if notice["notice_type"] == notice_type]
@@ -44,12 +47,13 @@ def _notice_table(data: dict, notice_type: str | None = None, pinned: bool = Fal
         "|:--|:--|:--|:--|:--|",
     ]
     for notice in notices:
+        href = posixpath.relpath(notice["docname"], Path(source_docname).parent) + "/"
         updated = notice.get("notice_updated")
         if not updated or _date(updated).date() == _date(notice["notice_created"]).date():
             updated = notice["notice_created"]
         output.append(
             f"| **{notice['notice_type'].upper()} {notice['notice_id']}**<br>{_notice_status_label(notice)} "
-            f"| [{notice['title']}](/notices/{Path(notice['docname']).name}/) "
+            f"| [{notice['title']}]({href}) "
             f"| {notice['notice_topic']} | {notice['notice_rapids_version']} | {_long_date(updated)} |"
         )
     return "\n".join(output)

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -8,7 +8,7 @@ notice_type: rsn
 notice_id: 62 # should match notice number
 notice_pin: true # set to true to pin to notice page
 
-title: "Sunsetting rapids-xgboost conda package after RAPIDS Release v26.10"
+title: "Remove rapids-xgboost conda package in RAPIDS Release v26.10"
 notice_author: RAPIDS TPM
 notice_status: In Progress
 notice_status_color: yellow

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -8,7 +8,7 @@ notice_type: rsn
 notice_id: 62 # should match notice number
 notice_pin: true # set to true to pin to notice page
 
-title: "Remove rapids-xgboost conda package in RAPIDS Release v26.10"
+title: "Removing rapids-xgboost conda package in RAPIDS Release v26.10"
 notice_author: RAPIDS TPM
 notice_status: In Progress
 notice_status_color: yellow

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -27,7 +27,8 @@ notice_updated: 2026-07-30
 
 ## Overview
 
-Staring with RAPIDS `v26.10`, the `rapids-xgboost` conda package is deprecated and removed.
+RAPIDS `v26.08` will be the final release that publishes the `rapids-xgboost` conda package.
+The package will be removed in RAPIDS `v26.10`.
 
 ## Impact
 

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -1,0 +1,43 @@
+---
+layout: notice
+parent: RAPIDS Support Notices
+grand_parent: RAPIDS Notices
+nav_exclude: true
+notice_type: rsn
+# Update meta-data for notice
+notice_id: 62 # should match notice number
+notice_pin: true # set to true to pin to notice page
+
+title: "Sunsetting rapids-xgboost conda package after RAPIDS Release v26.10"
+notice_author: RAPIDS TPM
+notice_status: In Progress
+notice_status_color: yellow
+# 'notice_status' and 'notice_status_color' combinations:
+#   "Proposal" - "blue"
+#   "Completed" - "green"
+#   "Review" - "purple"
+#   "In Progress" - "yellow"
+#   "Closed" - "red"
+notice_topic: Platform Support Change
+notice_rapids_version: "v26.10+"
+notice_created: 2026-07-24
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2026-07-24
+---
+
+## Overview
+
+Staring with RAPIDS `v26.10`, the `rapids-xgboost` conda package is deprecated and planned
+for removal in RAPIDS `v26.12`. Deprecation warnings will begin in RAPIDS `v26.10`.
+
+## Impact
+
+User of `rapids-xgboost` will receive deprecation warnings beginning in RAPIDS
+`v26.10`. After the 26.10 release, `rapids-xgboost` will no longer be published in the `rapidsai` conda
+channel.
+
+## Migration guidance
+
+Existing users should plan to migrate workloads away from `rapids-xgboost` before RAPIDS
+`v26.12`. You are encouraged to use the `xgboost` package from `conda-forge`, or the
+wheels from the Python Package Index `PyPI`.

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -27,17 +27,15 @@ notice_updated: 2026-07-24
 
 ## Overview
 
-Staring with RAPIDS `v26.10`, the `rapids-xgboost` conda package is deprecated and planned
-for removal in RAPIDS `v26.12`. Deprecation warnings will begin in RAPIDS `v26.10`.
+Staring with RAPIDS `v26.10`, the `rapids-xgboost` conda package is deprecated and removed.
 
 ## Impact
 
-User of `rapids-xgboost` will receive deprecation warnings beginning in RAPIDS
-`v26.10`. After the 26.10 release, `rapids-xgboost` will no longer be published in the `rapidsai` conda
-channel.
+`rapids-xgboost` will no longer be published in the `rapidsai` conda channel with the
+26.10 release.
 
 ## Migration guidance
 
 Existing users should plan to migrate workloads away from `rapids-xgboost` before RAPIDS
-`v26.12`. You are encouraged to use the `xgboost` package from `conda-forge`, or the
+`v26.10`. You are encouraged to use the `xgboost` package from `conda-forge`, or the
 wheels from the Python Package Index `PyPI`.

--- a/notices/rsn0062.md
+++ b/notices/rsn0062.md
@@ -20,9 +20,9 @@ notice_status_color: yellow
 #   "Closed" - "red"
 notice_topic: Platform Support Change
 notice_rapids_version: "v26.10+"
-notice_created: 2026-07-24
+notice_created: 2026-07-30
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-07-24
+notice_updated: 2026-07-30
 ---
 
 ## Overview

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
@@ -106,10 +106,11 @@ def test_notice_metadata_and_indexes() -> None:
     source_notices = list((ROOT / "notices").glob("r[dgs]n[0-9][0-9][0-9][0-9].md"))
     assert len(data["notices"]) == len(source_notices)
 
-    support_notices = notices._notice_table(data, "rsn")
+    support_notices = notices._notice_table(data, "rsn", source_docname="notices/rsn/index")
     support_notice = next(notice for notice in data["notices"] if notice["notice_type"] == "rsn")
     assert f"RSN {support_notice['notice_id']}" in support_notices
     assert support_notice["title"] in support_notices
+    assert f"](../{Path(support_notice['docname']).name}/)" in support_notices
     assert 'class="notice-status-label notice-status-green">Completed</span>' in support_notices
     assert 'class="notice-status-label notice-status-yellow">In Progress</span>' in support_notices
 


### PR DESCRIPTION
## Summary

- Add RSN 62 for the rapids-xgboost conda package removal.