### PR TITLE
Redirect migrated API docs to docs.nvidia.com

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,25 +1,25 @@
-/api/cucim /api/cucim/stable/
-/api/cucim/ /api/cucim/stable/
+/api/cucim https://docs.nvidia.com/cucim/ 301!
+/api/cucim/ https://docs.nvidia.com/cucim/ 301!
 /api/cucim/nightly https://docs.nvidia.com/cucim/latest/ 301!
 /api/cucim/nightly/* https://docs.nvidia.com/cucim/latest/:splat 301!
 /api/cucim/stable https://docs.nvidia.com/cucim/latest/ 301!
 /api/cucim/stable/* https://docs.nvidia.com/cucim/latest/:splat 301!
-/api/cudf /api/cudf/stable/
+/api/cudf https://docs.nvidia.com/cudf/ 301!
 /api/cudf-java /api/cudf-java/stable/
 /api/cudf-java/ /api/cudf-java/stable/
-/api/cudf/ /api/cudf/stable/
+/api/cudf/ https://docs.nvidia.com/cudf/ 301!
 /api/cudf/nightly https://docs.nvidia.com/cudf/latest/ 301!
 /api/cudf/nightly/* https://docs.nvidia.com/cudf/latest/:splat 301!
 /api/cudf/stable https://docs.nvidia.com/cudf/latest/ 301!
 /api/cudf/stable/* https://docs.nvidia.com/cudf/latest/:splat 301!
-/api/cugraph /api/cugraph/stable/
-/api/cugraph/ /api/cugraph/stable/
+/api/cugraph https://docs.nvidia.com/cugraph/ 301!
+/api/cugraph/ https://docs.nvidia.com/cugraph/ 301!
 /api/cugraph/nightly https://docs.nvidia.com/cugraph/latest/ 301!
 /api/cugraph/nightly/* https://docs.nvidia.com/cugraph/latest/:splat 301!
 /api/cugraph/stable https://docs.nvidia.com/cugraph/latest/ 301!
 /api/cugraph/stable/* https://docs.nvidia.com/cugraph/latest/:splat 301!
-/api/cuml /api/cuml/stable/
-/api/cuml/ /api/cuml/stable/
+/api/cuml https://docs.nvidia.com/cuml/ 301!
+/api/cuml/ https://docs.nvidia.com/cuml/ 301!
 /api/cuml/nightly https://docs.nvidia.com/cuml/latest/ 301!
 /api/cuml/nightly/* https://docs.nvidia.com/cuml/latest/:splat 301!
 /api/cuml/stable https://docs.nvidia.com/cuml/latest/ 301!
@@ -29,26 +29,26 @@
 /api/cuspatial/ /api/cuspatial/stable/
 /api/cuxfilter /api/cuxfilter/stable/
 /api/cuxfilter/ /api/cuxfilter/stable/
-/api/dask-cuda /api/dask-cuda/stable/
-/api/dask-cuda/ /api/dask-cuda/stable/
+/api/dask-cuda https://docs.nvidia.com/dask-cuda/ 301!
+/api/dask-cuda/ https://docs.nvidia.com/dask-cuda/ 301!
 /api/dask-cuda/nightly https://docs.nvidia.com/dask-cuda/latest/ 301!
 /api/dask-cuda/nightly/* https://docs.nvidia.com/dask-cuda/latest/:splat 301!
 /api/dask-cuda/stable https://docs.nvidia.com/dask-cuda/latest/ 301!
 /api/dask-cuda/stable/* https://docs.nvidia.com/dask-cuda/latest/:splat 301!
-/api/dask-cudf /api/dask-cudf/stable/
-/api/dask-cudf/ /api/dask-cudf/stable/
+/api/dask-cudf https://docs.nvidia.com/dask-cudf/ 301!
+/api/dask-cudf/ https://docs.nvidia.com/dask-cudf/ 301!
 /api/dask-cudf/nightly https://docs.nvidia.com/dask-cudf/latest/ 301!
 /api/dask-cudf/nightly/* https://docs.nvidia.com/dask-cudf/latest/:splat 301!
 /api/dask-cudf/stable https://docs.nvidia.com/dask-cudf/latest/ 301!
 /api/dask-cudf/stable/* https://docs.nvidia.com/dask-cudf/latest/:splat 301!
-/api/kvikio /api/kvikio/stable/
-/api/kvikio/ /api/kvikio/stable/
+/api/kvikio https://docs.nvidia.com/kvikio/ 301!
+/api/kvikio/ https://docs.nvidia.com/kvikio/ 301!
 /api/kvikio/nightly https://docs.nvidia.com/kvikio/latest/ 301!
 /api/kvikio/nightly/* https://docs.nvidia.com/kvikio/latest/:splat 301!
 /api/kvikio/stable https://docs.nvidia.com/kvikio/latest/ 301!
 /api/kvikio/stable/* https://docs.nvidia.com/kvikio/latest/:splat 301!
-/api/nvforest /api/nvforest/stable/
-/api/nvforest/ /api/nvforest/stable/
+/api/nvforest https://docs.nvidia.com/nvforest/ 301!
+/api/nvforest/ https://docs.nvidia.com/nvforest/ 301!
 /api/nvforest/nightly https://docs.nvidia.com/nvforest/latest/ 301!
 /api/nvforest/nightly/* https://docs.nvidia.com/nvforest/latest/:splat 301!
 /api/nvforest/stable https://docs.nvidia.com/nvforest/latest/ 301!
@@ -69,26 +69,26 @@
 /api/librmm/ /api/rmm/stable/
 /api/libucxx /api/libucxx/stable/
 /api/libucxx/ /api/libucxx/stable/
-/api/raft /api/raft/stable/
-/api/raft/ /api/raft/stable/
+/api/raft https://docs.nvidia.com/raft/ 301!
+/api/raft/ https://docs.nvidia.com/raft/ 301!
 /api/raft/nightly https://docs.nvidia.com/raft/latest/ 301!
 /api/raft/nightly/* https://docs.nvidia.com/raft/latest/:splat 301!
 /api/raft/stable https://docs.nvidia.com/raft/latest/ 301!
 /api/raft/stable/* https://docs.nvidia.com/raft/latest/:splat 301!
-/api/rapids-cmake /api/rapids-cmake/stable/
-/api/rapids-cmake/ /api/rapids-cmake/stable/
+/api/rapids-cmake https://docs.nvidia.com/rapids-cmake/ 301!
+/api/rapids-cmake/ https://docs.nvidia.com/rapids-cmake/ 301!
 /api/rapids-cmake/nightly https://docs.nvidia.com/rapids-cmake/latest/ 301!
 /api/rapids-cmake/nightly/* https://docs.nvidia.com/rapids-cmake/latest/:splat 301!
 /api/rapids-cmake/stable https://docs.nvidia.com/rapids-cmake/latest/ 301!
 /api/rapids-cmake/stable/* https://docs.nvidia.com/rapids-cmake/latest/:splat 301!
-/api/rapidsmpf /api/rapidsmpf/stable/
-/api/rapidsmpf/ /api/rapidsmpf/stable/
+/api/rapidsmpf https://docs.nvidia.com/rapidsmpf/ 301!
+/api/rapidsmpf/ https://docs.nvidia.com/rapidsmpf/ 301!
 /api/rapidsmpf/nightly https://docs.nvidia.com/rapidsmpf/latest/ 301!
 /api/rapidsmpf/nightly/* https://docs.nvidia.com/rapidsmpf/latest/:splat 301!
 /api/rapidsmpf/stable https://docs.nvidia.com/rapidsmpf/latest/ 301!
 /api/rapidsmpf/stable/* https://docs.nvidia.com/rapidsmpf/latest/:splat 301!
-/api/rmm /api/rmm/stable/
-/api/rmm/ /api/rmm/stable/
+/api/rmm https://docs.nvidia.com/rmm/ 301!
+/api/rmm/ https://docs.nvidia.com/rmm/ 301!
 /api/rmm/nightly https://docs.nvidia.com/rmm/latest/ 301!
 /api/rmm/nightly/* https://docs.nvidia.com/rmm/latest/:splat 301!
 /api/rmm/stable https://docs.nvidia.com/rmm/latest/ 301!

--- a/_redirects
+++ b/_redirects
@@ -1,13 +1,28 @@
 /api/cucim /api/cucim/stable/
 /api/cucim/ /api/cucim/stable/
+/api/cucim/nightly https://docs.nvidia.com/cucim/latest/ 301!
+/api/cucim/nightly/* https://docs.nvidia.com/cucim/latest/:splat 301!
+/api/cucim/stable https://docs.nvidia.com/cucim/latest/ 301!
+/api/cucim/stable/* https://docs.nvidia.com/cucim/latest/:splat 301!
 /api/cudf /api/cudf/stable/
 /api/cudf-java /api/cudf-java/stable/
 /api/cudf-java/ /api/cudf-java/stable/
 /api/cudf/ /api/cudf/stable/
+/api/cudf/nightly https://docs.nvidia.com/cudf/latest/ 301!
+/api/cudf/nightly/* https://docs.nvidia.com/cudf/latest/:splat 301!
+/api/cudf/stable https://docs.nvidia.com/cudf/latest/ 301!
+/api/cudf/stable/* https://docs.nvidia.com/cudf/latest/:splat 301!
 /api/cugraph /api/cugraph/stable/
 /api/cugraph/ /api/cugraph/stable/
+/api/cugraph/nightly https://docs.nvidia.com/cugraph/latest/ 301!
+/api/cugraph/nightly/* https://docs.nvidia.com/cugraph/latest/:splat 301!
+/api/cugraph/stable https://docs.nvidia.com/cugraph/latest/ 301!
+/api/cugraph/stable/* https://docs.nvidia.com/cugraph/latest/:splat 301!
 /api/cuml /api/cuml/stable/
 /api/cuml/ /api/cuml/stable/
+/api/cuml/nightly https://docs.nvidia.com/cuml/latest/ 301!
+/api/cuml/nightly/* https://docs.nvidia.com/cuml/latest/:splat 301!
+/api/cuml/stable https://docs.nvidia.com/cuml/latest/ 301!
 /api/cusignal /api/cusignal/stable/
 /api/cusignal/ /api/cusignal/stable/
 /api/cuspatial /api/cuspatial/stable/
@@ -22,10 +37,22 @@
 /api/dask-cuda/stable/* https://docs.nvidia.com/dask-cuda/latest/:splat 301!
 /api/dask-cudf /api/dask-cudf/stable/
 /api/dask-cudf/ /api/dask-cudf/stable/
+/api/dask-cudf/nightly https://docs.nvidia.com/dask-cudf/latest/ 301!
+/api/dask-cudf/nightly/* https://docs.nvidia.com/dask-cudf/latest/:splat 301!
+/api/dask-cudf/stable https://docs.nvidia.com/dask-cudf/latest/ 301!
+/api/dask-cudf/stable/* https://docs.nvidia.com/dask-cudf/latest/:splat 301!
 /api/kvikio /api/kvikio/stable/
 /api/kvikio/ /api/kvikio/stable/
+/api/kvikio/nightly https://docs.nvidia.com/kvikio/latest/ 301!
+/api/kvikio/nightly/* https://docs.nvidia.com/kvikio/latest/:splat 301!
+/api/kvikio/stable https://docs.nvidia.com/kvikio/latest/ 301!
+/api/kvikio/stable/* https://docs.nvidia.com/kvikio/latest/:splat 301!
 /api/nvforest /api/nvforest/stable/
 /api/nvforest/ /api/nvforest/stable/
+/api/nvforest/nightly https://docs.nvidia.com/nvforest/latest/ 301!
+/api/nvforest/nightly/* https://docs.nvidia.com/nvforest/latest/:splat 301!
+/api/nvforest/stable https://docs.nvidia.com/nvforest/latest/ 301!
+/api/nvforest/stable/* https://docs.nvidia.com/nvforest/latest/:splat 301!
 /api/libcudf /api/libcudf/stable/
 /api/libcudf/ /api/libcudf/stable/
 /api/libcugraph /api/libcugraph/stable/
@@ -44,12 +71,28 @@
 /api/libucxx/ /api/libucxx/stable/
 /api/raft /api/raft/stable/
 /api/raft/ /api/raft/stable/
+/api/raft/nightly https://docs.nvidia.com/raft/latest/ 301!
+/api/raft/nightly/* https://docs.nvidia.com/raft/latest/:splat 301!
+/api/raft/stable https://docs.nvidia.com/raft/latest/ 301!
+/api/raft/stable/* https://docs.nvidia.com/raft/latest/:splat 301!
 /api/rapids-cmake /api/rapids-cmake/stable/
 /api/rapids-cmake/ /api/rapids-cmake/stable/
+/api/rapids-cmake/nightly https://docs.nvidia.com/rapids-cmake/latest/ 301!
+/api/rapids-cmake/nightly/* https://docs.nvidia.com/rapids-cmake/latest/:splat 301!
+/api/rapids-cmake/stable https://docs.nvidia.com/rapids-cmake/latest/ 301!
+/api/rapids-cmake/stable/* https://docs.nvidia.com/rapids-cmake/latest/:splat 301!
 /api/rapidsmpf /api/rapidsmpf/stable/
 /api/rapidsmpf/ /api/rapidsmpf/stable/
+/api/rapidsmpf/nightly https://docs.nvidia.com/rapidsmpf/latest/ 301!
+/api/rapidsmpf/nightly/* https://docs.nvidia.com/rapidsmpf/latest/:splat 301!
+/api/rapidsmpf/stable https://docs.nvidia.com/rapidsmpf/latest/ 301!
+/api/rapidsmpf/stable/* https://docs.nvidia.com/rapidsmpf/latest/:splat 301!
 /api/rmm /api/rmm/stable/
 /api/rmm/ /api/rmm/stable/
+/api/rmm/nightly https://docs.nvidia.com/rmm/latest/ 301!
+/api/rmm/nightly/* https://docs.nvidia.com/rmm/latest/:splat 301!
+/api/rmm/stable https://docs.nvidia.com/rmm/latest/ 301!
+/api/rmm/stable/* https://docs.nvidia.com/rmm/latest/:splat 301!
 /api/ucxx /api/ucxx/stable/
 /api/ucxx/ /api/ucxx/stable/
 /deployment /deployment/stable/
@@ -60,3 +103,4 @@
 /api/cuml/stable/zero-code-change-limitations/ /api/cuml/stable/cuml-accel/limitations/
 /api/cuml/stable/zero-code-change-logging/ /api/cuml/stable/cuml-accel/logging-and-profiling/
 /api/cuml/stable/zero_code_change_examples/plot_kmeans_digits/ /api/cuml/stable/cuml-accel/examples/plot_kmeans_digits/
+/api/cuml/stable/* https://docs.nvidia.com/cuml/latest/:splat 301!

--- a/api.md
+++ b/api.md
@@ -3,14 +3,11 @@
 Explore documentation for current and previous RAPIDS releases. Each project
 card links to its available documentation versions and related resources.
 
-Stable
-: Documentation for the current release, recommended for most users.
+Latest
+: Documentation for the latest available release, recommended for most users.
 
-Nightly
-: Documentation for the upcoming release, generated from development branches.
-
-Legacy
-: Documentation for the previous release, retained for reference.
+Versioned releases
+: Documentation for specific RAPIDS releases, retained for reference.
 
 ## RAPIDS APIs
 

--- a/api.md
+++ b/api.md
@@ -4,10 +4,10 @@ Explore documentation for current and previous RAPIDS releases. Each project
 card links to its available documentation versions and related resources.
 
 Latest
-: Documentation for the latest available release, recommended for most users.
+: Documentation built from the latest development branch. It may describe features and changes not yet included in a published release.
 
 Versioned releases
-: Documentation for specific RAPIDS releases, retained for reference.
+: Documentation for published, stable RAPIDS releases. Choose the version that matches your installed release.
 
 ## RAPIDS APIs
 

--- a/api.md
+++ b/api.md
@@ -1,13 +1,7 @@
 # RAPIDS API Documentation
 
-Explore documentation for current and previous RAPIDS releases. Each project
-card links to its available documentation versions and related resources.
-
-Latest
-: Documentation built from the latest development branch. It may describe features and changes not yet included in a published release.
-
-Versioned releases
-: Documentation for published, stable RAPIDS releases. Choose the version that matches your installed release.
+Below are links to each library's documentation by release. Latest docs are built
+from the current development branch and may describe unreleased changes.
 
 ## RAPIDS APIs
 

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -1,65 +1,45 @@
 {
   "cudf": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "dask-cudf": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "cuml": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "cugraph": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "cudf-java": {
     "legacy": "26.06",
     "stable": "26.08"
   },
   "cucim": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "cuvs": {},
   "kvikio": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "raft": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "dask-cuda": {
     "legacy": "26.06"
   },
   "rmm": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "rapidsmpf": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "ucxx": {
     "stable": "0.51",
     "nightly": "0.52"
   },
   "nvforest": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "librmm": {
     "legacy": "26.06",
@@ -92,9 +72,7 @@
     "nightly": "0.52"
   },
   "rapids-cmake": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "cuproj": {
     "legacy": "25.02",

--- a/ci/generate-projects-to-versions.py
+++ b/ci/generate-projects-to-versions.py
@@ -70,11 +70,16 @@ for docs_key in ["apis", "libs", "inactive-projects"]:
                     version_name, ""
                 )
                 if version_override:
-                    versions_for_this_project[version_name] = version_override
+                    version_number = version_override
                 else:
-                    versions_for_this_project[version_name] = RELEASES_JSON_DICT[version_name][
-                        version_key
-                    ]
+                    version_number = RELEASES_JSON_DICT[version_name][version_key]
+                first_docs_nvidia_com_release = project_details.get("first_docs_nvidia_com_release")
+                if first_docs_nvidia_com_release and tuple(
+                    map(int, version_number.split("."))
+                ) >= tuple(map(int, first_docs_nvidia_com_release.split("."))):
+                    print(f"Skipping: {project_name} | {version_name}", file=sys.stderr)
+                    continue
+                versions_for_this_project[version_name] = version_number
             else:
                 print(f"Skipping: {project_name} | {version_name}", file=sys.stderr)
 

--- a/ci/generate-projects-to-versions.py
+++ b/ci/generate-projects-to-versions.py
@@ -62,9 +62,6 @@ for docs_key in ["apis", "libs", "inactive-projects"]:
             PROJECTS_TO_VERSIONS_DICT[project_name] = versions_for_this_project
             continue
         for version_name, should_include in project_details["versions"].items():
-            if project_name == "dask-cuda" and version_name in {"stable", "nightly"}:
-                print(f"Skipping: {project_name} | {version_name}", file=sys.stderr)
-                continue
             if should_include == 1:
                 version_override = project_details.get("version-overrides", dict()).get(
                     version_name, ""

--- a/extensions/rapids_docs/api.py
+++ b/extensions/rapids_docs/api.py
@@ -31,9 +31,13 @@ def _api_docs(data: dict, section: str) -> str:
         if not external_docs_url:
             for name in ("nightly", "stable", "legacy"):
                 if project["versions"].get(name) == 1:
-                    label = _version_label(project, name, data["releases"])
-                    url = _documentation_url(project, name, label)
-                    versions.append(f"[{name.title()} ({label})]({url})")
+                    version = _version_label(project, name, data["releases"])
+                    url = _documentation_url(project, name, version)
+                    if project["first_docs_nvidia_com_release"]:
+                        label = "Latest" if name == "nightly" else version
+                    else:
+                        label = f"{name.title()} ({version})"
+                    versions.append(f"[{label}]({url})")
         links = []
         if project.get("cllink"):
             links.append(f"[Changelog]({project['cllink']})")

--- a/extensions/rapids_docs/api.py
+++ b/extensions/rapids_docs/api.py
@@ -17,7 +17,8 @@ def _documentation_url(project: dict, version_name: str, version: str) -> str:
     if first_docs_nvidia_com_release and tuple(map(int, version.split("."))) >= tuple(
         map(int, first_docs_nvidia_com_release.split("."))
     ):
-        return f"https://docs.nvidia.com/{project['path']}/{version}/"
+        target_version = "latest" if version_name == "nightly" else version
+        return f"https://docs.nvidia.com/{project['path']}/{target_version}/"
     return f"https://docs.rapids.ai/api/{project['path']}/{version_name}/"
 
 

--- a/extensions/rapids_docs/api.py
+++ b/extensions/rapids_docs/api.py
@@ -33,10 +33,7 @@ def _api_docs(data: dict, section: str) -> str:
                 if project["versions"].get(name) == 1:
                     version = _version_label(project, name, data["releases"])
                     url = _documentation_url(project, name, version)
-                    if project["first_docs_nvidia_com_release"]:
-                        label = "Latest" if name == "nightly" else version
-                    else:
-                        label = f"{name.title()} ({version})"
+                    label = "Latest" if name == "nightly" else version
                     versions.append(f"[{label}]({url})")
         links = []
         if project.get("cllink"):

--- a/scripts/validate_site.py
+++ b/scripts/validate_site.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Validate the rendered RAPIDS portal and optional assembled documentation tree."""
@@ -115,9 +115,9 @@ def main() -> None:
 
     if args.full:
         full_paths = [
-            "api/cudf/stable",
-            "api/cudf/latest",
-            "api/cudf/nightly",
+            "api/ucxx/stable",
+            "api/ucxx/latest",
+            "api/ucxx/nightly",
             "deployment/stable/index.html",
             "deployment/nightly/index.html",
         ]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -21,9 +21,13 @@ def test_api_docs() -> None:
     legacy_version = data["releases"]["legacy"]["version"]
 
     rendered = api._api_docs(data, "apis")
+    cudf_latest = f"[Latest](https://docs.nvidia.com/cudf/{nightly_version}/)"
+    cudf_stable = f"[{stable_version}](https://docs.nvidia.com/cudf/{stable_version}/)"
+    cudf_legacy = f"[{legacy_version}](https://docs.rapids.ai/api/cudf/legacy/)"
     assert f"Stable ({stable_version})" in rendered
-    assert f"https://docs.nvidia.com/cudf/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/cudf/{stable_version}/" in rendered
+    assert cudf_latest in rendered
+    assert cudf_stable in rendered
+    assert cudf_legacy in rendered
     assert f"https://docs.nvidia.com/cuml/{nightly_version}/" in rendered
     assert f"https://docs.nvidia.com/cugraph/{nightly_version}/" in rendered
     assert f"https://docs.nvidia.com/rmm/{nightly_version}/" in rendered
@@ -40,12 +44,8 @@ def test_api_docs() -> None:
     assert "**Documentation:**" in rendered
     assert "[GitHub]" in rendered
     assert "DOCS" not in rendered
-    assert rendered.index(f"Nightly ({nightly_version})") < rendered.index(
-        f"Stable ({stable_version})"
-    )
-    assert rendered.index(f"Stable ({stable_version})") < rendered.index(
-        f"Legacy ({legacy_version})"
-    )
+    assert rendered.index(cudf_latest) < rendered.index(cudf_stable)
+    assert rendered.index(cudf_stable) < rendered.index(cudf_legacy)
 
     libs = api._api_docs(data, "libs")
     assert f"https://docs.nvidia.com/rapids-cmake/{nightly_version}/" in libs

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -24,7 +24,9 @@ def test_api_docs() -> None:
     cudf_latest = f"[Latest](https://docs.nvidia.com/cudf/{nightly_version}/)"
     cudf_stable = f"[{stable_version}](https://docs.nvidia.com/cudf/{stable_version}/)"
     cudf_legacy = f"[{legacy_version}](https://docs.rapids.ai/api/cudf/legacy/)"
-    assert f"Stable ({stable_version})" in rendered
+    assert "[Nightly (" not in rendered
+    assert "[Stable (" not in rendered
+    assert "[Legacy (" not in rendered
     assert cudf_latest in rendered
     assert cudf_stable in rendered
     assert cudf_legacy in rendered
@@ -57,7 +59,7 @@ def test_api_docs() -> None:
         if not project.get("hidden", False) and project["versions"].get("stable") == 1
     )
     inactive_version = api._version_label(inactive_project, "stable", data["releases"])
-    assert f"Stable ({inactive_version})" in inactive
+    assert f"[{inactive_version}]" in inactive
 
 
 def test_platform_support() -> None:

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -21,7 +21,7 @@ def test_api_docs() -> None:
     legacy_version = data["releases"]["legacy"]["version"]
 
     rendered = api._api_docs(data, "apis")
-    cudf_latest = f"[Latest](https://docs.nvidia.com/cudf/{nightly_version}/)"
+    cudf_latest = "[Latest](https://docs.nvidia.com/cudf/latest/)"
     cudf_stable = f"[{stable_version}](https://docs.nvidia.com/cudf/{stable_version}/)"
     cudf_legacy = f"[{legacy_version}](https://docs.rapids.ai/api/cudf/legacy/)"
     assert "[Nightly (" not in rendered
@@ -30,16 +30,16 @@ def test_api_docs() -> None:
     assert cudf_latest in rendered
     assert cudf_stable in rendered
     assert cudf_legacy in rendered
-    assert f"https://docs.nvidia.com/cuml/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/cugraph/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/rmm/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/nvforest/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/dask-cudf/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/cucim/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/kvikio/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/raft/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/dask-cuda/{nightly_version}/" in rendered
-    assert f"https://docs.nvidia.com/rapidsmpf/{nightly_version}/" in rendered
+    assert "https://docs.nvidia.com/cuml/latest/" in rendered
+    assert "https://docs.nvidia.com/cugraph/latest/" in rendered
+    assert "https://docs.nvidia.com/rmm/latest/" in rendered
+    assert "https://docs.nvidia.com/nvforest/latest/" in rendered
+    assert "https://docs.nvidia.com/dask-cudf/latest/" in rendered
+    assert "https://docs.nvidia.com/cucim/latest/" in rendered
+    assert "https://docs.nvidia.com/kvikio/latest/" in rendered
+    assert "https://docs.nvidia.com/raft/latest/" in rendered
+    assert "https://docs.nvidia.com/dask-cuda/latest/" in rendered
+    assert "https://docs.nvidia.com/rapidsmpf/latest/" in rendered
     assert rendered.count("[Documentation](https://docs.nvidia.com/cuvs/)") == 1
     assert "::::{grid} 1 1 1 1" in rendered
     assert ":::{grid-item-card} cuDF" in rendered
@@ -50,7 +50,8 @@ def test_api_docs() -> None:
     assert rendered.index(cudf_stable) < rendered.index(cudf_legacy)
 
     libs = api._api_docs(data, "libs")
-    assert f"https://docs.nvidia.com/rapids-cmake/{nightly_version}/" in libs
+    assert "https://docs.nvidia.com/rapids-cmake/latest/" in libs
+    assert f"/{nightly_version}/" not in rendered + libs
 
     inactive = api._api_docs(data, "inactive-projects")
     inactive_project = next(


### PR DESCRIPTION
## Summary

Redirect API roots directly to each migrated library's `docs.nvidia.com/<library>/` site. Redirect stable and nightly paths to `docs.nvidia.com/<library>/latest/`, preserving nested paths. Stop importing externally hosted versions from S3 while retaining pre-migration docs.

Retire the user-facing legacy, stable, and nightly documentation labels. Label the newest documentation `Latest`, label other links by release number, and update the API page definitions accordingly.

This is the full migration rollout. Use the Dask-CUDA-only draft in #834 to test the redirect approach first.