### PR TITLE
Mark RSN 59 and 61 complete

### DIFF
--- a/notices/rsn0059.md
+++ b/notices/rsn0059.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "RAPIDS 26.08 release, cuDF will transition to Pandas 3.0+"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,7 +22,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v26.08+"
 notice_created: 2026-05-19
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-05-19
+notice_updated: 2026-08-16
 ---
 
 ## Overview

--- a/notices/rsn0061.md
+++ b/notices/rsn0061.md
@@ -10,8 +10,8 @@ notice_pin: true # set to true to pin to notice page
 
 title: "RAPIDS 26.08 will require CuPy 14 and NumPy 2"
 notice_author: RAPIDS TPM
-notice_status: In Progress
-notice_status_color: yellow
+notice_status: Completed
+notice_status_color: green
 # 'notice_status' and 'notice_status_color' combinations:
 #   "Proposal" - "blue"
 #   "Completed" - "green"
@@ -22,7 +22,7 @@ notice_topic: Platform Support Change
 notice_rapids_version: "v26.08+"
 notice_created: 2026-06-30
 # 'notice_updated' should match 'notice_created' until an update is made
-notice_updated: 2026-06-30
+notice_updated: 2026-08-16
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

- mark RSN 59 (Pandas 3 transition) as completed
- mark RSN 61 (CuPy 14 and NumPy 2 requirements) as completed
- update both notices' `notice_updated` dates to 2026-08-16

## Impact

The RAPIDS support notices now reflect that the announced v26.08 platform changes have been completed.