### PR TITLE
Require successful PR builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,22 @@ concurrency:
 permissions: {}
 
 jobs:
+  pr-builder:
+    needs:
+      - check-style
+      - docs
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
+
   check-style:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/validate_site.py
+++ b/scripts/validate_site.py
@@ -93,9 +93,13 @@ def main() -> None:
     if "G-DLJNCEWKZD" not in analytics or "_satellite.pageBottom" not in analytics:
         missing.append("GA4 or Adobe page-bottom telemetry is missing")
 
-    # Theme packages contain unrendered Jinja macro files under ``_static``;
-    # only rendered site pages should be checked for legacy Liquid syntax.
-    html_files = [path for path in args.site.rglob("*.html") if "_static" not in path.parts]
+    # Imported API docs may include upstream source links and template examples.
+    # Limit portal-specific checks to portal and deployment pages.
+    html_files = [
+        path
+        for path in args.site.rglob("*.html")
+        if "_static" not in path.parts and not path.is_relative_to(args.site / "api")
+    ]
     stale_liquid = [path for path in html_files if "{%" in path.read_text(errors="ignore")]
     if stale_liquid:
         missing.append(f"Liquid syntax remains in {len(stale_liquid)} rendered files")


### PR DESCRIPTION
Require all PR jobs and exclude imported API docs from portal-specific checks.