### PR TITLE
Update 26.10 and 26.12 release schedule dates

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -35,7 +35,7 @@
     "other_codefreeze": {
       "start": "Sep 22 2026",
       "end": "Oct 6 2026",
-      "days": "11"
+      "days": "9"
     },
     "release": {
       "start": "Oct 7 2026",

--- a/_data/releases.json
+++ b/_data/releases.json
@@ -14,8 +14,8 @@
     "ucxx_version": "0.52",
     "dev": {
       "start": "Jul 16 2026",
-      "end": "Sep 9 2026",
-      "days": "39"
+      "end": "Sep 7 2026",
+      "days": "37"
     },
     "cudf_burndown": {
       "start": "Sep 8 2026",
@@ -33,9 +33,9 @@
       "days": "14"
     },
     "other_codefreeze": {
-      "start": "Sep 29 2026",
+      "start": "Sep 22 2026",
       "end": "Oct 6 2026",
-      "days": "6"
+      "days": "11"
     },
     "release": {
       "start": "Oct 7 2026",
@@ -48,8 +48,8 @@
     "ucxx_version": "0.53",
     "dev": {
       "start": "Sep 10 2026",
-      "end": "Nov 11 2026",
-      "days": "42"
+      "end": "Nov 9 2026",
+      "days": "40"
     },
     "cudf_burndown": {
       "start": "Nov 10 2026",


### PR DESCRIPTION
## Summary

- end v26.10 development on Monday, September 7, 2026
- start the v26.10 code freeze for the remaining projects on Tuesday, September 22, 2026
- end v26.12 development on Monday, November 9, 2026
- update the corresponding working-day durations

## Validation

- `pytest` (13 passed)
- `pre-commit run --files _data/releases.json`
- strict Sphinx build (`sphinx-build -E -b dirhtml -c sphinx . <output> -W --keep-going -n`)
- `git diff --check`