### PR TITLE
Update v26.12 development start date

### DIFF
--- a/_data/releases.json
+++ b/_data/releases.json
@@ -47,9 +47,9 @@
     "version": "26.12",
     "ucxx_version": "0.53",
     "dev": {
-      "start": "Sep 10 2026",
+      "start": "Sep 8 2026",
       "end": "Nov 9 2026",
-      "days": "40"
+      "days": "42"
     },
     "cudf_burndown": {
       "start": "Nov 10 2026",


### PR DESCRIPTION
## Summary

- start v26.12 development on Tuesday, September 8, 2026
- update the development duration from 40 to 42 working days

## Validation

- pytest (13 passed)
- pre-commit run --files _data/releases.json
- strict Sphinx build
- git diff --check