### PR TITLE
Route migrated API docs to docs.nvidia.com

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -5,6 +5,7 @@ apis:
   cudf:
     name: cuDF
     path: cudf
+    first_docs_nvidia_com_release: "26.08"
     desc: 'cuDF is a Python GPU DataFrame library (built on the [Apache Arrow](http://arrow.apache.org/) columnar memory format) for loading, joining, aggregating, filtering, and otherwise manipulating data.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
@@ -16,6 +17,7 @@ apis:
   dask-cudf:
     name: dask-cuDF
     path: dask-cudf
+    first_docs_nvidia_com_release: null
     desc: 'Dask-cuDF extends Dask where necessary to allow its DataFrame partitions to be processed using cuDF GPU DataFrames instead of Pandas DataFrames. Dask-cuDF is used to leverage multiple gpus and multiple nodes for more performance at larger scales'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
@@ -27,6 +29,7 @@ apis:
   cuml:
     name: cuML
     path: cuml
+    first_docs_nvidia_com_release: "26.08"
     desc: 'cuML is a suite of libraries that implement machine learning algorithms and mathematical primitives functions that share compatible APIs with other RAPIDS projects.'
     ghlink: https://github.com/rapidsai/cuml
     cllink: https://github.com/rapidsai/cuml/blob/main/CHANGELOG.md
@@ -38,6 +41,7 @@ apis:
   cugraph:
     name: cuGraph
     path: cugraph
+    first_docs_nvidia_com_release: "26.08"
     desc: 'cuGraph is a GPU accelerated graph analytics library, the core part of an ecosystem of libraries supporting graph-processing workloads like NetworkX integration (nx-cugraph), GNNs with PyG (cugraph-pyg), and more efficient memory management for large graphs (pylibwholegraph).'
     ghlink: https://github.com/rapidsai/cugraph
     cllink: https://github.com/rapidsai/cugraph/blob/main/CHANGELOG.md
@@ -49,6 +53,7 @@ apis:
   cudf-java:
     name: 'Java + cuDF'
     path: cudf-java
+    first_docs_nvidia_com_release: null
     desc: 'Java bindings for the cuDF library.'
     ghlink: https://github.com/rapidsai/cudf/tree/main/java
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
@@ -60,6 +65,7 @@ apis:
   cucim:
     name: cuCIM
     path: cucim
+    first_docs_nvidia_com_release: null
     desc: 'The RAPIDS cuCIM is an extensible toolkit designed to provide GPU accelerated I/O, computer vision & image processing primitives for N-Dimensional images with a focus on biomedical imaging.'
     ghlink: https://github.com/rapidsai/cucim
     cllink: https://github.com/rapidsai/cucim/blob/main/CHANGELOG.md
@@ -71,6 +77,7 @@ apis:
   cuvs:
     name: cuVS
     path: cuvs
+    first_docs_nvidia_com_release: null
     desc: 'cuVS is a library for GPU-accelerated vector search and clustering.'
     ghlink: https://github.com/rapidsai/cuvs
     cllink: https://github.com/rapidsai/cuvs/blob/main/CHANGELOG.md
@@ -82,6 +89,7 @@ apis:
   kvikio:
     name: KvikIO
     path: kvikio
+    first_docs_nvidia_com_release: null
     desc: "KvikIO is a Python and C++ library for high performance file IO using GPUDirect Storage (GDS)."
     ghlink: https://github.com/rapidsai/kvikio
     cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
@@ -93,6 +101,7 @@ apis:
   raft:
     name: RAFT
     path: raft
+    first_docs_nvidia_com_release: null
     desc: "RAFT contains fundamental widely-used algorithms and primitives for vector search, machine learning, and information retrieval."
     ghlink: https://github.com/rapidsai/raft
     cllink: https://github.com/rapidsai/raft/blob/main/CHANGELOG.md
@@ -104,6 +113,7 @@ apis:
   dask-cuda:
     name: Dask-CUDA
     path: dask-cuda
+    first_docs_nvidia_com_release: null
     desc: "Various utilities to improve deployment and management of Dask workers on CUDA-enabled systems."
     ghlink: https://github.com/rapidsai/dask-cuda
     cllink: https://github.com/rapidsai/dask-cuda/blob/main/CHANGELOG.md
@@ -115,6 +125,7 @@ apis:
   rmm:
     name: RMM
     path: rmm
+    first_docs_nvidia_com_release: "26.08"
     desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
@@ -126,6 +137,7 @@ apis:
   rapidsmpf:
     name: RapidsMPF
     path: rapidsmpf
