### PR TITLE
Remove dask-cuda from package selectors

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -668,11 +668,6 @@
                         .flatMap(libraryToPkg);
                 }
 
-                // pkgs.length == 2 because it includes the "Choose Specific Packages" option
-                if (this.active_release === "Nightly" && !(pkgs.length === 2 && pkgs[0] === "cucim")) {
-                    pkgs.push(["dask-cuda" + cuda_suffix.slice(5)])
-                }
-
                 // Make sure all packages (and version selectors) are quoted
                 pkgs = pkgs.flatMap(pkg => '"' + pkg + '"');
 


### PR DESCRIPTION
Fixes #813.

Remove the nightly-only dask-cuda package injection from the selector output. I don't know why this was added originally, or if there's a reason it might still be needed, but I can't think of any reasons. The git blame traces back to https://github.com/rapidsai/docs/pull/450.