### PR TITLE
Add 26.10 nightly platform support and update CCCL

### DIFF
--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -16,7 +16,7 @@ releases:
       - "Ubuntu 26.04"
       - "Rocky Linux 8"
     source_build:
-      cccl: "3.4.1"
+      cccl: "3.4.3"
       nvcomp: "5.3.0.16"
       gcc: "13.3+"
     cuda:
@@ -70,7 +70,7 @@ releases:
       - "Ubuntu 26.04"
       - "Rocky Linux 8"
     source_build:
-      cccl: "3.4.1"
+      cccl: "3.4.3"
       nvcomp: "5.3.0.16"
       gcc: "13.3+"
     cuda:

--- a/_data/platform_support.yml
+++ b/_data/platform_support.yml
@@ -1,4 +1,58 @@
 releases:
+  - version: "26.10"
+    nightly: true
+    python:
+      - "3.11"
+      - "3.12"
+      - "3.13"
+      - "3.14"
+    glibc_min: "2.28"
+    cpu_arch:
+      - "x86_64"
+      - "aarch64"
+    os_support:
+      - "Ubuntu 22.04"
+      - "Ubuntu 24.04"
+      - "Ubuntu 26.04"
+      - "Rocky Linux 8"
+    source_build:
+      cccl: "3.4.1"
+      nvcomp: "5.3.0.16"
+      gcc: "13.3+"
+    cuda:
+      - major: 12
+        toolkit_min: "12.2"
+        toolkit_max: "12.9"
+        driver_min: "535"
+        compute_capability:
+          - name: "Volta"
+            sm: 70
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+      - major: 13
+        toolkit_min: "13.0"
+        toolkit_max: "13.3"
+        driver_min: "580"
+        compute_capability:
+          - name: "Turing"
+            sm: 75
+          - name: "Ampere"
+            sm: [80, 86]
+          - name: "Ada"
+            sm: 89
+          - name: "Hopper"
+            sm: 90
+          - name: "Blackwell"
+            sm: [100, 120]
+
   - version: "26.08"
     nightly: true
     python:


### PR DESCRIPTION
Add 26.10 nightly platform support information and update the CCCL source-build pin to 3.4.3 for the 26.08 and 26.10 releases.