+    first_docs_nvidia_com_release: null
     desc: 'RAPIDS Multi-Process Foundation (rapidsmpf) is a collection of multi-GPU, distributed memory algorithms written in C++ and exposed to Python.'
     ghlink: https://github.com/rapidsai/rapidsmpf
     versions:
@@ -136,6 +148,7 @@ apis:
   ucxx:
     name: UCXX
     path: ucxx
+    first_docs_nvidia_com_release: null
     desc: 'UCXX is the Python interface for [UCX](https://github.com/openucx/ucx), a low-level high-performance networking library. UCX and UCXX support several transport methods including InfiniBand and NVLink while still using traditional networking protocols like TCP.'
     ghlink: https://github.com/rapidsai/ucxx
     cllink: https://github.com/rapidsai/ucxx/blob/main/CHANGELOG.md
@@ -148,6 +161,7 @@ apis:
   nvforest:
     name: nvForest
     path: nvforest
+    first_docs_nvidia_com_release: "26.08"
     desc: 'nvForest is a highly-optimized and lightweight RAPIDS library that enables fast inference for decision tree models on NVIDIA GPUs and CPUs.'
     ghlink: https://github.com/rapidsai/nvforest
     cllink: https://github.com/rapidsai/nvforest/blob/main/CHANGELOG.md
@@ -163,6 +177,7 @@ libs:
   librmm:
     name: librmm
     path: librmm
+    first_docs_nvidia_com_release: null
     desc: 'RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.'
     ghlink: https://github.com/rapidsai/rmm
     cllink: https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md
@@ -175,6 +190,7 @@ libs:
   libcudf:
     name: libcudf
     path: libcudf
+    first_docs_nvidia_com_release: null
     desc: 'libcudf is a C/C++ CUDA library for implementing standard dataframe operations.'
     ghlink: https://github.com/rapidsai/cudf
     cllink: https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md
@@ -186,6 +202,7 @@ libs:
   libcuml:
     name: libcuml
     path: libcuml
+    first_docs_nvidia_com_release: null
     desc: 'libcuml is a C/C++ CUDA library for cuML.'
     ghlink: https://github.com/rapidsai/cuml
     cllink: https://github.com/rapidsai/cuml/blob/main/CHANGELOG.md
@@ -197,6 +214,7 @@ libs:
   libkvikio:
     name: libkvikio
     path: libkvikio
+    first_docs_nvidia_com_release: null
     desc: "libkvikio is a C++ header-only library providing bindings to cuFile, which enables GPUDirect Storage (GDS)."
     ghlink: https://github.com/rapidsai/kvikio
     cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
@@ -208,6 +226,7 @@ libs:
   librapidsmpf:
     name: librapidsmpf
     path: librapidsmpf
+    first_docs_nvidia_com_release: null
     desc: "librapidsmpf is a C++ collection of multi-GPU, distributed memory algorithms."
     ghlink: https://github.com/rapidsai/rapidsmpf
     versions:
@@ -218,6 +237,7 @@ libs:
   libucxx:
     name: libucxx
     path: libucxx
+    first_docs_nvidia_com_release: null
     desc: "libucxx is an object-oriented C++ interface for UCX, with native support for Python bindings."
     ghlink: https://github.com/rapidsai/ucxx
     versions:
@@ -228,6 +248,7 @@ libs:
   rapids-cmake:
     name: rapids-cmake
     path: rapids-cmake
+    first_docs_nvidia_com_release: null
     desc: "This is a collection of CMake modules that are useful for all CUDA RAPIDS projects. By sharing the code in a single place it makes rolling out CMake fixes easier."
     ghlink: https://github.com/rapidsai/rapids-cmake
     cllink: https://github.com/rapidsai/rapids-cmake/blob/main/CHANGELOG.md
@@ -243,6 +264,7 @@ inactive-projects:
   cuproj:
     name: cuProj
     path: cuProj
+    first_docs_nvidia_com_release: null
     desc: 'cuProj is a GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), compatible with PyProj.'
     ghlink: https://github.com/rapidsai/cuspatial/tree/main/python/cuproj
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # cuProj is housed within cuSpatial so updates remain in the cuSpatial changelog
@@ -259,6 +281,7 @@ inactive-projects:
   cusignal:
     name: cusignal
     path: cusignal
+    first_docs_nvidia_com_release: null
     desc: 'cuSignal functionality has been moved to CuPy. Please see the CuPy documentation for more information.'
     ghlink: https://github.com/cupy/cupy
     cllink: https://docs.cupy.dev/en/latest/reference/scipy_signal.html
