### PR TITLE
Redirect Dask-CUDA docs to docs.nvidia.com

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,6 +16,10 @@
 /api/cuxfilter/ /api/cuxfilter/stable/
 /api/dask-cuda /api/dask-cuda/stable/
 /api/dask-cuda/ /api/dask-cuda/stable/
+/api/dask-cuda/nightly https://docs.nvidia.com/dask-cuda/latest/ 301!
+/api/dask-cuda/nightly/* https://docs.nvidia.com/dask-cuda/latest/:splat 301!
+/api/dask-cuda/stable https://docs.nvidia.com/dask-cuda/latest/ 301!
+/api/dask-cuda/stable/* https://docs.nvidia.com/dask-cuda/latest/:splat 301!
 /api/dask-cudf /api/dask-cudf/stable/
 /api/dask-cudf/ /api/dask-cudf/stable/
 /api/kvikio /api/kvikio/stable/

--- a/ci/customization/projects-to-versions.json
+++ b/ci/customization/projects-to-versions.json
@@ -40,9 +40,7 @@
     "nightly": "26.10"
   },
   "dask-cuda": {
-    "legacy": "26.06",
-    "stable": "26.08",
-    "nightly": "26.10"
+    "legacy": "26.06"
   },
   "rmm": {
     "legacy": "26.06",

--- a/ci/generate-projects-to-versions.py
+++ b/ci/generate-projects-to-versions.py
@@ -62,6 +62,9 @@ for docs_key in ["apis", "libs", "inactive-projects"]:
             PROJECTS_TO_VERSIONS_DICT[project_name] = versions_for_this_project
             continue
         for version_name, should_include in project_details["versions"].items():
+            if project_name == "dask-cuda" and version_name in {"stable", "nightly"}:
+                print(f"Skipping: {project_name} | {version_name}", file=sys.stderr)
+                continue
             if should_include == 1:
                 version_override = project_details.get("version-overrides", dict()).get(
                     version_name, ""


### PR DESCRIPTION
## Summary

Redirect the Dask-CUDA API root directly to `docs.nvidia.com/dask-cuda/`. Redirect stable and nightly paths to `docs.nvidia.com/dask-cuda/latest/`, preserving nested paths. Stop importing Dask-CUDA stable and nightly docs from S3 while retaining legacy docs.

This is a limited rollout for testing before the full migration in #833.