### PR TITLE
Fix v26.10 release schedule dates

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -18,24 +18,24 @@
       "days": "39"
     },
     "cudf_burndown": {
-      "start": "Sep 10 2026",
-      "end": "Sep 16 2026",
+      "start": "Sep 8 2026",
+      "end": "Sep 14 2026",
       "days": "5"
     },
     "other_burndown": {
-      "start": "Sep 10 2026",
-      "end": "Sep 30 2026",
-      "days": "15"
+      "start": "Sep 8 2026",
+      "end": "Sep 21 2026",
+      "days": "10"
     },
     "cudf_codefreeze": {
-      "start": "Sep 17 2026",
+      "start": "Sep 15 2026",
       "end": "Oct 6 2026",
-      "days": "12"
+      "days": "14"
     },
     "other_codefreeze": {
-      "start": "Oct 1 2026",
+      "start": "Sep 29 2026",
       "end": "Oct 6 2026",
-      "days": "5"
+      "days": "6"
     },
     "release": {
       "start": "Oct 7 2026",


### PR DESCRIPTION
## Summary

Update the v26.10 burn-down and code-freeze dates and durations to the current tentative plan.

The release schedule page will show the corrected timeline for contributors planning the v26.10 release.