@@ -270,6 +293,7 @@ inactive-projects:
   cuspatial:
     name: cuSpatial
     path: cuspatial
+    first_docs_nvidia_com_release: null
     desc: 'cuSpatial is a GPU-accelerated vector GIS library including binary predicates (DE-9IM), point-in-polygon, spatial join, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md
@@ -286,6 +310,7 @@ inactive-projects:
   cuxfilter:
     name: cuxfilter
     path: cuxfilter
+    first_docs_nvidia_com_release: null
     desc: 'cuxfilter acts as a connector library, which provides the connections between different visualization libraries and a GPU dataframe without much hassle. This also allows the user to use charts from different libraries in a single dashboard, while also providing the interaction.'
     ghlink: https://github.com/rapidsai/cuxfilter
     cllink: https://github.com/rapidsai/cuxfilter/blob/main/CHANGELOG.md
@@ -302,6 +327,7 @@ inactive-projects:
   libcuproj:
     name: libcuproj
     path: libcuproj
+    first_docs_nvidia_com_release: null
     desc: 'libcuproj is a C++ header-only library for GPU-accelerated geographic and geodetic coordinate transformation library which supports projecting coordinates between coordinate reference systems (CRSes), similar to PROJ.'
     ghlink: https://github.com/rapidsai/cuspatial/tree/main/cpp/cuproj
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md # Shares a changelog with cuSpatial
@@ -318,6 +344,7 @@ inactive-projects:
   libcuspatial:
     name: libcuspatial
     path: libcuspatial
+    first_docs_nvidia_com_release: null
     desc: 'libcuspatial is a GPU-accelerated header-only C++ vector GIS library including binary predicates (DE-9IM), point-in-polygon, spatial join, distances, and trajectory analysis.'
     ghlink: https://github.com/rapidsai/cuspatial
     cllink: https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md

--- a/extensions/rapids_docs/api.py
+++ b/extensions/rapids_docs/api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Render the API documentation listings."""
@@ -12,6 +12,15 @@ def _version_label(project: dict, version_name: str, releases: dict) -> str:
     return str(releases[version_name][version_key])
 
 
+def _documentation_url(project: dict, version_name: str, version: str) -> str:
+    first_docs_nvidia_com_release = project["first_docs_nvidia_com_release"]
+    if first_docs_nvidia_com_release and tuple(map(int, version.split("."))) >= tuple(
+        map(int, first_docs_nvidia_com_release.split("."))
+    ):
+        return f"https://docs.nvidia.com/{project['path']}/{version}/"
+    return f"https://docs.rapids.ai/api/{project['path']}/{version_name}/"
+
+
 def _api_docs(data: dict, section: str) -> str:
     cards = []
     for project in data["docs"][section].values():
@@ -21,7 +30,8 @@ def _api_docs(data: dict, section: str) -> str:
         for name in ("nightly", "stable", "legacy"):
             if project["versions"].get(name) == 1:
                 label = _version_label(project, name, data["releases"])
-                versions.append(f"[{name.title()} ({label})](/api/{project['path']}/{name}/)")
+                url = _documentation_url(project, name, label)
+                versions.append(f"[{name.title()} ({label})]({url})")
         links = []
         if project.get("cllink"):
             links.append(f"[Changelog]({project['cllink']})")

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -22,7 +22,13 @@ def test_api_docs() -> None:
 
     rendered = api._api_docs(data, "apis")
     assert f"Stable ({stable_version})" in rendered
-    assert "/api/cudf/stable/" in rendered
+    assert f"https://docs.nvidia.com/cudf/{nightly_version}/" in rendered
+    assert "https://docs.rapids.ai/api/cudf/stable/" in rendered
+    assert f"https://docs.nvidia.com/cuml/{nightly_version}/" in rendered
+    assert f"https://docs.nvidia.com/cugraph/{nightly_version}/" in rendered
+    assert f"https://docs.nvidia.com/rmm/{nightly_version}/" in rendered
+    assert f"https://docs.nvidia.com/nvforest/{nightly_version}/" in rendered
+    assert "https://docs.rapids.ai/api/dask-cudf/nightly/" in rendered
     assert "::::{grid} 1 1 1 1" in rendered
     assert ":::{grid-item-card} cuDF" in rendered
     assert "**Documentation:**" in rendered


### PR DESCRIPTION
## Summary

Route API documentation links to versioned docs.nvidia.com endpoints beginning with each project's configured migration release. Keep earlier and unmigrated documentation links explicitly on docs.rapids.ai.

The currently verified migrations begin with release 26.08 for cuDF, cuML, cuGraph, RMM, and nvForest.